### PR TITLE
feat: restructure admin sidebar navigation into three sections

### DIFF
--- a/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { navSections } from '../../components/AdminLayout'
+import { AdminLayout } from '../../components/AdminLayout'
+
+// Mock useAuth
+const mockCan = vi.fn()
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { name: 'Test Admin', email: 'admin@example.com' },
+    logout: vi.fn(),
+    can: mockCan,
+  }),
+}))
+
+describe('navSections', () => {
+  it('has three sections: NAVIGATION, ADMIN, AI INFRASTRUCTURE', () => {
+    expect(navSections.map((s) => s.label)).toEqual([
+      'NAVIGATION',
+      'ADMIN',
+      'AI INFRASTRUCTURE',
+    ])
+  })
+
+  it('NAVIGATION contains Dashboard and Users', () => {
+    const nav = navSections.find((s) => s.label === 'NAVIGATION')!
+    expect(nav.items.map((i) => i.label)).toEqual(['Dashboard', 'Users'])
+  })
+
+  it('ADMIN contains Admin Accounts, Roles, and Permissions', () => {
+    const admin = navSections.find((s) => s.label === 'ADMIN')!
+    expect(admin.items.map((i) => i.label)).toEqual([
+      'Admin Accounts',
+      'Roles',
+      'Permissions',
+    ])
+  })
+
+  it('Dashboard has no requiredCapability', () => {
+    const dashboard = navSections[0].items.find((i) => i.label === 'Dashboard')!
+    expect(dashboard.requiredCapability).toBeUndefined()
+  })
+
+  it('Users requires User:read', () => {
+    const users = navSections[0].items.find((i) => i.label === 'Users')!
+    expect(users.requiredCapability).toEqual({ resource: 'User', action: 'read' })
+  })
+
+  it('all ADMIN section items require Admin:read', () => {
+    const admin = navSections.find((s) => s.label === 'ADMIN')!
+    for (const item of admin.items) {
+      expect(item.requiredCapability).toEqual({ resource: 'Admin', action: 'read' })
+    }
+  })
+})
+
+describe('AdminLayout', () => {
+  const renderLayout = () =>
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <AdminLayout />
+      </MemoryRouter>
+    )
+
+  afterEach(() => {
+    mockCan.mockReset()
+  })
+
+  it('hides section header when all items are filtered out', () => {
+    // Only grant User:read — ADMIN section should be hidden
+    mockCan.mockImplementation(
+      (resource: string, action: string) =>
+        resource === 'User' && action === 'read'
+    )
+
+    renderLayout()
+
+    expect(screen.getByText('NAVIGATION')).toBeInTheDocument()
+    expect(screen.queryByText('ADMIN')).not.toBeInTheDocument()
+  })
+
+  it('shows ADMIN section when user has Admin:read', () => {
+    mockCan.mockImplementation(
+      (resource: string, action: string) =>
+        (resource === 'Admin' && action === 'read') ||
+        (resource === 'User' && action === 'read')
+    )
+
+    renderLayout()
+
+    expect(screen.getByText('NAVIGATION')).toBeInTheDocument()
+    expect(screen.getByText('ADMIN')).toBeInTheDocument()
+    expect(screen.getByText('Admin Accounts')).toBeInTheDocument()
+    expect(screen.getByText('Roles')).toBeInTheDocument()
+    expect(screen.getByText('Permissions')).toBeInTheDocument()
+  })
+
+  it('hides Users when user lacks User:read', () => {
+    mockCan.mockImplementation(
+      (resource: string, action: string) =>
+        resource === 'Admin' && action === 'read'
+    )
+
+    renderLayout()
+
+    expect(screen.queryByText('Users')).not.toBeInTheDocument()
+    expect(screen.getByText('Admin Accounts')).toBeInTheDocument()
+  })
+})

--- a/app/javascript/admin/components/AdminLayout.tsx
+++ b/app/javascript/admin/components/AdminLayout.tsx
@@ -11,7 +11,7 @@ type NavItem = {
   requiredCapability?: { resource: ResourceType; action: Action }
 }
 
