### PR TITLE
fix: refresh capabilities on 403 to prevent stale cache

### DIFF
--- a/app/javascript/admin/__tests__/components/ProtectedRoute.test.tsx
+++ b/app/javascript/admin/__tests__/components/ProtectedRoute.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ProtectedRoute } from '@admin/components/ProtectedRoute'
+import * as AuthContextModule from '@admin/contexts/AuthContext'
+
+vi.mock('@admin/contexts/AuthContext')
+const mockUseAuth = vi.mocked(AuthContextModule.useAuth)
+
+const renderWithRouter = (ui: React.ReactElement, initialRoute = '/admin/users') =>
+  render(<MemoryRouter initialEntries={[initialRoute]}>{ui}</MemoryRouter>)
+
+const baseAuth = {
+  user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: {} },
+  loading: false,
+  refreshing: false,
+  login: vi.fn(),
+  logout: vi.fn(),
+  can: vi.fn().mockReturnValue(true),
+  isAdmin: true,
+} as unknown as ReturnType<typeof AuthContextModule.useAuth>
+
+describe('ProtectedRoute', () => {
+  it('shows loading when refreshing capabilities', () => {
+    mockUseAuth.mockReturnValue({ ...baseAuth, refreshing: true, can: vi.fn().mockReturnValue(false) })
+
+    renderWithRouter(
+      <ProtectedRoute requiredCapability={{ resource: 'User', action: 'read' }}>
+        <div>Protected Content</div>
+      </ProtectedRoute>
+    )
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+
+  it('renders children when not refreshing and capability is met', () => {
+    mockUseAuth.mockReturnValue({ ...baseAuth, refreshing: false, can: vi.fn().mockReturnValue(true) })
+
+    renderWithRouter(
+      <ProtectedRoute requiredCapability={{ resource: 'User', action: 'read' }}>
+        <div>Protected Content</div>
+      </ProtectedRoute>
+    )
+
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+  })
+})

--- a/app/javascript/admin/__tests__/contexts/AuthContext.test.tsx
+++ b/app/javascript/admin/__tests__/contexts/AuthContext.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { AuthProvider, useAuth } from '@admin/contexts/AuthContext'
+import { api, CAPABILITIES_STALE_EVENT, Capabilities } from '@admin/lib/api'
+
+vi.mock('@admin/lib/api', async () => {
+  const actual = await vi.importActual('@admin/lib/api')
+  return {
+    ...actual,
+    api: {
+      session: {
+        current: vi.fn(),
+        create: vi.fn(),
+        destroy: vi.fn(),
+      },
+    },
+  }
+})
+
+const mockSessionCurrent = vi.mocked(api.session.current)
+
+const makeCapabilities = (overrides: Partial<Record<string, Partial<Record<string, boolean>>>> = {}): Capabilities => {
+  const defaults = { read: false, write: false, delete: false, manage: false }
+  return {
+    User: { ...defaults, ...overrides.User },
+    Project: { ...defaults, ...overrides.Project },
+    Task: { ...defaults, ...overrides.Task },
+    Comment: { ...defaults, ...overrides.Comment },
+    Admin: { ...defaults, ...overrides.Admin },
+    LlmProvider: { ...defaults, ...overrides.LlmProvider },
+  }
+}
+
+const TestConsumer = () => {
+  const { user, loading, refreshing, can } = useAuth()
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="refreshing">{String(refreshing)}</span>
+      <span data-testid="user">{user?.email ?? 'none'}</span>
+      <span data-testid="can-user-read">{String(can('User', 'read'))}</span>
+    </div>
+  )
+}
+
+describe('AuthContext capability refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('refreshes capabilities when capabilities-stale event is dispatched', async () => {
+    const initialCaps = makeCapabilities({ User: { read: false } })
+    const updatedCaps = makeCapabilities({ User: { read: true } })
+
+    mockSessionCurrent
+      .mockResolvedValueOnce({ user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: initialCaps } })
+      .mockResolvedValueOnce({ user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: updatedCaps } })
+
+    render(<AuthProvider><TestConsumer /></AuthProvider>)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+    expect(screen.getByTestId('can-user-read').textContent).toBe('false')
+
+    await act(async () => {
+      window.dispatchEvent(new Event(CAPABILITIES_STALE_EVENT))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('can-user-read').textContent).toBe('true')
+    })
+    expect(mockSessionCurrent).toHaveBeenCalledTimes(2)
+  })
+
+  it('sets refreshing to true during capability refresh', async () => {
+    let resolveRefresh: (value: unknown) => void
+    const refreshPromise = new Promise(resolve => { resolveRefresh = resolve })
+
+    mockSessionCurrent
+      .mockResolvedValueOnce({ user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: makeCapabilities() } })
+      .mockReturnValueOnce(refreshPromise as ReturnType<typeof api.session.current>)
+
+    render(<AuthProvider><TestConsumer /></AuthProvider>)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+    expect(screen.getByTestId('refreshing').textContent).toBe('false')
+
+    act(() => {
+      window.dispatchEvent(new Event(CAPABILITIES_STALE_EVENT))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refreshing').textContent).toBe('true')
+    })
+
+    await act(async () => {
+      resolveRefresh!({ user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: makeCapabilities() } })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refreshing').textContent).toBe('false')
+    })
+  })
+
+  it('silently handles errors during capability refresh', async () => {
+    mockSessionCurrent
+      .mockResolvedValueOnce({ user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: makeCapabilities() } })
+      .mockRejectedValueOnce(new Error('Network error'))
+
+    render(<AuthProvider><TestConsumer /></AuthProvider>)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    // Should not throw
+    await act(async () => {
+      window.dispatchEvent(new Event(CAPABILITIES_STALE_EVENT))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refreshing').textContent).toBe('false')
+    })
+    // User should remain unchanged
+    expect(screen.getByTestId('user').textContent).toBe('admin@test.com')
+  })
+
+  it('cleans up event listener on unmount', async () => {
+    mockSessionCurrent
+      .mockResolvedValueOnce({ user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: makeCapabilities() } })
+
+    const { unmount } = render(<AuthProvider><TestConsumer /></AuthProvider>)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    unmount()
+
+    // Dispatch after unmount should not cause errors or additional calls
+    window.dispatchEvent(new Event(CAPABILITIES_STALE_EVENT))
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // Only the initial mount call
+    expect(mockSessionCurrent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/javascript/admin/__tests__/lib/api.test.ts
+++ b/app/javascript/admin/__tests__/lib/api.test.ts
@@ -1,4 +1,4 @@
-import { api, resetRedirectGuard } from '@admin/lib/api'
+import { api, resetRedirectGuard, resetCapabilitiesStaleCooldown, CAPABILITIES_STALE_EVENT } from '@admin/lib/api'
 
 describe('apiRequest 401 handling', () => {
   const originalLocation = window.location
@@ -132,5 +132,101 @@ describe('apiRequest 401 handling', () => {
 
     await expect(api.get('/users')).rejects.toThrow('Forbidden')
     expect(window.location.href).not.toBe('/admin/login')
+  })
+})
+
+describe('apiRequest 403 handling', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    resetRedirectGuard()
+    resetCapabilitiesStaleCooldown()
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, href: '' },
+    })
+    vi.spyOn(document, 'querySelector').mockReturnValue({
+      content: 'test-csrf-token',
+    } as HTMLMetaElement)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    })
+    vi.restoreAllMocks()
+    globalThis.fetch = originalFetch
+  })
+
+  const originalFetch = globalThis.fetch
+
+  const mockFetch = (status: number, body: unknown = {}) => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    })
+  }
+
+  it('dispatches capabilities-stale event on 403', async () => {
+    mockFetch(403, { error: 'Forbidden' })
+    const handler = vi.fn()
+    window.addEventListener(CAPABILITIES_STALE_EVENT, handler)
+
+    await expect(api.get('/users')).rejects.toThrow('Forbidden')
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    window.removeEventListener(CAPABILITIES_STALE_EVENT, handler)
+  })
+
+  it('still throws error after dispatching event', async () => {
+    mockFetch(403, { error: 'Forbidden' })
+
+    await expect(api.get('/users')).rejects.toThrow('Forbidden')
+  })
+
+  it('suppresses duplicate events within cooldown period', async () => {
+    vi.useFakeTimers()
+    mockFetch(403, { error: 'Forbidden' })
+    const handler = vi.fn()
+    window.addEventListener(CAPABILITIES_STALE_EVENT, handler)
+
+    await expect(api.get('/users')).rejects.toThrow('Forbidden')
+    await expect(api.get('/roles')).rejects.toThrow('Forbidden')
+
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener(CAPABILITIES_STALE_EVENT, handler)
+    vi.useRealTimers()
+  })
+
+  it('allows re-dispatch after cooldown expires', async () => {
+    vi.useFakeTimers()
+    mockFetch(403, { error: 'Forbidden' })
+    const handler = vi.fn()
+    window.addEventListener(CAPABILITIES_STALE_EVENT, handler)
+
+    await expect(api.get('/users')).rejects.toThrow('Forbidden')
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(5001)
+
+    await expect(api.get('/users')).rejects.toThrow('Forbidden')
+    expect(handler).toHaveBeenCalledTimes(2)
+
+    window.removeEventListener(CAPABILITIES_STALE_EVENT, handler)
+    vi.useRealTimers()
+  })
+
+  it('does not dispatch event for non-403 errors', async () => {
+    mockFetch(500, { error: 'Server Error' })
+    const handler = vi.fn()
+    window.addEventListener(CAPABILITIES_STALE_EVENT, handler)
+
+    await expect(api.get('/users')).rejects.toThrow('Server Error')
+
+    expect(handler).not.toHaveBeenCalled()
+    window.removeEventListener(CAPABILITIES_STALE_EVENT, handler)
   })
 })

