### PR TITLE
fix: replace curl|bash with multi-stage Node.js copy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.4.8
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim AS base
 
 # Rails app lives here
 WORKDIR /rails
@@ -14,16 +14,21 @@ ENV RAILS_ENV="production" \
     BUNDLE_WITHOUT="development"
 
 
+# Node.js stage for copying binaries (avoids curl | bash supply chain risk)
+FROM node:20-slim AS node
+
 # Throw-away build stage to reduce size of final image
-FROM base as build
+FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential curl git libvips pkg-config libsqlite3-dev libyaml-dev
 
-# Install Node.js 20
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install --no-install-recommends -y nodejs
+# Copy Node.js from official image
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
## Summary
- `curl | bash` によるNodeSourceスクリプト実行を廃止し、公式 `node:20-slim` イメージからバイナリをCOPYするマルチステージビルドに変更
- supply chain攻撃リスクを排除
- `FROM ... AS` のcasing warningも修正

Closes #202

## Test plan
- [x] `docker build --target build` でビルドステージ成功確認
- [x] `docker build` でフルビルド成功確認
- [x] warningが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)