### PR TITLE
fix(csp): 本番環境でTrixリンク入力ダイアログが常時表示される問題を修正 (#282)

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,8 +9,10 @@ Rails.application.configure do
 
     policy.script_src :self
     # Allow @vite/client to hot reload javascript changes in development
-    policy.script_src(*policy.script_src, :unsafe_eval,
-                      "http://#{ViteRuby.config.host_with_port}") if Rails.env.development?
+    if Rails.env.development?
+      policy.script_src(*policy.script_src, :unsafe_eval,
+                        "http://#{ViteRuby.config.host_with_port}")
+    end
     # Allow blob: for vite-ruby test builds
     policy.script_src(*policy.script_src, :blob) if Rails.env.test?
 
@@ -21,12 +23,14 @@ Rails.application.configure do
     policy.font_src    :self, "https://fonts.gstatic.com"
     policy.img_src     :self, :data
     policy.connect_src :self
-    policy.connect_src(*policy.connect_src,
-                       "ws://#{ViteRuby.config.host_with_port}",
-                       "http://#{ViteRuby.config.host_with_port}") if Rails.env.development?
+    if Rails.env.development?
+      policy.connect_src(*policy.connect_src,
+                         "ws://#{ViteRuby.config.host_with_port}",
+                         "http://#{ViteRuby.config.host_with_port}")
+    end
   end
 
   # Generate nonces for permitted inline scripts and styles.
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
-  config.content_security_policy_nonce_directives = %w[script-src]
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
 end


### PR DESCRIPTION
Closes #282

## Summary

- \`content_security_policy_nonce_directives\` に \`style-src\` を追加し、本番環境でTrixエディタのリンク入力ダイアログが常時表示される問題を解消
- Trix.jsは\`installDefaultCSSForTagName\`でJSランタイムに\`<style>\`要素を\`<head>\`へ挿入し\`[data-trix-dialog] { display: none }\`でダイアログ表示を制御しているが、挿入要素に付くnonceとCSPヘッダの\`style-src\`のnonceが一致しないため本番ではブロックされていた
- dev環境は\`style_src\`に\`:unsafe_inline\`が追加されているため問題が顕在化していなかった
- 同ファイル内の既存 \`Style/MultilineIfModifier\` 違反2件も rubocop autocorrect で修正

## 根本原因

1. Trix.js (\`trix.js:1057-1070\`) は\`<meta name="csp-nonce">\`を読んで挿入する\`<style>\`要素にnonceを貼る実装
2. Rails 側は\`content_security_policy_nonce_directives = %w[script-src]\`だったため、CSPヘッダの\`style-src\`に\`'nonce-xxx'\`が発行されず
3. → ブラウザがnonce付きstyleをCSP違反でブロック → ランタイムCSSが効かず\`display: none\`が適用されない → ダイアログ常時表示

## Test plan

- [x] \`bin/rails test:all\` パス（867 runs, 0 failures, 0 errors）
- [ ] 本番環境で新規タスク作成フォームのdescription入力欄が正常動作する
- [ ] 本番環境でリンクボタン（鎖アイコン）押下時にダイアログが開閉する
- [ ] dev環境で従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)