### PR TITLE
fix: re-verify admin capability after TOTP challenge

### DIFF
--- a/app/controllers/api/v1/admin/sessions_controller.rb
+++ b/app/controllers/api/v1/admin/sessions_controller.rb
@@ -75,7 +75,7 @@ module Api
           def handle_totp_challenge
             user = User.find_by(id: session[:admin_pending_user_id])
 
-            unless user
+            unless user&.can_read?("Admin")
               session.delete(:admin_pending_user_id)
               render json: { error: "Invalid email or password" }, status: :unauthorized
               return

--- a/test/controllers/api/v1/admin/sessions_controller_test.rb
+++ b/test/controllers/api/v1/admin/sessions_controller_test.rb
@@ -190,6 +190,30 @@ module Api
           assert_equal false, caps["User"]["write"]
         end
 
+        # TOTP challenge capability re-verification
+        test "POST create with valid TOTP returns 401 when admin capability revoked between steps" do
+          user = users(:admin_totp_user)
+          # Step 1: credential check
+          post api_v1_admin_session_path,
+               params: { email: user.email, password: TEST_PASSWORD },
+               as: :json
+          assert_response :ok
+          assert session[:admin_pending_user_id]
+          # Revoke admin capability between steps
+          user.user_roles.destroy_all
+          # Step 2: TOTP challenge
+          totp = ROTP::TOTP.new(user.totp_secret, issuer: "Hobo Todo")
+          valid_code = totp.now
+          post api_v1_admin_session_path,
+               params: { totp_code: valid_code },
+               as: :json
+          assert_response :unauthorized
+          json = response.parsed_body
+          assert_equal "Invalid email or password", json["error"]
+          assert_nil session[:admin_user_id]
+          assert_nil session[:admin_pending_user_id]
+        end
+
         # セッション固定化対策
         test "POST create でログインのたびにセッション ID がローテーションされる" do
           user = users(:admin_user)


### PR DESCRIPTION
## Summary
- `handle_totp_challenge` で `user.can_read?("Admin")` を再検証するように修正
- パスワード認証→TOTP入力の間に管理者権限が剥奪された場合のログインを防止

Closes #200

## Test plan
- [x] TOTP認証ステップ間でadmin権限が剥奪された場合に401が返ることを確認するテスト追加
- [x] 既存の全セッションコントローラテスト通過（19テスト、73アサーション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)