--- a/app/javascript/admin/components/ProtectedRoute.tsx
+++ b/app/javascript/admin/components/ProtectedRoute.tsx
@@ -9,9 +9,9 @@ interface ProtectedRouteProps {
 }
 
 export const ProtectedRoute = ({ children, requiredCapability, requireAdmin }: ProtectedRouteProps) => {
-  const { user, loading, can, isAdmin } = useAuth()
+  const { user, loading, refreshing, can, isAdmin } = useAuth()
 
-  if (loading) return <div>Loading...</div>
+  if (loading || refreshing) return <div>Loading...</div>
   if (!user) return <Navigate to="/admin/login" replace />
 
   if (requireAdmin && !isAdmin) return <Navigate to="/admin" replace />

--- a/app/javascript/admin/contexts/AuthContext.tsx
+++ b/app/javascript/admin/contexts/AuthContext.tsx
@@ -1,9 +1,10 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
-import { Action, ResourceType, SessionUser, api } from '../lib/api'
+import { Action, CAPABILITIES_STALE_EVENT, ResourceType, SessionUser, api } from '../lib/api'
 
 interface AuthContextType {
   user: SessionUser | null
   loading: boolean
+  refreshing: boolean
   login: (email: string, password: string, totpCode?: string) => Promise<{ totpRequired?: boolean }>
   logout: () => Promise<void>
   can: (resource: ResourceType, action: Action) => boolean
@@ -15,12 +16,25 @@ const AuthContext = createContext<AuthContextType | null>(null)
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<SessionUser | null>(null)
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   useEffect(() => {
     api.session.current()
       .then(({ user }) => setUser(user))
       .catch(() => setUser(null))
       .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    const handleCapabilitiesStale = () => {
+      setRefreshing(true)
+      api.session.current()
+        .then(({ user }) => setUser(user))
+        .catch(() => {})
+        .finally(() => setRefreshing(false))
+    }
+    window.addEventListener(CAPABILITIES_STALE_EVENT, handleCapabilitiesStale)
+    return () => window.removeEventListener(CAPABILITIES_STALE_EVENT, handleCapabilitiesStale)
   }, [])
 
   const login = async (email: string, password: string, totpCode?: string) => {
@@ -49,7 +63,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const isAdmin = user?.is_admin ?? false
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout, can, isAdmin }}>
+    <AuthContext.Provider value={{ user, loading, refreshing, login, logout, can, isAdmin }}>
       {children}
     </AuthContext.Provider>
   )

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -89,6 +89,17 @@ export const resetRedirectGuard = () => {
   isRedirectingToLogin = false
 }
 
