### PR TITLE
fix: increase max_tokens for suggestion LLM requests

### DIFF
--- a/app/services/suggestion_llm_service.rb
+++ b/app/services/suggestion_llm_service.rb
@@ -1,5 +1,6 @@
 class SuggestionLlmService
   MAX_ATTEMPTS = 3
+  MAX_TOKENS = 8192
   TEMPERATURES = [0.7, 0.3, 0.3].freeze
   FINAL_ATTEMPT_PROMPT = <<~PROMPT.squish.freeze
     IMPORTANT: Your response MUST be valid JSON only. No text before or after.
@@ -107,6 +108,7 @@ class SuggestionLlmService
         messages: build_messages(attempt),
         model: entry.llm_model.name,
         temperature: TEMPERATURES[attempt],
+        max_tokens: MAX_TOKENS,
       }.merge(client.json_output_options(**structured_output_options))
     end
 

--- a/test/services/suggestion_llm_service_test.rb
+++ b/test/services/suggestion_llm_service_test.rb
@@ -147,7 +147,7 @@ class SuggestionLlmServiceTest < ActiveSupport::TestCase
     end
   end
 
-  # === Temperature changes across retries ===
+  # === Temperature and max_tokens across retries ===
 
   test "uses decreasing temperature across retries" do
     temperatures = []
@@ -166,6 +166,17 @@ class SuggestionLlmServiceTest < ActiveSupport::TestCase
     assert_equal 0.7, temperatures[0]
     assert_equal 0.3, temperatures[1]
     assert_equal 0.3, temperatures[2]
+  end
+
+  test "passes max_tokens to LLM client" do
+    mock_client = build_mock_client
+    mock_client.expects(:chat).once.with do |args|
+      args[:max_tokens] == 8192
+    end.returns(@valid_response)
+    LlmClientFactory.stubs(:create_client_from_model).returns(mock_client)
+
+    service = SuggestionLlmService.new(entry: @entry, session: @session, variables: @variables)
+    service.call
   end
 
   # === Instrumentation ===


### PR DESCRIPTION
## Summary
- Increase `max_tokens` from default 1000 to 8192 in `SuggestionLlmService`
- Fixes JSON truncation when LLM generates multi-byte language (e.g. Japanese) responses
- Adds test to verify `max_tokens` is passed to LLM client

Closes #246

## Test plan
- [x] Existing suggestion LLM service tests pass (16 runs, 73 assertions)
- [x] New test verifies `max_tokens: 8192` is sent to LLM client
- [x] RuboCop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)