### PR TITLE
Admin: LLM関連の不要ボタン削除 & モデル作成画面にモデル選択ボックス追加

### DIFF
--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -201,11 +201,17 @@ export interface UpdateLlmModelInput {
   default_model?: boolean
 }
 
+export interface AvailableModel {
+  id: string
+  name: string
+  display_name?: string
+}
+
 export const llmProvidersApi = {
   list: () => api.get<LlmProvider[]>('/llm_providers'),
   get: (id: number) => api.get<LlmProvider>(`/llm_providers/${id}`),
   update: (id: number, data: UpdateLlmProviderInput) => api.patch<LlmProvider>(`/llm_providers/${id}`, { llm_provider: data }),
-  getAvailableModels: (id: number) => api.get<{ models: string[] }>(`/llm_providers/${id}/available_models`),
+  getAvailableModels: (id: number) => api.get<AvailableModel[]>(`/llm_providers/${id}/available_models`),
 }
 
 export const llmModelsApi = {

--- a/app/javascript/admin/pages/llm-providers/LlmModelNewPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmModelNewPage.tsx
@@ -1,6 +1,6 @@
-import { FormEvent, useState } from 'react'
+import { FormEvent, useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { llmModelsApi, CreateLlmModelInput } from '../../lib/api'
+import { llmModelsApi, llmProvidersApi, CreateLlmModelInput, AvailableModel } from '../../lib/api'
 
 export const LlmModelNewPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -13,6 +13,27 @@ export const LlmModelNewPage = () => {
   const [defaultModel, setDefaultModel] = useState(false)
   const [error, setError] = useState('')
   const [submitting, setSubmitting] = useState(false)
+
+  const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
+  const [loadingModels, setLoadingModels] = useState(true)
+  const [modelsError, setModelsError] = useState('')
+
+  const fetchModels = useCallback(() => {
+    setLoadingModels(true)
+    setModelsError('')
+    llmProvidersApi.getAvailableModels(providerId)
+      .then(setAvailableModels)
+      .catch(err => setModelsError(err instanceof Error ? err.message : 'Failed to fetch available models'))
+      .finally(() => setLoadingModels(false))
+  }, [providerId])
+
+  useEffect(() => { fetchModels() }, [fetchModels])
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    const selected = availableModels.find(m => m.id === value)
+    setDisplayName(selected?.display_name ?? value)
+  }
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -57,14 +78,33 @@ export const LlmModelNewPage = () => {
           <div className="space-y-4">
             <div className="space-y-1">
               <label htmlFor="name" className="text-xs font-medium text-slate-600">Name</label>
-              <input
-                id="name"
-                type="text"
-                value={name}
-                onChange={e => setName(e.target.value)}
-                required
-                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30"
-              />
+              {loadingModels ? (
+                <p className="text-sm text-slate-400">Loading available models...</p>
+              ) : modelsError ? (
+                <div className="flex items-center gap-2">
+                  <p className="text-sm text-rose-400">{modelsError}</p>
+                  <button
+                    type="button"
+                    onClick={fetchModels}
+                    className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : (
+                <select
+                  id="name"
+                  value={name}
+                  onChange={e => handleNameChange(e.target.value)}
+                  required
+                  className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30"
+                >
+                  <option value="">Select a model</option>
+                  {availableModels.map(model => (
+                    <option key={model.id} value={model.id}>{model.name}</option>
+                  ))}
+                </select>
+              )}
             </div>
             <div className="space-y-1">
               <label htmlFor="display_name" className="text-xs font-medium text-slate-600">Display Name</label>
@@ -110,8 +150,8 @@ export const LlmModelNewPage = () => {
             </Link>
             <button
               type="submit"
-              disabled={submitting}
-              className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]"
+              disabled={submitting || loadingModels || !!modelsError}
+              className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8] disabled:opacity-50"
             >
               {submitting ? 'Creating...' : 'Create'}
             </button>

--- a/app/javascript/admin/pages/llm-providers/LlmProviderDetailPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmProviderDetailPage.tsx
@@ -8,26 +8,13 @@ export const LlmProviderDetailPage = () => {
   const providerId = Number(id)
 
   const [provider, setProvider] = useState<LlmProvider | null>(null)
-  const [availableModels, setAvailableModels] = useState<string[] | null>(null)
   const [error, setError] = useState('')
-  const [fetchingModels, setFetchingModels] = useState(false)
-  const [modelsError, setModelsError] = useState('')
 
   useEffect(() => {
     llmProvidersApi.get(providerId)
       .then(setProvider)
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load provider'))
   }, [providerId])
-
-  const handleFetchAvailableModels = () => {
-    setFetchingModels(true)
-    setModelsError('')
-    setAvailableModels(null)
-    llmProvidersApi.getAvailableModels(providerId)
-      .then(data => setAvailableModels(data.models))
-      .catch(err => setModelsError(err instanceof Error ? err.message : 'Failed to fetch available models'))
-      .finally(() => setFetchingModels(false))
-  }
 
   if (error) {
     return (
@@ -113,48 +100,6 @@ export const LlmProviderDetailPage = () => {
         </table>
       </div>
 
-      {/* Available Models */}
-      <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <button
-            onClick={handleFetchAvailableModels}
-            disabled={fetchingModels}
-            className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-          >
-            {fetchingModels ? 'Fetching...' : 'Fetch Available Models'}
-          </button>
-        </div>
-        {modelsError && (
-          <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
-            {modelsError}
-          </div>
-        )}
-        {availableModels !== null && (
-          <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr className="border-b border-slate-100">
-                  <th scope="col" className="px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-400">Model</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-50">
-                {availableModels.length === 0
-                  ? (
-                    <tr>
-                      <td className="px-5 py-3.5 text-sm text-slate-700">No models found.</td>
-                    </tr>
-                    )
-                  : availableModels.map(model => (
-                    <tr key={model} className="transition-colors hover:bg-slate-50/50">
-                      <td className="px-5 py-3.5 text-sm text-slate-700" style={{ fontFamily: 'DM Mono, monospace' }}>{model}</td>
-                    </tr>
-                  ))
-                }
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
     </div>
   )
 }

--- a/app/javascript/admin/pages/llm-providers/LlmProvidersIndexPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmProvidersIndexPage.tsx
@@ -34,12 +34,6 @@ export const LlmProvidersIndexPage = () => {
           <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400" style={{ fontFamily: 'DM Mono, monospace' }}>AI INFRASTRUCTURE</p>
           <h1 className="text-2xl font-bold text-slate-800" style={{ fontFamily: 'Syne, sans-serif' }}>LLM Providers</h1>
         </div>
-        <button className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50">
-          <svg className="h-4 w-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
-          </svg>
-          Sync Available Models
-        </button>
       </div>
 
       {/* Provider cards */}


### PR DESCRIPTION
## Summary
- LLMプロバイダ一覧・詳細ページの不要なボタン/セクションを削除
- モデル新規作成画面のNameフィールドをselectに変更し、プロバイダAPIから利用可能モデル一覧を取得して選択肢に表示
- モデル選択時にDisplay Nameを自動入力、APIエラー時はリトライボタンを表示

## Test plan
- [ ] `/admin/llm-providers` で「Sync Available Models」ボタンが消えていること
- [ ] `/admin/llm-providers/:id` で「Fetch Available Models」セクションが消えていること
- [ ] `/admin/llm-providers/:id/models/new` でNameが選択ボックスになっていること
- [ ] モデル選択時にDisplay Nameが自動入力されること
- [ ] APIエラー時にリトライボタンが表示・動作すること

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)