### PR TITLE
fix: flaky TaskFlowTest — retry querySelector in Stimulus readiness check

### DIFF
--- a/test/support/system_test_helpers.rb
+++ b/test/support/system_test_helpers.rb
@@ -22,11 +22,10 @@ module SystemTestHelpers
         var name = arguments[1];
         var timeoutMs = arguments[2];
         var done = arguments[3];
-        var el = document.querySelector(selector);
-        if (!el) { done(false); return; }
         var timerId = setTimeout(function() { done(false); }, timeoutMs);
         var check = function() {
-          if (window.Stimulus && window.Stimulus.getControllerForElementAndIdentifier(el, name)) {
+          var el = document.querySelector(selector);
+          if (el && window.Stimulus && window.Stimulus.getControllerForElementAndIdentifier(el, name)) {
             clearTimeout(timerId);
             done(true);
           } else {


### PR DESCRIPTION
## Summary
- `wait_for_stimulus_controller` の `querySelector` をポーリングループ内に移動し、DOM要素が未出現でもタイムアウトまでリトライするよう修正
- #232 で追加された null ガードの即失敗パスを排除し、要素出現+コントローラー接続の両方をポーリングで待機

## Test plan
- [x] `bin/rails test test/system/task_flow_test.rb` パス確認
- [x] `bin/rails test test/system/project_flow_test.rb` パス確認
- [ ] CI全テスト通過

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)