-const navSections: { label: string; items: NavItem[] }[] = [
+export const navSections: { label: string; items: NavItem[] }[] = [
   {
     label: 'NAVIGATION',
     items: [
@@ -35,6 +35,11 @@ const navSections: { label: string; items: NavItem[] }[] = [
           </svg>
         ),
       },
+    ],
+  },
+  {
+    label: 'ADMIN',
+    items: [
       {
         to: '/admin/admin-accounts',
         label: 'Admin Accounts',
@@ -48,6 +53,7 @@ const navSections: { label: string; items: NavItem[] }[] = [
       {
         to: '/admin/roles',
         label: 'Roles',
+        requiredCapability: { resource: 'Admin', action: 'read' },
         icon: (
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
@@ -57,6 +63,7 @@ const navSections: { label: string; items: NavItem[] }[] = [
       {
         to: '/admin/permissions',
         label: 'Permissions',
+        requiredCapability: { resource: 'Admin', action: 'read' },
         icon: (
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" />
@@ -140,35 +147,39 @@ export const AdminLayout = () => {
 
         {/* Navigation */}
         <div className="flex-1 overflow-y-auto py-4">
-          {navSections.map((section) => (
-            <div key={section.label} className="mb-4 px-3">
-              <p className="mb-2 px-2 text-[9px] font-semibold tracking-[0.15em] text-slate-600" style={{ fontFamily: 'DM Mono, monospace' }}>
-                {section.label}
-              </p>
-              <ul className="space-y-0.5">
-                {section.items.filter((item) =>
-                  !item.requiredCapability || can(item.requiredCapability.resource, item.requiredCapability.action)
-                ).map((item) => {
-                  const active = isActive(item)
-                  return (
-                    <li key={item.to}>
-                      <Link
-                        to={item.to}
-                        className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
-                          active
-                            ? 'bg-[rgba(99,102,241,0.15)] text-[#6366f1]'
-                            : 'text-slate-400 hover:bg-white/5 hover:text-slate-200'
-                        }`}
-                      >
-                        <span className={active ? 'text-[#6366f1]' : 'text-slate-600'}>{item.icon}</span>
-                        {item.label}
-                      </Link>
-                    </li>
-                  )
-                })}
-              </ul>
-            </div>
-          ))}
+          {navSections.map((section) => {
+            const visibleItems = section.items.filter((item) =>
+              !item.requiredCapability || can(item.requiredCapability.resource, item.requiredCapability.action)
+            )
+            if (visibleItems.length === 0) return null
+            return (
+              <div key={section.label} className="mb-4 px-3">
+                <p className="mb-2 px-2 text-[9px] font-semibold tracking-[0.15em] text-slate-600" style={{ fontFamily: 'DM Mono, monospace' }}>
+                  {section.label}
+                </p>
+                <ul className="space-y-0.5">
+                  {visibleItems.map((item) => {
+                    const active = isActive(item)
+                    return (
+                      <li key={item.to}>
+                        <Link
+                          to={item.to}
+                          className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                            active
+                              ? 'bg-[rgba(99,102,241,0.15)] text-[#6366f1]'
+                              : 'text-slate-400 hover:bg-white/5 hover:text-slate-200'
+                          }`}
+                        >
+                          <span className={active ? 'text-[#6366f1]' : 'text-slate-600'}>{item.icon}</span>
+                          {item.label}
+                        </Link>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            )
+          })}
         </div>
 
         {/* User footer */}


### PR DESCRIPTION
## Summary
- Reorganize admin sidebar from 2 sections to 3: **NAVIGATION** (Dashboard, Users), **ADMIN** (Admin Accounts, Roles, Permissions), **AI INFRASTRUCTURE** (unchanged)
- Add `Admin:read` capability requirement to Roles and Permissions nav items (previously had no sidebar permission check)
- Hide section headers when all items are filtered out by capability checks

Closes #236

## Test plan
- [x] `navSections` structure tests (3 sections, correct items, correct capabilities)
- [x] Rendering tests: ADMIN section hidden when user lacks `Admin:read`
- [x] Rendering tests: Users hidden when user lacks `User:read`
- [x] All 35 JS tests pass
- [ ] Manual verification: admin with full permissions sees all 3 sections
- [ ] Manual verification: admin with only `User:read` sees NAVIGATION but not ADMIN
- [ ] Manual verification: admin with only `Admin:read` sees ADMIN but not Users

🤖 Generated with [Claude Code](https://claude.com/claude-code)