### PR TITLE
feat: admin account role management and permission detail view

### DIFF
--- a/app/controllers/api/v1/admin/admin_accounts/roles_controller.rb
+++ b/app/controllers/api/v1/admin/admin_accounts/roles_controller.rb
@@ -1,0 +1,76 @@
+module Api
+  module V1
+    module Admin
+      module AdminAccounts
+        class RolesController < Admin::ApplicationController
+          before_action :set_admin_account
+          before_action -> { require_capability!("User", "read") }, only: %i[show]
+          before_action -> { require_capability!("User", "write") }, only: %i[update]
+          before_action :protect_self_modification, only: %i[update]
+          before_action :validate_and_set_roles, only: %i[update]
+          before_action :protect_privilege_escalation, only: %i[update]
+
+          def show
+            render json: @admin_account.roles.as_json(only: %i[id name description system_role])
+          end
+
+          def update
+            @admin_account.roles = @roles
+            render json: @admin_account.roles.as_json(only: %i[id name description system_role])
+          end
+
+          private
+
+            def set_admin_account
+              @admin_account = User.admin_accounts.find_by(id: params[:admin_account_id])
+              render json: { error: "Not found" }, status: :not_found unless @admin_account
+            end
+
+            def protect_self_modification
+              return unless @admin_account == current_admin
+
+              render json: { error: "Cannot change your own roles" }, status: :forbidden
+            end
+
+            def validate_and_set_roles
+              ids = role_ids_param
+              if ids.empty?
+                return render json: { error: "At least one role is required" },
+                              status: :unprocessable_entity
+              end
+
+              @roles = Role.where(id: ids)
+              unless @roles.count == ids.count
+                return render json: { error: "Some roles were not found" },
+                              status: :unprocessable_entity
+              end
+
+              return if roles_have_admin_access?
+
+              render json: { error: "At least one role with admin access is required" },
+                     status: :unprocessable_entity
+            end
+
+            def role_ids_param
+              params.permit(role_ids: [])[:role_ids]&.compact_blank&.map(&:to_i) || []
+            end
+
+            def roles_have_admin_access?
+              @roles.joins(:permissions)
+                    .exists?(permissions: { resource_type: "Admin", action: %w[read manage] })
+            end
+
+            def protect_privilege_escalation
+              new_ids = RolePermission.where(role_id: @roles.pluck(:id)).pluck(:permission_id).uniq
+              return if new_ids.empty?
+
+              admin_ids = current_admin.roles.joins(:permissions).pluck("permissions.id").uniq
+              return if (new_ids - admin_ids).empty?
+
+              render json: { error: "Forbidden" }, status: :forbidden
+            end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/admin_accounts_controller.rb
+++ b/app/controllers/api/v1/admin/admin_accounts_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     module Admin
       class AdminAccountsController < ApplicationController
-        before_action :set_admin_account, only: %i[destroy]
-        before_action -> { require_capability!("Admin", "read") }, only: %i[index]
+        before_action :set_admin_account, only: %i[show destroy]
+        before_action -> { require_capability!("Admin", "read") }, only: %i[index show]
         before_action -> { require_capability!("User", "write") }, only: %i[create]
         before_action -> { require_capability!("User", "delete") }, only: %i[destroy]
         before_action :protect_privilege_escalation, only: %i[create]
@@ -15,6 +15,24 @@ module Api
             only: %i[id email name created_at updated_at],
             include: { roles: { only: %i[id name] } },
           )
+        end
+
+        def show
+          granted = @admin_account.roles.joins(:permissions)
+                                  .pluck("permissions.resource_type", "permissions.action")
+                                  .to_set
+
+          matrix = Permission::RESOURCE_TYPES.index_with do |rt|
+            has_manage = granted.include?([rt, "manage"])
+            Permission::ACTIONS.index_with do |action|
+              granted.include?([rt, action]) || (has_manage && action != "manage")
+            end
+          end
+
+          render json: @admin_account.as_json(
+            only: %i[id email name created_at updated_at],
+            include: { roles: { only: %i[id name description system_role] } },
+          ).merge(permission_matrix: matrix)
         end
 
         def create

