### PR TITLE
Fix login error message display for Turbo requests

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,17 @@ class SessionsController < ApplicationController
   def create
     user = User.authenticate_by(email: params[:email], password: params[:password])
     unless user
-      redirect_to login_path(email_hint: params[:email]), error: "Email or password is invalid", status: :unprocessable_entity
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.update("notification", 
+            partial: "shared/notification", 
+            locals: { status: "error", message: "Email or password is invalid" }
+          ), status: :unprocessable_entity
+        end
+        format.html do
+          redirect_to login_path(email_hint: params[:email]), flash: { error: "Email or password is invalid" }, status: :unprocessable_entity
+        end
+      end
       return
     end
 


### PR DESCRIPTION
## Summary
- Fix login error message not displaying on repeated failures with Turbo requests
- Add proper Turbo Stream support to sessions#create for error handling
- Use turbo_stream.update instead of replace to ensure error messages display consistently

## Test plan
- [ ] Test login failure with incorrect credentials (first attempt)
- [ ] Test repeated login failures to ensure error message displays consistently
- [ ] Verify HTML fallback still works for non-Turbo requests
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)