### PR TITLE
docs: add AGENTS.md contributor guide (architecture + C4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,23 +18,23 @@
 ## C4 Diagrams
 ### C1 — System Context
 ```mermaid
-graph LR
-  user[Registered User];
-  admin[Admin];
-  app[Hobo Web App (Rails)];
-  pg[(PostgreSQL)];
-  redis[(Redis)];
-  gcs[(Google Cloud Storage)];
-  sentry[(Sentry)];
-  llm[(OpenAI / Anthropic / Gemini)];
+flowchart LR
+  user[Registered User]
+  admin[Admin]
+  app[Hobo Web App]
+  pg[(PostgreSQL)]
+  redis[(Redis)]
+  gcs[(GCS Storage)]
+  sentry[(Sentry)]
+  llm[[LLM APIs]]
 
-  user --> app;
-  admin --> app;
-  app -->|reads/writes| pg;
-  app -->|sessions| redis;
-  app -->|files| gcs;
-  app -->|errors| sentry;
-  app -->|LLM APIs| llm;
+  user --> app
+  admin --> app
+  app -->|reads/writes| pg
+  app -->|sessions| redis
+  app -->|files| gcs
+  app -->|errors| sentry
+  app -->|calls| llm
 ```
 
 ### C2 — Containers


### PR DESCRIPTION
This PR adds AGENTS.md as a concise contributor guide for the repo.

Highlights
- Architecture Overview (Rails 8 + Hotwire, Stimulus, Postgres, Redis sessions, Active Storage GCS, Sentry)
- C4 diagrams (C1 Context, C2 Containers, C3 Components) using Mermaid
- Component deep dive for Admin + LLM integrations (lib/llm_client, ModelListService caching)
- Build/test/lint commands and coding conventions (RuboCop, ESLint, Prettier)

Notes
- Mermaid diagrams render inline on GitHub.
- No app code changes; docs only.

Checklist
- [x] Lint/format scripts referenced
- [x] Rails and Playwright commands verified against repo

Please review wording and suggest any repo-specific tweaks before merging.