+// Dispatched on 403 to signal that cached capabilities may be stale.
+// Note: A 403 does not always mean stale cache — the user may genuinely lack
+// the permission. The cooldown prevents excessive refresh attempts.
+export const CAPABILITIES_STALE_EVENT = 'capabilities-stale'
+const CAPABILITIES_STALE_COOLDOWN_MS = 5000
+let lastCapabilitiesStaleDispatch = 0
+
+export const resetCapabilitiesStaleCooldown = () => {
+  lastCapabilitiesStaleDispatch = 0
+}
+
 const apiRequest = async <T>(
   path: string,
   options: RequestInit = {}
@@ -109,6 +120,13 @@ const apiRequest = async <T>(
         window.location.href = '/admin/login'
       }
       return new Promise(() => {}) as T
+    }
+    if (response.status === 403) {
+      const now = Date.now()
+      if (now - lastCapabilitiesStaleDispatch > CAPABILITIES_STALE_COOLDOWN_MS) {
+        lastCapabilitiesStaleDispatch = now
+        window.dispatchEvent(new Event(CAPABILITIES_STALE_EVENT))
+      }
     }
     const error = await response.json().catch(() => ({ error: 'Unknown error' }))
     throw new Error(error.error ?? `HTTP ${response.status}`)


### PR DESCRIPTION
## Summary
- 403レスポンス受信時にカスタムDOMイベント(`capabilities-stale`)を発火し、AuthContextがcapabilityを再取得する仕組みを追加
- 5秒クールダウンで無限ループを防止
- リフレッシュ中はProtectedRouteがリダイレクトせずローディング表示を維持

Closes #201

## Test plan
- [x] api.ts: 403でイベント発火、エラーもthrow、クールダウン抑制、クールダウン後再発火
- [x] AuthContext: イベント受信でcapability再取得、refreshing状態管理、エラーのsilent処理、unmountクリーンアップ
- [x] ProtectedRoute: refreshing中はローディング表示
- [x] 全26テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)