### PR TITLE
fix: handle logout when admin session is already expired

### DIFF
--- a/app/javascript/admin/__tests__/lib/api.test.ts
+++ b/app/javascript/admin/__tests__/lib/api.test.ts
@@ -67,11 +67,20 @@ describe('apiRequest 401 handling', () => {
     expect(window.location.href).not.toBe('/admin/login')
   })
 
-  it('does NOT redirect on 401 for DELETE /session (logout)', async () => {
+  it('redirects on 401 for DELETE /session (logout with expired session)', async () => {
     mockFetch(401, { error: 'Unauthorized' })
 
-    await expect(api.session.destroy()).rejects.toThrow('Unauthorized')
-    expect(window.location.href).not.toBe('/admin/login')
+    const promise = api.session.destroy()
+
+    await vi.waitFor(() => {
+      expect(window.location.href).toBe('/admin/login')
+    })
+
+    const result = await Promise.race([
+      promise.then(() => 'resolved').catch(() => 'rejected'),
+      new Promise(resolve => setTimeout(() => resolve('pending'), 50)),
+    ])
+    expect(result).toBe('pending')
   })
 
   it('sets window.location.href only once for concurrent 401 responses', async () => {

--- a/app/javascript/admin/components/AdminLayout.tsx
+++ b/app/javascript/admin/components/AdminLayout.tsx
@@ -98,7 +98,11 @@ export const AdminLayout = () => {
   const location = useLocation()
 
   const handleLogout = async () => {
-    await logout()
+    try {
+      await logout()
+    } catch {
+      // Session may already be expired; proceed to login regardless
+    }
     navigate('/admin/login')
   }
 

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -103,7 +103,11 @@ const apiRequest = async <T>(
   })
 
   if (!response.ok) {
-    if (response.status === 401 && !path.startsWith('/session')) {
+    // Suppress redirect for GET/POST /session (session check and login)
+    // to avoid redirect loops. DELETE /session (logout) should still redirect.
+    const method = (options.method ?? 'GET').toUpperCase()
+    const isSessionAuthEndpoint = path.startsWith('/session') && (method === 'GET' || method === 'POST')
+    if (response.status === 401 && !isSessionAuthEndpoint) {
       if (!isRedirectingToLogin) {
         isRedirectingToLogin = true
         window.location.href = '/admin/login'


### PR DESCRIPTION
## Summary
- `apiRequest` の401リダイレクト除外を `GET/POST /session` に限定し、`DELETE /session`（ログアウト）は401時にリダイレクトするように修正
- `handleLogout` に防御的 try/catch を追加
- codex-review で発見されたバグの修正

## Test plan
- [x] `DELETE /session` で401時にリダイレクトされることを確認するテスト追加
- [x] 既存の `GET/POST /session` の除外テストが引き続き通過
- [x] 全15フロントエンドテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)