### PR TITLE
Skip Claude Code Review workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   claude-review:
+    # Skip Dependabot PRs as dependency updates don't need AI review
+    if: github.actor != 'dependabot[bot]'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

Fixes GitHub Actions failure on Dependabot PRs by skipping the Claude Code Review workflow for automated dependency updates.

## Problem

The Claude Code Review workflow was failing on PR #163 and other Dependabot PRs with the error:

```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

This occurs because Dependabot PRs cannot access regular GitHub secrets for security reasons (to prevent malicious dependency updates from stealing secrets).

## Solution

Added a condition to `.github/workflows/claude-code-review.yml` to skip the workflow when the PR author is `dependabot[bot]`:

```yaml
if: github.actor != 'dependabot[bot]'
```

## Rationale

- Dependency updates are mechanical changes that don't benefit from AI code review
- Test suites provide adequate quality assurance for dependency updates
- This prevents workflow failures while keeping Claude Code Review active for human-created PRs

## Test Plan

- [x] Workflow file syntax is valid
- [ ] Verify workflow is skipped on next Dependabot PR
- [ ] Verify workflow still runs on human-created PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)