### PR TITLE
chore(db): route system tests to a separate sqlite file

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,9 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
+# Flag system-test runs before Rails' command parser consumes ARGV, so that
+# config/database.yml can route them to a separate SQLite file (keeps `bin/rails
+# test` and `bin/rails test:system` from stepping on each other's DB state).
+ENV["RAILS_SYSTEM_TEST"] = "1" if ARGV.any? { |a| a == "test:system" || a.start_with?("test:system:") }
+
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,8 +9,9 @@ development:
 
 test:
   <<: *default
-  database: storage/test.sqlite3
+  database: storage/<%= ENV["RAILS_SYSTEM_TEST"] == "1" ? "system_test" : "test" %>.sqlite3
 
 production:
   <<: *default
   database: <%= ENV.fetch("DATABASE_PATH", "storage/production.sqlite3") %>
+


### PR DESCRIPTION
## Summary
- `bin/rails test` と `bin/rails test:system` を別のSQLiteファイルに振り分け、ローカルで並行実行してもDB状態がぶつからないようにする
- `config/boot.rb` で Rails のコマンドパーサーがARGVを食う前に `ENV["RAILS_SYSTEM_TEST"]` を立て、`config/database.yml` のERBでそれを読んで `storage/test.sqlite3` / `storage/system_test.sqlite3` を切り替え

## なぜこの作り？
最初はARGV直接検査を `database.yml` に書いたが、Railsの `test:system` コマンドは database.yml 評価時点で ARGV を空にしてしまうため不発だった (`ARGV=[]` を確認済み)。そのため、`config/boot.rb` — bundler/bootsnap より前 — で ARGV を覗いて ENV フラグを立てる形に変更している。

動作確認:
- `bin/rails test test/models/task_test.rb` → `storage/test.sqlite3` を更新、`system_test.sqlite3` 不変 ✅
- `bin/rails test:system test/system/project_flow_test.rb` → `storage/system_test.sqlite3` を新規作成、`test.sqlite3` 不変 ✅
- `maintain_test_schema!` が初回実行時に自動でスキーマをロードするため、手動マイグレーションは不要

## Test plan
- [ ] CI で `bin/rails test` が従来どおり green になる
- [ ] CI で `bin/rails test:system` が従来どおり green になる
- [ ] ローカルで別ターミナル同時実行しても相互干渉しないこと (リリース前に手元で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)