### PR TITLE
feat(shortcuts): add core keyboard shortcuts for user-side UI

### DIFF
--- a/app/assets/stylesheets/keyboard-shortcuts.css
+++ b/app/assets/stylesheets/keyboard-shortcuts.css
@@ -1,0 +1,66 @@
+.shortcuts-help-modal {
+  max-width: 32rem;
+}
+
+.shortcuts-help-body {
+  padding: var(--space-2) var(--space-3);
+}
+
+.shortcuts-help-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+}
+
+.shortcuts-help-item {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
+  border-bottom: 1px dashed var(--border);
+}
+
+.shortcuts-help-item:last-child {
+  border-bottom: none;
+}
+
+.shortcuts-help-item__key {
+  margin: 0;
+  text-align: left;
+}
+
+.shortcuts-help-item__key kbd {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  font-family: var(--mono-font, ui-monospace, Menlo, monospace);
+  font-size: 0.9rem;
+  color: var(--form-text);
+  background: var(--overlay-hover, #f2f2f2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  box-shadow: 0 1px 0 var(--border);
+  line-height: 1.2;
+}
+
+.shortcuts-help-item__description {
+  margin: 0;
+  color: var(--form-text);
+  font-size: 0.95rem;
+}
+
+.menu-list__shortcuts {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+@media (max-width: 640px) {
+  .shortcuts-help-item {
+    grid-template-columns: 7rem 1fr;
+  }
+}

--- a/app/javascript/controllers/keyboard_shortcuts_controller.js
+++ b/app/javascript/controllers/keyboard_shortcuts_controller.js
@@ -1,0 +1,254 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Global keyboard shortcuts for the user-side Hotwire UI.
+//
+// Attached once to <body> in application.html.erb. Since Turbo morph refreshes
+// preserve the <body> element, the controller's state (g-prefix, listeners)
+// survives page transitions without re-connecting.
+//
+// See docs & plan: Issue #14.
+export default class extends Controller {
+  static targets = ['helpDialog']
+  static values = {
+    inboxId: String
+  }
+
+  connect() {
+    this.gPrefixActive = false
+    this.gPrefixTimer = null
+  }
+
+  disconnect() {
+    this._clearGPrefix()
+  }
+
+  // ---------------- Main dispatcher ----------------
+
+  handleKeydown(e) {
+    // IME composition: never intercept
+    if (this._isComposing(e)) return
+
+    const key = e.key
+
+    // Cmd/Ctrl + Enter — form submit (works inside inputs)
+    if (key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      this._submitForm(e)
+      return
+    }
+
+    // Escape — unified close (works inside inputs)
+    if (key === 'Escape') {
+      this._handleEscape(e)
+      return
+    }
+
+    // All other shortcuts must NOT trigger while typing
+    if (this._isTypingInInput()) return
+
+    // Modifier keys other than Shift disqualify the key as a shortcut
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+
+    // `g` prefix sequence — only consume the key when the prefix is active
+    if (this.gPrefixActive) {
+      this._handleGPrefixFollowup(e, key)
+      return
+    }
+
+    // Single-key shortcuts
+    switch (key) {
+      case '/':
+        if (this._isModalOpen()) return
+        this._focusSearch(e)
+        return
+      case 'n':
+        if (this._isModalOpen()) return
+        this._newTask(e)
+        return
+      case '?':
+        this._openHelp(e)
+        return
+      case 'g':
+        if (this._isModalOpen()) return
+        this._startGPrefix(e)
+        return
+      default:
+        return
+    }
+  }
+
+  // ---------------- Action handlers (exposed via data-action) ----------------
+
+  openHelp(e) {
+    // Called by click on menu item. Prevent default link-like behavior.
+    e?.preventDefault?.()
+    this._showHelpDialog()
+  }
+
+  closeHelp(e) {
+    e?.preventDefault?.()
+    if (this.hasHelpDialogTarget && this.helpDialogTarget.open) {
+      this.helpDialogTarget.close()
+    }
+  }
+
+  onHelpBackdropClick(e) {
+    // Dialog click handler: if the click target is the dialog itself
+    // (i.e. the backdrop area, not any child), close it.
+    if (e.target === this.helpDialogTarget) {
+      this.helpDialogTarget.close()
+    }
+  }
+
+  // ---------------- Internal handlers ----------------
+
+  _focusSearch(e) {
+    const searchEl = document.querySelector('[data-controller~="search"]')
+    if (!searchEl) return
+    const ctrl = this.application.getControllerForElementAndIdentifier(searchEl, 'search')
+    if (!ctrl || typeof ctrl.open !== 'function') return
+    e.preventDefault()
+    ctrl.open()
+  }
+
+  _newTask(e) {
+    const frame = document.getElementById('new_task')
+    if (!frame) return
+    // Skip if the frame already holds a rendered form (multiple children or
+    // non-button elements beyond the default add-task button)
+    if (this._newTaskFrameHasForm(frame)) return
+
+    const projectId = this._currentProjectId() || this.inboxIdValue
+    if (!projectId) return
+
+    e.preventDefault()
+    frame.setAttribute('src', `/tasks/new?project_id=${encodeURIComponent(projectId)}`)
+  }
+
+  _openHelp(e) {
+    // Input/composition guards already applied in handleKeydown before reaching here.
+    if (!this.hasHelpDialogTarget) return
+    if (this.helpDialogTarget.open) return
+    e.preventDefault()
+    this._showHelpDialog()
+  }
+
+  _showHelpDialog() {
+    if (!this.hasHelpDialogTarget) return
+    if (this.helpDialogTarget.open) return
+    this.helpDialogTarget.showModal()
+  }
+
+  _handleEscape(e) {
+    // 1) Clear active g-prefix — swallow the Esc
+    if (this.gPrefixActive) {
+      this._clearGPrefix()
+      e.preventDefault()
+      return
+    }
+
+    // 2) Close the topmost open <dialog>
+    const openDialogs = document.querySelectorAll('dialog[open]')
+    if (openDialogs.length > 0) {
+      const topDialog = openDialogs[openDialogs.length - 1]
+      topDialog.close()
+      e.preventDefault()
+      return
+    }
+
+    // 3) If turbo-frame "modal" is still populated (task detail overlay),
+    //    do not touch background menus.
+    const modalFrame = document.getElementById('modal')
+    if (modalFrame?.hasAttribute('src')) return
+
+    // 4) Close any open popup menus
+    const openMenus = document.querySelectorAll('.menu-navigation:not(.hidden)')
+    if (openMenus.length > 0) {
+      openMenus.forEach(m => m.classList.add('hidden'))
+      e.preventDefault()
+    }
+  }
+
+  _submitForm(e) {
+    // Composition guard already applied in handleKeydown.
+    const target = e.target
+    if (!target) return
+    const isEditable = target.tagName === 'TEXTAREA' ||
+                       target.tagName === 'TRIX-EDITOR' ||
+                       target.isContentEditable
+    if (!isEditable) return
+    const form = target.closest('form')
+    if (!form) return
+    e.preventDefault()
+    form.requestSubmit()
+  }
+
+  _startGPrefix(e) {
+    e.preventDefault()
+    this.gPrefixActive = true
+    if (this.gPrefixTimer) clearTimeout(this.gPrefixTimer)
+    this.gPrefixTimer = setTimeout(() => this._clearGPrefix(), 1000)
+  }
+
+  _handleGPrefixFollowup(e, key) {
+    // Consume any follow-up key: navigate if valid, otherwise just clear
+    this._clearGPrefix()
+    if (key === 'i') {
+      if (!this.inboxIdValue) return
+      e.preventDefault()
+      this._visit(`/projects/${encodeURIComponent(this.inboxIdValue)}`)
+    } else if (key === 'p') {
+      e.preventDefault()
+      this._visit('/')
+    }
+  }
+
+  _clearGPrefix() {
+    this.gPrefixActive = false
+    if (this.gPrefixTimer) {
+      clearTimeout(this.gPrefixTimer)
+      this.gPrefixTimer = null
+    }
+  }
+
+  _visit(path) {
+    if (window.Turbo && typeof window.Turbo.visit === 'function') {
+      window.Turbo.visit(path)
+    } else {
+      window.location.href = path
+    }
+  }
+
+  // ---------------- Predicates ----------------
+
+  _isTypingInInput() {
+    const el = document.activeElement
+    if (!el) return false
+    const tag = el.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'TRIX-EDITOR') {
+      return true
+    }
+    return el.isContentEditable === true
+  }
+
+  _isComposing(e) {
+    return e.isComposing === true || e.keyCode === 229
+  }
+
+  _isModalOpen() {
+    const modalFrame = document.getElementById('modal')
+    if (modalFrame?.hasAttribute('src')) return true
+    return document.querySelector('dialog[open]') !== null
+  }
+
+  _currentProjectId() {
+    const el = document.querySelector('[data-current-project-id]')
+    return el?.dataset.currentProjectId || null
+  }
+
+  _newTaskFrameHasForm(frame) {
+    // Default state: contains a single <form> (the add-task button).
+    // When a new task form is loaded it replaces the button with the
+    // task-form markup which contains a form with a task name input.
+    return frame.querySelector('form.task-form, .task-form') !== null
+  }
+}

--- a/app/javascript/controllers/keyboard_shortcuts_controller.js
+++ b/app/javascript/controllers/keyboard_shortcuts_controller.js
@@ -126,6 +126,13 @@ export default class extends Controller {
 
   _openHelp(e) {
     // Input/composition guards already applied in handleKeydown before reaching here.
+    //
+    // Intentionally asymmetric with `/`, `n`, and `g`: those shortcuts
+    // bail out via `_isModalOpen()` when another dialog is visible, but
+    // `?` must remain reachable at all times (power users rely on the
+    // help list to recover from getting lost inside a stacked modal).
+    // The help `<dialog>` uses top-layer stacking, and Escape closes
+    // each layer in DOM order, so stacking is safe.
     if (!this.hasHelpDialogTarget) return
     if (this.helpDialogTarget.open) return
     e.preventDefault()

--- a/app/javascript/controllers/keyboard_shortcuts_controller.js
+++ b/app/javascript/controllers/keyboard_shortcuts_controller.js
@@ -155,12 +155,10 @@ export default class extends Controller {
       return
     }
 
-    // 3) If turbo-frame "modal" is still populated (task detail overlay),
-    //    do not touch background menus.
-    const modalFrame = document.getElementById('modal')
-    if (modalFrame?.hasAttribute('src')) return
-
-    // 4) Close any open popup menus
+    // 3) Close any open popup menus. No guard on turbo-frame#modal src
+    // attribute: it is not reliably cleared when a task-detail dialog is
+    // dismissed via native Esc, so using it here would leave menus stuck
+    // open for the rest of the session.
     const openMenus = document.querySelectorAll('.menu-navigation:not(.hidden)')
     if (openMenus.length > 0) {
       openMenus.forEach(m => m.classList.add('hidden'))
@@ -235,8 +233,10 @@ export default class extends Controller {
   }
 
   _isModalOpen() {
-    const modalFrame = document.getElementById('modal')
-    if (modalFrame?.hasAttribute('src')) return true
+    // Do not rely on turbo-frame#modal's `src` attribute — it persists after
+    // a task-detail dialog is dismissed via native Esc (turbo_modal_controller
+    // only clears it via click->hideModal). The actually-visible dialog is
+    // the correct signal.
     return document.querySelector('dialog[open]') !== null
   }
 

--- a/app/javascript/controllers/mixins/popupMenu.js
+++ b/app/javascript/controllers/mixins/popupMenu.js
@@ -22,16 +22,11 @@ export const popupMenu = controller => {
       this.menuTarget.classList.add('hidden')
     },
 
-    // hide modal when clicking ESC
-    // action: "keyup@window->turbo-modal#closeWithKeyboard"
-    closeWithKeyboard(e) {
-      if (e.code === 'Escape') {
-        this.hideMenu()
-      }
-    },
-
     // hide modal when clicking outside of modal
     // action: "click@window->turbo-modal#closeBackground"
+    //
+    // Escape-key handling is delegated to the global
+    // `keyboard-shortcuts` controller (see issue #14).
     closeBackground(e) {
       if (e && this.element.contains(e.target)) {
         return

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,9 @@
 
   </head>
 
-  <body>
+  <body data-controller="keyboard-shortcuts"
+        data-action="keydown@window->keyboard-shortcuts#handleKeydown"
+        data-keyboard-shortcuts-inbox-id-value="<%= current_user&.inbox_project&.id %>">
     <%= turbo_frame_tag "notification" %>
     <%= turbo_frame_tag "modal" %>
     <%# TODO: Turboでできたらしたい %>
@@ -39,5 +41,6 @@
     <div id="loader-wrapper"><div id="loader"></div></div>
     <%= hidden_field_tag :uid, current_user&.id %>
     <%= audio_tag "complete.mp3", id: "complete-sound" %>
+    <%= render "shared/keyboard_shortcuts_help" if current_user %>
   </body>
 </html>

--- a/app/views/projects/_header.html.erb
+++ b/app/views/projects/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="project-header">
-  <div class="menu-container project-selector" data-controller="menu" data-action="keyup@window->menu#closeWithKeyboard click@window->menu#closeBackground">
+<header class="project-header" data-current-project-id="<%= @project.id %>">
+  <div class="menu-container project-selector" data-controller="menu" data-action="click@window->menu#closeBackground">
     <%= button_tag type: "button", class: "menu-button", data: { action: "menu#toggleMenu" } do %>
       <h2 class="project-name"><%= @project.display_name %></h2>
       <span class="material-symbols-outlined">expand_more</span>
@@ -54,7 +54,7 @@
 
   <div class="project-header__right">
     <% unless @project.inbox? %>
-      <div class="menu-container menu-container--header project-members" data-controller="project-members" data-action="keyup@window->project-members#closeWithKeyboard click@window->project-members#closeBackground">
+      <div class="menu-container menu-container--header project-members" data-controller="project-members" data-action="click@window->project-members#closeBackground">
         <%= button_tag type: "button", class: "menu-button", data: { action: "project-members#toggleMenu project-members#clear" } do %>
           <span class="material-symbols-outlined">group</span>
         <% end %>
@@ -73,7 +73,7 @@
       </div>
     <% end %>
 
-    <div class="menu-container menu-container--header" data-controller="menu" data-action="keyup@window->menu#closeWithKeyboard click@window->menu#closeBackground">
+    <div class="menu-container menu-container--header" data-controller="menu" data-action="click@window->menu#closeBackground">
       <%= button_tag type: "button", class: "menu-button", data: { action: "menu#toggleMenu" } do %>
         <span class="material-symbols-outlined">menu</span>
       <% end %>
@@ -87,6 +87,12 @@
             <%= link_to user_path, class: "menu-list__setting label-with-icon", data: { turbo_frame: "modal", action: "menu#hideMenu" } do %>
               <span class="material-symbols-outlined">settings</span>
               <%= t("projects.header.setting") %>
+            <% end %>
+          </li>
+          <li>
+            <%= button_tag type: "button", class: "menu-list__shortcuts label-with-icon", data: { action: "click->keyboard-shortcuts#openHelp click->menu#hideMenu" } do %>
+              <span class="material-symbols-outlined">keyboard</span>
+              <%= t("shortcuts.menu_label") %>
             <% end %>
           </li>
           <li>

--- a/app/views/shared/_keyboard_shortcuts_help.html.erb
+++ b/app/views/shared/_keyboard_shortcuts_help.html.erb
@@ -1,0 +1,23 @@
+<dialog class="modal-base shortcuts-help-modal"
+        data-keyboard-shortcuts-target="helpDialog"
+        data-action="click->keyboard-shortcuts#onHelpBackdropClick">
+  <div class="modal-header">
+    <h3 class="modal-header__title"><%= t("shortcuts.help.title") %></h3>
+    <%= button_tag type: "button",
+                   class: "modal-header__close",
+                   aria: { label: t("shortcuts.help.close") },
+                   data: { action: "click->keyboard-shortcuts#closeHelp" } do %>
+      <span class="material-symbols-outlined">close</span>
+    <% end %>
+  </div>
+  <div class="modal-body shortcuts-help-body">
+    <dl class="shortcuts-help-list">
+      <% t("shortcuts.help.items").each_value do |item| %>
+        <div class="shortcuts-help-item">
+          <dt class="shortcuts-help-item__key"><kbd><%= item[:key] %></kbd></dt>
+          <dd class="shortcuts-help-item__description"><%= item[:description] %></dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+</dialog>

--- a/app/views/tasks/_assignees.html.erb
+++ b/app/views/tasks/_assignees.html.erb
@@ -1,7 +1,7 @@
 <div class="menu-container assignee-list <%= task.assignee.present? ? "assigned" : "" %> <%= task.assignee == current_user ? "assigned-to-me" : "" %>"
     data-controller="assignees"
     data-assignees-you-value="<%= t('tasks.assignees.you') %>"
-    data-action="keyup@window->assignees#closeWithKeyboard click@window->assignees#closeBackground">
+    data-action="click@window->assignees#closeBackground">
   <%= button_tag type: "button", class: "menu-button menu-button--assignee", data: { action: "assignees#toggleMenu" } do %>
     <% if task.assignee.present? %>
       <%= user_icon(task.assignee) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,6 +189,33 @@ en:
     completed_tasks_on:
       hide: "Hide completed tasks"
       empty: "There are no completed tasks."
+  shortcuts:
+    menu_label: "Keyboard shortcuts"
+    help:
+      title: "Keyboard shortcuts"
+      close: "Close"
+      items:
+        focus_search:
+          key: "/"
+          description: "Focus the task search box"
+        new_task:
+          key: "n"
+          description: "Create a new task in the current project"
+        open_help:
+          key: "?"
+          description: "Show this shortcut list"
+        close_modal:
+          key: "Esc"
+          description: "Close the open modal or menu"
+        submit_form:
+          key: "⌘/Ctrl + Enter"
+          description: "Submit the current form"
+        go_inbox:
+          key: "g → i"
+          description: "Go to Inbox"
+        go_projects:
+          key: "g → p"
+          description: "Go to project list"
   tasks:
     show:
       comments: "Comments"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,6 +212,33 @@ ja:
     completed_tasks_on:
       hide: "完了したタスクを非表示"
       empty: "完了したタスクはありません。"
+  shortcuts:
+    menu_label: "キーボードショートカット"
+    help:
+      title: "キーボードショートカット"
+      close: "閉じる"
+      items:
+        focus_search:
+          key: "/"
+          description: "タスク検索ボックスにフォーカス"
+        new_task:
+          key: "n"
+          description: "現在のプロジェクトに新規タスクを作成"
+        open_help:
+          key: "?"
+          description: "このショートカット一覧を表示"
+        close_modal:
+          key: "Esc"
+          description: "モーダル／メニューを閉じる"
+        submit_form:
+          key: "⌘/Ctrl + Enter"
+          description: "編集中のフォームを送信"
+        go_inbox:
+          key: "g → i"
+          description: "Inbox に移動"
+        go_projects:
+          key: "g → p"
+          description: "プロジェクト一覧に移動"
   tasks:
     show:
       comments: "コメント"

--- a/test/system/keyboard_shortcuts_test.rb
+++ b/test/system/keyboard_shortcuts_test.rb
@@ -110,6 +110,10 @@ class KeyboardShortcutsTest < ApplicationSystemTestCase
 
   test "hamburger menu shortcut link opens the help modal" do
     find(".menu-container--header:not(.project-members) .menu-button").click
+    # Explicitly wait for the menu to open before looking for the child
+    # link — headless Chrome on CI can otherwise race the toggle and fail
+    # the `visible` check on `.menu-list__shortcuts`.
+    assert_selector ".menu-container--header:not(.project-members) .menu-navigation:not(.hidden)"
     find(".menu-list__shortcuts").click
     assert_selector "dialog.shortcuts-help-modal[open]"
   end

--- a/test/system/keyboard_shortcuts_test.rb
+++ b/test/system/keyboard_shortcuts_test.rb
@@ -114,6 +114,45 @@ class KeyboardShortcutsTest < ApplicationSystemTestCase
     assert_selector "dialog.shortcuts-help-modal[open]"
   end
 
+  test "slash still works after a task detail modal is closed via escape" do
+    # Regression for PR #285 review: turbo_modal_controller only clears the
+    # `#modal` frame's `src` attribute on click->hideModal, not on native
+    # Esc dialog close. Relying on `src` for modal-open detection leaves
+    # `/`, `n`, `g` shortcuts permanently disabled after one Esc-close.
+    open_project_menu
+    click_link "Test Project Two"
+    assert_selector ".project-name", text: "Test Project Two"
+    click_link "Test Task Two"
+    assert_selector "dialog.modal-base[open]", text: "Test Task Two"
+
+    dispatch_key("Escape")
+    assert_no_selector "dialog.modal-base[open]"
+    wait_for_keyboard_shortcuts_ready
+
+    dispatch_key("/")
+    assert_selector "dialog.search-modal[open]"
+  end
+
+  test "escape still closes popup menus after a task modal was closed via escape" do
+    # Regression for PR #285 review: the old `_handleEscape` guard used
+    # `#modal[src]`, which persists across native Esc dismissals and
+    # prevented popup menus from closing for the rest of the session.
+    open_project_menu
+    click_link "Test Project Two"
+    assert_selector ".project-name", text: "Test Project Two"
+    click_link "Test Task Two"
+    assert_selector "dialog.modal-base[open]", text: "Test Task Two"
+
+    dispatch_key("Escape")
+    assert_no_selector "dialog.modal-base[open]"
+    wait_for_keyboard_shortcuts_ready
+
+    find(".menu-container--header:not(.project-members) .menu-button").click
+    assert_selector ".menu-container--header:not(.project-members) .menu-navigation:not(.hidden)"
+    dispatch_key("Escape")
+    assert_no_selector ".menu-container--header:not(.project-members) .menu-navigation:not(.hidden)"
+  end
+
   private
 
     # Dispatches a synthetic keydown event directly on window so that the

--- a/test/system/keyboard_shortcuts_test.rb
+++ b/test/system/keyboard_shortcuts_test.rb
@@ -1,0 +1,151 @@
+require "application_system_test_case"
+
+class KeyboardShortcutsTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:regular_user)
+    sign_in_as(@user)
+    # Ensure the landing page is fully rendered (header + search controller
+    # inside it) before firing synthetic keydown events.
+    assert_selector ".project-header"
+    assert_selector ".search-container[data-controller='search']", visible: :all
+    wait_for_keyboard_shortcuts_ready
+  end
+
+  test "slash focuses the search box" do
+    dispatch_key("/")
+    assert_selector "dialog.search-modal[open]"
+    assert_selector ".search-form__input:focus"
+  end
+
+  test "n opens the new task form in the current project" do
+    dispatch_key("n")
+    assert_selector "turbo-frame#new_task .task-form"
+    assert_selector ".task-form__name--input"
+  end
+
+  test "question mark opens the shortcuts help modal" do
+    dispatch_key("?", shift: true)
+    assert_selector "dialog.shortcuts-help-modal[open]"
+    assert_selector ".shortcuts-help-list"
+  end
+
+  test "escape closes the shortcuts help modal" do
+    dispatch_key("?", shift: true)
+    assert_selector "dialog.shortcuts-help-modal[open]"
+    dispatch_key("Escape")
+    assert_no_selector "dialog.shortcuts-help-modal[open]"
+  end
+
+  test "escape closes the hamburger menu" do
+    # Regression: popup menus used to register their own keyup handler; the
+    # global keyboard-shortcuts controller now owns that responsibility.
+    find(".menu-container--header:not(.project-members) .menu-button").click
+    assert_selector ".menu-container--header:not(.project-members) .menu-navigation:not(.hidden)"
+    dispatch_key("Escape")
+    assert_no_selector ".menu-container--header:not(.project-members) .menu-navigation:not(.hidden)"
+  end
+
+  test "g then i navigates to the inbox" do
+    open_project_menu
+    click_link "Test Project Two"
+    assert_selector ".project-name", text: "Test Project Two"
+    wait_for_keyboard_shortcuts_ready
+
+    dispatch_key("g")
+    dispatch_key("i")
+
+    inbox = @user.inbox_project
+    assert_current_path project_path(inbox)
+  end
+
+  test "g then p navigates to the project list root" do
+    open_project_menu
+    click_link "Test Project Two"
+    assert_selector ".project-name", text: "Test Project Two"
+    wait_for_keyboard_shortcuts_ready
+
+    dispatch_key("g")
+    dispatch_key("p")
+
+    # Root `/` redirects to the user's inbox project, so verify we land on
+    # the inbox page.
+    inbox = @user.inbox_project
+    assert_current_path project_path(inbox)
+  end
+
+  test "n is disabled while typing inside an input" do
+    click_button I18n.t("tasks.add_task_btn.add_task")
+    name_field = find(".task-form__name--input")
+    name_field.click
+    name_field.send_keys "x"
+    name_field.send_keys "n"
+
+    # The `n` should have been typed into the input rather than triggering
+    # a new-task shortcut (which would have replaced the frame contents).
+    assert_equal "xn", find(".task-form__name--input").value
+  end
+
+  test "escape clears an active g-prefix without navigating" do
+    open_project_menu
+    click_link "Test Project Two"
+    assert_selector ".project-name", text: "Test Project Two"
+    wait_for_keyboard_shortcuts_ready
+
+    dispatch_key("g")
+    dispatch_key("Escape")
+    # After Esc the g-prefix is cleared, so pressing `i` alone is a no-op.
+    dispatch_key("i")
+
+    # We should still be on Test Project Two.
+    assert_selector ".project-name", text: "Test Project Two"
+  end
+
+  test "help modal cannot be stacked" do
+    dispatch_key("?", shift: true)
+    assert_selector "dialog.shortcuts-help-modal[open]"
+    # Second `?` should be a no-op; the dialog count stays at 1.
+    dispatch_key("?", shift: true)
+    assert_selector "dialog.shortcuts-help-modal[open]", count: 1
+  end
+
+  test "hamburger menu shortcut link opens the help modal" do
+    find(".menu-container--header:not(.project-members) .menu-button").click
+    find(".menu-list__shortcuts").click
+    assert_selector "dialog.shortcuts-help-modal[open]"
+  end
+
+  private
+
+    # Dispatches a synthetic keydown event directly on window so that the
+    # keyboard-shortcuts controller receives it regardless of which element
+    # currently has browser focus. Ruby-side string interpolation (with
+    # `to_json` for safety) avoids Capybara/Selenium's `arguments[]`
+    # passing quirks inside IIFE-wrapped scripts.
+    def dispatch_key(key, shift: false, meta: false, ctrl: false)
+      script = +"window.dispatchEvent(new KeyboardEvent('keydown', {"
+      script << "key: #{key.to_json},"
+      script << "shiftKey: #{shift},"
+      script << "metaKey: #{meta},"
+      script << "ctrlKey: #{ctrl},"
+      script << "bubbles: true, cancelable: true"
+      script << "}));"
+      page.execute_script(script)
+    end
+
+    def wait_for_keyboard_shortcuts_ready
+      page.evaluate_async_script(<<~JS)
+        var done = arguments[0];
+        var timerId = setTimeout(function() { done(false); }, 5000);
+        var check = function() {
+          if (window.Stimulus &&
+              window.Stimulus.getControllerForElementAndIdentifier(document.body, "keyboard-shortcuts")) {
+            clearTimeout(timerId);
+            done(true);
+          } else {
+            requestAnimationFrame(check);
+          }
+        };
+        check();
+      JS
+    end
+end


### PR DESCRIPTION
## Summary
- user 側 Hotwire 画面に6つのキーボードショートカットを導入 (`/` 検索、`n` 新規タスク、`?` ヘルプ、`Esc` モーダル閉じ、`Cmd/Ctrl+Enter` 送信、`g→i`/`g→p` 画面遷移)
- 新規グローバル Stimulus controller `keyboard-shortcuts` を `<body>` に設置し、IME・入力中・composition ガード、`g` プレフィックス状態機械を実装
- 既存 `popupMenu.js` の Esc 処理をグローバル controller 側へ統一（重複 `keyup@window` data-action を3箇所削除）
- ハンバーガーメニューに「キーボードショートカット」リンクを追加し、`?` キー未知のユーザーにも導線を提供

## Closes
- Closes #14
- コマンドパレット機能 (`Cmd+K`) は follow-up #284 に分離済み（スコープ外）

## Scope
- **In**: user 側（Hotwire）のみ
- **Out**: admin SPA (React)、`j/k/x/e` 等の選択系ショートカット、ユーザーごとのカスタマイズ、コマンドパレット

## Test plan
- [x] `bin/rails test test/system/keyboard_shortcuts_test.rb` — 11 runs, 42 assertions, 0 failures
- [x] `bin/rails test test/system/project_flow_test.rb test/system/task_flow_test.rb` — 既存退行なし
- [x] `bin/rails test:all` — 878 runs, 2087 assertions, 0 failures, 0 errors, 2 skips（skip 2件は既存）
- [x] Codex review (`/codex-review`) — P2 指摘1件は false positive と判定（DOM 構造上到達不可）、Nit 3件を反映済み
- [ ] **手動検証が必要**: macOS 日本語 IME 変換中に `n`/`g` を含む文字を打っても誤作動しないこと
- [ ] **手動検証が必要**: macOS Chrome/Safari および Windows Chrome での動作確認

## Design notes
- `keyboard-shortcuts` controller は `<body>` に載るため Turbo morph refresh で再マウントされず、状態（`g` プレフィックス、リスナー）が温存される
- ヘルプモーダルは静的な `<dialog>` を `application.html.erb` 末尾で常時レンダリング、Stimulus target で `showModal()` 制御
- `n` の新規タスク作成は `#new_task` turbo-frame の `src` 書き換えで既存の add-task ボタン挙動を再現（`Turbo.visit` ではなくフレーム単位ロード）
- `g p` の遷移先 `/` は現状 `projects#index` で `redirect_to_inbox` するため実質 `g i` と同じ終点になる。将来プロジェクト一覧ページが実装されれば自然に「生きる」設計

## Files
- 新規 (4): `keyboard_shortcuts_controller.js`, `_keyboard_shortcuts_help.html.erb`, `keyboard-shortcuts.css`, `keyboard_shortcuts_test.rb`
- 変更 (6): `application.html.erb`, `projects/_header.html.erb`, `tasks/_assignees.html.erb`, `popupMenu.js`, `ja.yml`, `en.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)