### PR TITLE
docs/chore: correct test:all description and drop dead rake task

### DIFF
--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -54,7 +54,7 @@ ALWAYS update `.progress/issue-XXXXX.md` during work. Update the progress file *
    - → **Done when**: a feature branch derived from the latest `main` is checked out.
 7. **Implement** - Write code and tests. During development, run the domain test suite for the area you are changing (see `docs/conventions/TESTING.md`). Do not run the full test suite at this stage.
    - → **Done when**: the domain test suite for the changed area passes and the implementation matches the plan.
-8. **Testing** - Run the full test suite (`bin/rails test:all`) once to ensure all tests pass. This runs `bin/rails test` followed by `bin/rails test:system`, each in a clean subprocess. The full suite takes 5+ minutes — run it via `Bash` with `run_in_background: true` and wait for the completion notification. Never re-run the suite before the previous run's result is confirmed.
+8. **Testing** - Run the full test suite (`bin/rails test:all`) once to ensure all tests pass. In Rails 8 this is a single-process invocation that runs every file matching `test/**/*_test.rb` (unit and system tests share the same process and database connection). The full suite takes 5+ minutes — run it via `Bash` with `run_in_background: true` and wait for the completion notification. Never re-run the suite before the previous run's result is confirmed.
    - → **Done when**: `bin/rails test:all` exits 0.
 9. **Local Review** - Ask codex (`/codex-review`) for review the changes.
    - → **Done when**: `/codex-review` has responded and no blocker-level issues remain open.

--- a/lib/tasks/test_suites.rake
+++ b/lib/tasks/test_suites.rake
@@ -90,13 +90,4 @@ namespace :test do
       "test/services/model_list_service_test.rb",
     ])
   end
-
-  desc "Run the full test suite: `bin/rails test` followed by `bin/rails test:system`"
-  task all: :environment do
-    # Shell out so each suite runs in its own clean subprocess.
-    # Do NOT chain via Rake::Task#invoke or Runner.run — both share the parent
-    # process state and break controller tests (see the NOTE at the top of this file).
-    sh "bin/rails test"
-    sh "bin/rails test:system"
-  end
 end


### PR DESCRIPTION
## Summary
`bin/rails test:all` の挙動に関する 2 箇所の齟齬をまとめて解消する。

1. **`docs/process/WORKFLOW.md` Step 8 の記述を修正**
   - 旧: 「`bin/rails test` と `bin/rails test:system` を各々 clean subprocess で実行」
   - 新: 「Rails 8 では 1 プロセスで `test/**/*_test.rb` を実行、unit と system は同じプロセス・同じ DB コネクションを共有」
2. **`lib/tasks/test_suites.rake` から dead な `test:all` rake task を削除**

## 背景
PR #280（クローズ済み）でシステムテスト用に別 SQLite を使う仕組みを検討していた際、`bin/rails test:all` の挙動が想定と違うことが判明した：

- `bin/rails test:all` は Thor 経由で `Rails::Command::TestCommand#all`（`railties/lib/rails/commands/test/test_command.rb:44-47`）を呼び、そこが直接 `perform("test/**/*_test.rb", *args)` を実行する
- 該当ファイル冒頭には "Define Thor tasks to avoid going through Rake and booting twice when using bin/rails test:*" と明記されており、`bin/rails test:*` 系は **Rake を経由しない**
- そのため `lib/tasks/test_suites.rake` に定義されていた `task all: :environment do sh "bin/rails test"; sh "bin/rails test:system" end` は **一度も呼ばれない dead code** だった
- 実測でも `bin/rails test:all` のログは `Run options: --seed ...` と `Finished in ...` が 1 セットしか出ず、867 runs を単一プロセスで完走することを確認した

WORKFLOW.md Step 8 はこの存在しない subprocess 挙動を前提に書かれていたため、事実と一致しなくなっていた。該当 rake task も残しておく理由がないので同時に削除する。

なお、他の domain test task（`test:task`, `test:project`, ...）は引き続き有効なので `lib/tasks/test_suites.rake` ファイル自体は残す。冒頭の NOTE コメント（`run_from_rake` vs `run` の理由）も他 task に必要なのでそのまま。

## Test plan
- [ ] `bin/rails test:all` が従来どおり緑であること（CI）
- [ ] `bin/rails -T test` で `test:all` が Thor 側のみから出ることを目視確認（Rake 由来のものが消えていること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)