--- a/app/javascript/admin/App.tsx
+++ b/app/javascript/admin/App.tsx
@@ -16,6 +16,8 @@ import { PermissionsIndexPage } from './pages/permissions/PermissionsIndexPage'
 import { PermissionDetailPage } from './pages/permissions/PermissionDetailPage'
 import { AdminAccountsIndexPage } from './pages/admin-accounts/AdminAccountsIndexPage'
 import { AdminAccountNewPage } from './pages/admin-accounts/AdminAccountNewPage'
+import { AdminAccountDetailPage } from './pages/admin-accounts/AdminAccountDetailPage'
+import { AdminAccountRolesEditPage } from './pages/admin-accounts/AdminAccountRolesEditPage'
 import { LlmProvidersIndexPage } from './pages/llm-providers/LlmProvidersIndexPage'
 import { LlmProviderDetailPage } from './pages/llm-providers/LlmProviderDetailPage'
 import { LlmProviderEditPage } from './pages/llm-providers/LlmProviderEditPage'
@@ -44,6 +46,16 @@ const App = () => (
           <Route path="admin-accounts/new" element={
             <ProtectedRoute requiredCapability={{ resource: 'User', action: 'write' }}>
               <AdminAccountNewPage />
+            </ProtectedRoute>
+          } />
+          <Route path="admin-accounts/:id" element={
+            <ProtectedRoute requiredCapability={{ resource: 'Admin', action: 'read' }}>
+              <AdminAccountDetailPage />
+            </ProtectedRoute>
+          } />
+          <Route path="admin-accounts/:id/roles" element={
+            <ProtectedRoute requiredCapability={{ resource: 'User', action: 'write' }}>
+              <AdminAccountRolesEditPage />
             </ProtectedRoute>
           } />
           <Route path="users" element={

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -180,6 +180,13 @@ export interface CreateAdminAccountInput {
   role_ids: number[]
 }
 
+export type PermissionMatrix = Record<ResourceType, Record<Action, boolean>>
+
+export interface AdminAccountDetail extends User {
+  roles: { id: number; name: string; description: string | null; system_role: boolean }[]
+  permission_matrix: PermissionMatrix
+}
+
 export const adminAccountsApi = {
   list: (params?: { q?: string }, options?: { signal?: AbortSignal }) => {
     const query = new URLSearchParams()
@@ -187,10 +194,14 @@ export const adminAccountsApi = {
     const qs = query.toString()
     return api.get<User[]>(qs ? `/admin_accounts?${qs}` : '/admin_accounts', options)
   },
+  get: (id: number) => api.get<AdminAccountDetail>(`/admin_accounts/${id}`),
   create: (data: CreateAdminAccountInput) =>
     api.post<User>('/admin_accounts', { admin_account: data }),
   delete: (id: number) => api.delete<void>(`/admin_accounts/${id}`),
   revoke: (id: number) => api.post<void>(`/admin_accounts/${id}/revocation`),
+  getRoles: (id: number) => api.get<Role[]>(`/admin_accounts/${id}/roles`),
+  updateRoles: (id: number, roleIds: number[]) =>
+    api.patch<Role[]>(`/admin_accounts/${id}/roles`, { role_ids: roleIds }),
 }
 
 export const rolesApi = {

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountDetailPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountDetailPage.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { adminAccountsApi, type AdminAccountDetail, type ResourceType, type Action } from '../../lib/api'
+import { useAuth } from '../../contexts/AuthContext'
+import Avatar from '../../components/Avatar'
+import Badge from '../../components/Badge'
+
+const RESOURCE_TYPES: ResourceType[] = ['User', 'Project', 'Task', 'Comment', 'Admin', 'LlmProvider']
+const ACTIONS: Action[] = ['read', 'write', 'delete', 'manage']
+
+const roleBadgeVariant = (name: string) => {
+  if (name === 'admin') return 'danger' as const
+  if (name === 'user_manager') return 'warning' as const
+  return 'info' as const
+}
+
+export const AdminAccountDetailPage = () => {
+  const { id } = useParams<{ id: string }>()
+  const { can } = useAuth()
+  const [account, setAccount] = useState<AdminAccountDetail | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const canWrite = can('User', 'write')
+
+  useEffect(() => {
+    const fetchAccount = async () => {
+      try {
+        const data = await adminAccountsApi.get(Number(id))
+        setAccount(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load admin account')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchAccount()
+  }, [id])
+
+  if (loading) return <p>Loading...</p>
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
+             style={{ fontFamily: 'DM Mono, monospace' }}>ADMIN</p>
+          <h1 className="text-2xl font-bold text-slate-800"
+              style={{ fontFamily: 'Syne, sans-serif' }}>Admin Account Detail</h1>
+        </div>
+        {canWrite && account && (
+          <Link
+            to={`/admin/admin-accounts/${account.id}/roles`}
+            className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]"
+          >
+            Edit Roles
+          </Link>
+        )}
+      </div>
+
+      {error && <p className="text-rose-500">{error}</p>}
+
+      {account && (
+        <>
+          {/* Account info */}
+          <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex items-center gap-4">
+              <Avatar name={account.name ?? account.email} size="lg" />
+              <div>
+                <p className="text-lg font-semibold text-slate-800">{account.name}</p>
+                <p className="text-sm text-slate-400">{account.email}</p>
+                <p className="mt-1 text-xs text-slate-400">
+                  Created: {new Date(account.created_at).toLocaleDateString()}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Roles */}
+          <div>
+            <h2 className="mb-3 text-sm font-semibold text-slate-600">Assigned Roles</h2>
+            <div className="flex flex-wrap gap-2">
+              {account.roles.map(role => (
+                <Badge key={role.id} variant={roleBadgeVariant(role.name)}>
+                  {role.name}
+                  {role.system_role && ' (system)'}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          {/* Permission Matrix */}
+          <div>
+            <h2 className="mb-3 text-sm font-semibold text-slate-600">Permission Matrix</h2>
+            <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr className="border-b border-slate-100">
+                    <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-400">Resource</th>
+                    {ACTIONS.map(action => (
+                      <th key={action} className="px-5 py-3 text-center text-xs font-semibold uppercase tracking-wider text-slate-400">
+                        {action}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {RESOURCE_TYPES.map(rt => (
+                    <tr key={rt} className="border-b border-slate-50 last:border-0">
+                      <td className="px-5 py-3 text-sm font-medium text-slate-700">{rt}</td>
+                      {ACTIONS.map(action => (
+                        <td key={action} className="px-5 py-3 text-center">
+                          {account.permission_matrix[rt][action] ? (
+                            <span className="text-emerald-500">&#10003;</span>
+                          ) : (
+                            <span className="text-slate-300">&mdash;</span>
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+
+      <div>
+        <Link
+          to="/admin/admin-accounts"
+          className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+        >
+          Back to list
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { adminAccountsApi, rolesApi, type Role } from '../../lib/api'
+
+export const AdminAccountRolesEditPage = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [allRoles, setAllRoles] = useState<Role[]>([])
+  const [selectedRoleIds, setSelectedRoleIds] = useState<number[]>([])
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!id) return
+    Promise.all([
+      rolesApi.list(),
+      adminAccountsApi.getRoles(Number(id)),
+    ])
+      .then(([roles, accountRoles]) => {
+        setAllRoles(roles)
+        setSelectedRoleIds(accountRoles.map(r => r.id))
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load roles'))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  const handleToggle = (roleId: number) => {
+    setSelectedRoleIds(prev =>
+      prev.includes(roleId)
+        ? prev.filter(rid => rid !== roleId)
+        : [...prev, roleId]
+    )
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    try {
+      await adminAccountsApi.updateRoles(Number(id), selectedRoleIds)
+      navigate(`/admin/admin-accounts/${id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update roles')
+    }
+  }
+
+  if (loading) return <p>Loading...</p>
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
+             style={{ fontFamily: 'DM Mono, monospace' }}>ADMIN</p>
+          <h1 className="text-2xl font-bold text-slate-800"
+              style={{ fontFamily: 'Syne, sans-serif' }}>Edit Roles</h1>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <form onSubmit={handleSubmit}>
+          <ul className="space-y-2">
+            {allRoles.map(role => (
+              <li key={role.id}>
+                <label className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={selectedRoleIds.includes(role.id)}
+                    onChange={() => handleToggle(role.id)}
+                    className="rounded border-slate-300 text-[#6366f1]"
+                  />
+                  <span className="text-sm font-medium text-slate-700">{role.name}</span>
+                  {role.system_role && (
+                    <span className="text-[10px] text-slate-400">(system)</span>
+                  )}
+                  {role.description && (
+                    <span className="text-xs text-slate-400">— {role.description}</span>
+                  )}
+                </label>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 flex items-center justify-end gap-2">
+            <button type="button" onClick={() => navigate(`/admin/admin-accounts/${id}`)}
+              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
+              Cancel
+            </button>
+            <button type="submit"
+              className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountsIndexPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountsIndexPage.tsx
@@ -133,13 +133,13 @@ export const AdminAccountsIndexPage = () => {
               <tr key={account.id} className="transition-colors hover:bg-slate-50/50">
                 <td className="px-5 py-3.5 text-xs text-slate-400" style={{ fontFamily: 'DM Mono, monospace' }}>{account.id}</td>
                 <td className="px-5 py-3.5">
-                  <div className="flex items-center gap-3">
+                  <Link to={`/admin/admin-accounts/${account.id}`} className="flex items-center gap-3 hover:opacity-80 transition">
                     <Avatar name={account.name ?? account.email} size="sm" />
                     <div>
                       <p className="text-sm font-medium text-slate-700">{account.name}</p>
                       <p className="text-xs text-slate-400">{account.email}</p>
                     </div>
-                  </div>
+                  </Link>
                 </td>
                 <td className="px-5 py-3.5">
                   <div className="flex flex-wrap gap-1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,8 +45,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :admin do
         root "dashboard#index"
-        resources :admin_accounts, only: %i[index create destroy] do
+        resources :admin_accounts, only: %i[index show create destroy] do
           resource :revocation, only: [:create], module: :admin_accounts
+          resource :roles, only: %i[show update], module: :admin_accounts
         end
         resources :users, only: %i[index show create update destroy] do
           resource :roles, only: %i[show update], controller: "user_roles"

--- a/test/controllers/api/v1/admin/admin_accounts/roles_controller_test.rb
+++ b/test/controllers/api/v1/admin/admin_accounts/roles_controller_test.rb
@@ -1,0 +1,178 @@
+require "test_helper"
+
+module Api
+  module V1
+    module Admin
+      module AdminAccounts
+        class RolesControllerTest < ActionDispatch::IntegrationTest
+          # show
+          test "GET show returns 401 when not logged in" do
+            get api_v1_admin_admin_account_roles_path(users(:user_manager))
+            assert_response :unauthorized
+          end
+
+          test "GET show returns 401 when logged in as regular user" do
+            login_as(users(:regular_user))
+            get api_v1_admin_admin_account_roles_path(users(:user_manager))
+            assert_response :unauthorized
+          end
+
+          test "GET show returns 403 when admin lacks User:read" do
+            login_as_llm_admin_api
+            get api_v1_admin_admin_account_roles_path(users(:user_manager))
+            assert_response :forbidden
+          end
+
+          test "GET show returns 200 with roles list" do
+            login_as_admin_api
+            target = users(:user_manager)
+            get api_v1_admin_admin_account_roles_path(target)
+            assert_response :success
+            json = response.parsed_body
+            assert_kind_of Array, json
+            assert_equal 1, json.size
+            role = json.first
+            assert_equal roles(:user_manager).id, role["id"]
+            assert_equal "user_manager", role["name"]
+            assert role.key?("description")
+            assert role.key?("system_role")
+          end
+
+          test "GET show returns 404 for non-admin user" do
+            login_as_admin_api
+            get api_v1_admin_admin_account_roles_path(users(:regular_user))
+            assert_response :not_found
+          end
+
+          test "GET show returns 404 for non-existent user" do
+            login_as_admin_api
+            get api_v1_admin_admin_account_roles_path(admin_account_id: 0)
+            assert_response :not_found
+          end
+
+          # update
+          test "PATCH update returns 401 when not logged in" do
+            patch api_v1_admin_admin_account_roles_path(users(:user_manager)),
+                  params: { role_ids: [roles(:user_viewer).id] }
+            assert_response :unauthorized
+          end
+
+          test "PATCH update returns 401 when logged in as regular user" do
+            login_as(users(:regular_user))
+            patch api_v1_admin_admin_account_roles_path(users(:user_manager)),
+                  params: { role_ids: [roles(:user_viewer).id] }
+            assert_response :unauthorized
+          end
+
+          test "PATCH update returns 403 when admin lacks User:write" do
+            login_as_admin_api_read_only
+            patch api_v1_admin_admin_account_roles_path(users(:user_manager)),
+                  params: { role_ids: [roles(:user_viewer).id] }
+            assert_response :forbidden
+          end
+
+          test "PATCH update returns 403 when trying to change own roles" do
+            login_as_admin_api
+            patch api_v1_admin_admin_account_roles_path(users(:admin_user)),
+                  params: { role_ids: [roles(:admin).id] }
+            assert_response :forbidden
+            assert_equal "Cannot change your own roles", response.parsed_body["error"]
+          end
+
+          test "PATCH update returns 403 on privilege escalation" do
+            # user_manager does not have LlmProvider permissions
+            login_as_admin_api(users(:user_manager))
+            patch api_v1_admin_admin_account_roles_path(users(:user_viewer)),
+                  params: { role_ids: [roles(:llm_admin).id] }
+            assert_response :forbidden
+          end
+
+          test "PATCH update returns 422 when role_ids is empty" do
+            login_as_admin_api
+            patch api_v1_admin_admin_account_roles_path(users(:user_manager)),
+                  params: { role_ids: [] }
+            assert_response :unprocessable_entity
+            assert_equal "At least one role is required", response.parsed_body["error"]
+          end
+
+          test "PATCH update returns 422 when no role has admin access" do
+            login_as_admin_api
+            patch api_v1_admin_admin_account_roles_path(users(:user_manager)),
+                  params: { role_ids: [roles(:regular).id] }
+            assert_response :unprocessable_entity
+            assert_equal "At least one role with admin access is required",
+                         response.parsed_body["error"]
+          end
+
+          test "PATCH update returns 422 when role does not exist" do
+            login_as_admin_api
+            patch api_v1_admin_admin_account_roles_path(users(:user_manager)),
+                  params: { role_ids: [0] }
+            assert_response :unprocessable_entity
+            assert_equal "Some roles were not found", response.parsed_body["error"]
+          end
+
+          test "PATCH update returns 404 for non-admin user" do
+            login_as_admin_api
+            patch api_v1_admin_admin_account_roles_path(users(:regular_user)),
+                  params: { role_ids: [roles(:user_viewer).id] }
+            assert_response :not_found
+          end
+
+          test "PATCH update successfully changes roles" do
+            login_as_admin_api
+            target = users(:user_viewer)
+            new_role = roles(:user_manager)
+
+            patch api_v1_admin_admin_account_roles_path(target),
+                  params: { role_ids: [new_role.id] }
+            assert_response :success
+            json = response.parsed_body
+            assert_kind_of Array, json
+            assert_equal 1, json.size
+            assert_equal new_role.id, json.first["id"]
+
+            # Verify persisted
+            target.reload
+            assert_equal [new_role.id], target.role_ids
+          end
+
+          test "PATCH update allows assigning system roles" do
+            login_as_admin_api
+            target = users(:user_viewer)
+
+            patch api_v1_admin_admin_account_roles_path(target),
+                  params: { role_ids: [roles(:user_manager).id] }
+            assert_response :success
+            assert_equal "user_manager", response.parsed_body.first["name"]
+          end
+
+          test "PATCH update allows changing between system roles" do
+            login_as_admin_api
+            target = users(:user_viewer)
+
+            # Change from user_viewer to user_manager (both system roles)
+            patch api_v1_admin_admin_account_roles_path(target),
+                  params: { role_ids: [roles(:user_manager).id] }
+            assert_response :success
+
+            target.reload
+            assert_includes target.roles.pluck(:name), "user_manager"
+            assert_not_includes target.roles.pluck(:name), "user_viewer"
+          end
+
+          test "PATCH update preserves admin account status" do
+            login_as_admin_api
+            target = users(:user_viewer)
+
+            patch api_v1_admin_admin_account_roles_path(target),
+                  params: { role_ids: [roles(:user_manager).id] }
+            assert_response :success
+
+            assert User.admin_accounts.exists?(id: target.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/admin/admin_accounts_controller_test.rb
+++ b/test/controllers/api/v1/admin/admin_accounts_controller_test.rb
@@ -274,6 +274,104 @@ module Api
           delete api_v1_admin_admin_account_path(id: 0)
           assert_response :not_found
         end
+
+        # show
+        test "GET show returns 401 when not logged in" do
+          get api_v1_admin_admin_account_path(users(:admin_user))
+          assert_response :unauthorized
+        end
+
+        test "GET show returns 401 when logged in as regular user" do
+          login_as(users(:regular_user))
+          get api_v1_admin_admin_account_path(users(:admin_user))
+          assert_response :unauthorized
+        end
+
+        test "GET show returns 200 with account detail" do
+          login_as_admin_api
+          target = users(:user_manager)
+          get api_v1_admin_admin_account_path(target)
+          assert_response :success
+          json = response.parsed_body
+          assert_equal target.id, json["id"]
+          assert_equal target.email, json["email"]
+          assert_equal target.name, json["name"]
+          assert json.key?("created_at")
+          assert json.key?("updated_at")
+          assert_not json.key?("password_digest")
+        end
+
+        test "GET show includes roles with detail fields" do
+          login_as_admin_api
+          get api_v1_admin_admin_account_path(users(:user_manager))
+          assert_response :success
+          roles = response.parsed_body["roles"]
+          assert_kind_of Array, roles
+          assert_equal 1, roles.size
+          role = roles.first
+          assert role.key?("id")
+          assert role.key?("name")
+          assert role.key?("description")
+          assert role.key?("system_role")
+        end
+
+        test "GET show includes permission_matrix with all resource types and actions" do
+          login_as_admin_api
+          get api_v1_admin_admin_account_path(users(:user_manager))
+          assert_response :success
+          matrix = response.parsed_body["permission_matrix"]
+          assert_kind_of Hash, matrix
+
+          booleans = [true, false]
+          Permission::RESOURCE_TYPES.each do |rt|
+            assert matrix.key?(rt), "Missing resource type: #{rt}"
+            Permission::ACTIONS.each do |action|
+              assert booleans.include?(matrix[rt][action]),
+                     "Expected boolean for #{rt}:#{action}"
+            end
+          end
+        end
+
+        test "GET show permission_matrix reflects actual permissions" do
+          login_as_admin_api
+          # user_manager has User:read/write/delete and Admin:read
+          get api_v1_admin_admin_account_path(users(:user_manager))
+          assert_response :success
+          matrix = response.parsed_body["permission_matrix"]
+
+          assert_equal true, matrix["User"]["read"]
+          assert_equal true, matrix["User"]["write"]
+          assert_equal true, matrix["User"]["delete"]
+          assert_equal false, matrix["User"]["manage"]
+          assert_equal true, matrix["Admin"]["read"]
+          assert_equal false, matrix["Admin"]["write"]
+          assert_equal false, matrix["Project"]["read"]
+        end
+
+        test "GET show permission_matrix manage implies read/write/delete" do
+          login_as_admin_api
+          # admin role has User:manage
+          get api_v1_admin_admin_account_path(users(:admin_user))
+          assert_response :success
+          matrix = response.parsed_body["permission_matrix"]
+
+          assert_equal true, matrix["User"]["manage"]
+          assert_equal true, matrix["User"]["read"]
+          assert_equal true, matrix["User"]["write"]
+          assert_equal true, matrix["User"]["delete"]
+        end
+
+        test "GET show returns 404 for non-admin user" do
+          login_as_admin_api
+          get api_v1_admin_admin_account_path(users(:regular_user))
+          assert_response :not_found
+        end
+
+        test "GET show returns 404 for non-existent user" do
+          login_as_admin_api
+          get api_v1_admin_admin_account_path(id: 0)
+          assert_response :not_found
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- 管理アカウント詳細表示エンドポイント（`GET /admin_accounts/:id`）を追加。ロール一覧と権限マトリクス（ResourceType × Action）を返す
- 管理アカウントのロール変更用ネストコントローラ（`AdminAccounts::RolesController`）を追加。システムロール・カスタムロール両方の付与が可能
- React 詳細ページ（権限マトリクス表示）とロール編集ページを追加

Closes #235

## Test plan
- [ ] `bin/rails test test/controllers/api/v1/admin/admin_accounts_controller_test.rb` — show endpoint テスト
- [ ] `bin/rails test test/controllers/api/v1/admin/admin_accounts/roles_controller_test.rb` — roles controller テスト
- [ ] `bin/rails test` — 全テスト通過確認
- [ ] ブラウザで `/admin/admin-accounts` → アカウントクリック → 詳細表示 → 権限マトリクス確認
- [ ] 詳細ページから「Edit Roles」→ ロール変更 → 保存 → 反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)