### PR TITLE
feat(admin): add URL-synced event log filters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,25 @@ permissions:
   contents: read
 
 jobs:
+  vitest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run vitest
+        run: npm test
+
   test:
     runs-on: ubuntu-latest
 

--- a/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { navSections } from '../../components/AdminLayout'
-import { AdminLayout } from '../../components/AdminLayout'
+import { AdminLayout, navSections } from '../../components/AdminLayout'
 
 // Mock useAuth
 const mockCan = vi.fn()
@@ -22,9 +21,9 @@ describe('navSections', () => {
     ])
   })
 
-  it('NAVIGATION contains Dashboard and Users', () => {
+  it('NAVIGATION contains Dashboard, Event Logs, and Users', () => {
     const nav = navSections.find((s) => s.label === 'NAVIGATION')!
-    expect(nav.items.map((i) => i.label)).toEqual(['Dashboard', 'Users'])
+    expect(nav.items.map((i) => i.label)).toEqual(['Dashboard', 'Event Logs', 'Users'])
   })
 
   it('ADMIN contains Admin Accounts, Roles, and Permissions', () => {

--- a/app/javascript/admin/pages/events/EventsIndexPage.tsx
+++ b/app/javascript/admin/pages/events/EventsIndexPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { eventsApi, type EventLog, type EventLogMeta, type EventLogListParams } from '../../lib/api'
 
 const EVENT_BADGE_COLORS: Record<string, { bg: string; text: string; ring: string }> = {
@@ -23,12 +24,59 @@ const EVENT_NAMES = [
   'comment_posted', 'project_created', 'assignee_changed', 'due_date_changed',
 ]
 
+// Fall back to email, then ID, when a user has no name set.
+// (The TypeScript type says `name: string` but the DB allows empty.)
+const displayUserName = (user: { id: number; name: string; email: string }): string =>
+  user.name?.trim() || user.email || `User #${user.id}`
+
+const FilterChip = ({ label, onClear }: { label: string; onClear: () => void }) => (
+  <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-600">
+    {label}
+    <button
+      type="button"
+      onClick={onClear}
+      aria-label={`Clear ${label} filter`}
+      className="rounded text-slate-400 transition hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-indigo-500"
+    >
+      ✕
+    </button>
+  </span>
+)
+
 export const EventsIndexPage = () => {
   const [events, setEvents] = useState<EventLog[]>([])
   const [meta, setMeta] = useState<EventLogMeta>({ page: 1, per_page: 25, total_count: 0, total_pages: 0 })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [filters, setFilters] = useState<EventLogListParams>({ page: 1 })
+
+  const [searchParams, setSearchParams] = useSearchParams()
+  const searchParamsKey = searchParams.toString()
+
+  // Label caches populated at click time. They survive the brief window after
+  // `setSearchParams` fires but before the new fetch completes — without them,
+  // the chip would flash to "Loading…" every time the user clicks a different
+  // row (because the old `events` no longer contain the new filter's id).
+  // The cache is keyed by id and persists for the component's lifetime; it is
+  // NOT used on shared-URL first paint (no click ever happened), where the
+  // `events`-derived fallback still applies.
+  const userLabelCacheRef = useRef<Map<number, string>>(new Map())
+  const projectLabelCacheRef = useRef<Map<number, string>>(new Map())
+
+  const filters = useMemo<EventLogListParams>(() => {
+    const params = new URLSearchParams(searchParamsKey)
+    return {
+      page: Number(params.get('page')) || 1,
+      user_id: Number(params.get('user_id')) || undefined,
+      project_id: Number(params.get('project_id')) || undefined,
+      event_name: params.get('event_name') || undefined,
+      from: params.get('from') || undefined,
+      to: params.get('to') || undefined,
+    }
+  }, [searchParamsKey])
+
+  const hasAnyFilter = Boolean(
+    filters.event_name || filters.from || filters.to || filters.user_id || filters.project_id
+  )
 
   const fetchEvents = useCallback(async (params: EventLogListParams, signal?: AbortSignal) => {
     setLoading(true)
@@ -51,9 +99,94 @@ export const EventsIndexPage = () => {
     return () => controller.abort()
   }, [filters, fetchEvents])
 
-  const updateFilter = (key: keyof EventLogListParams, value: string) => {
-    setFilters(prev => ({ ...prev, [key]: value || undefined, page: 1 }))
+  const setFilterParam = (key: string, value: string | undefined) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (!value) next.delete(key)
+      else next.set(key, value)
+      next.delete('page') // reset to page 1 on any filter change
+      return next
+    }, { replace: false })
   }
+
+  const updateFilter = (key: keyof EventLogListParams, value: string) => {
+    setFilterParam(key, value || undefined)
+  }
+
+  const applyUserFilter = (user: { id: number; name: string; email: string }) => {
+    if (filters.user_id === user.id) return
+    // Cache the label before updating the URL so the chip renders the real
+    // name on the very next render, avoiding the "Loading…" flicker.
+    userLabelCacheRef.current.set(user.id, displayUserName(user))
+    setFilterParam('user_id', String(user.id))
+  }
+
+  const applyProjectFilter = (project: { id: number; name: string }) => {
+    if (filters.project_id === project.id) return
+    projectLabelCacheRef.current.set(project.id, project.name)
+    setFilterParam('project_id', String(project.id))
+  }
+
+  const clearUserFilter = () => setFilterParam('user_id', undefined)
+  const clearProjectFilter = () => setFilterParam('project_id', undefined)
+
+  const clearAllFilters = () => {
+    setSearchParams(new URLSearchParams(), { replace: false })
+  }
+
+  const setPage = (nextPage: number, options?: { replace?: boolean }) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (nextPage <= 1) next.delete('page')
+      else next.set('page', String(nextPage))
+      return next
+    }, { replace: options?.replace ?? false })
+  }
+
+  // Clamp an out-of-range `page` param that arrives via a shared/bookmarked URL
+  // (e.g. `/admin/events?page=999`, or a URL whose filter later narrowed the
+  // result set below the stored page number). Without this, the view gets
+  // stuck on an empty table with broken pagination even though earlier pages
+  // have data. Uses `replace: true` to scrub the bad URL from history.
+  useEffect(() => {
+    if (meta.total_pages > 0 && filters.page > meta.total_pages) {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        if (meta.total_pages <= 1) next.delete('page')
+        else next.set('page', String(meta.total_pages))
+        return next
+      }, { replace: true })
+    }
+  }, [meta.total_pages, filters.page, setSearchParams])
+
+  const resolveUserLabel = (): string | undefined => {
+    if (!filters.user_id) return undefined
+    // 1. Click cache — populated when the user clicked a row. Survives the
+    //    brief window where the new URL has been committed but the new events
+    //    haven't arrived yet.
+    const cached = userLabelCacheRef.current.get(filters.user_id)
+    if (cached) return cached
+    // 2. Derive from the currently-loaded events (handles shared-URL paste
+    //    after the first fetch completes).
+    const match = events.find(e => e.user.id === filters.user_id)
+    if (match) return displayUserName(match.user)
+    // 3. Fallbacks for first paint / empty result set.
+    if (loading) return 'Loading…'
+    return `User #${filters.user_id}`
+  }
+
+  const resolveProjectLabel = (): string | undefined => {
+    if (!filters.project_id) return undefined
+    const cached = projectLabelCacheRef.current.get(filters.project_id)
+    if (cached) return cached
+    const match = events.find(e => e.project?.id === filters.project_id)
+    if (match?.project) return match.project.name
+    if (loading) return 'Loading…'
+    return `Project #${filters.project_id}`
+  }
+
+  const userLabel = resolveUserLabel()
+  const projectLabel = resolveProjectLabel()
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr)
@@ -123,7 +256,29 @@ export const EventsIndexPage = () => {
             onChange={e => updateFilter('to', e.target.value)}
           />
         </div>
+        {hasAnyFilter && (
+          <button
+            type="button"
+            onClick={clearAllFilters}
+            className="ml-auto self-end rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+          >
+            Clear all filters
+          </button>
+        )}
       </div>
+
+      {/* Active row-click filters */}
+      {(userLabel || projectLabel) && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-slate-500">Active filters:</span>
+          {userLabel && (
+            <FilterChip label={`User: ${userLabel}`} onClear={clearUserFilter} />
+          )}
+          {projectLabel && (
+            <FilterChip label={`Project: ${projectLabel}`} onClear={clearProjectFilter} />
+          )}
+        </div>
+      )}
 
       {/* Error */}
       {error && (
@@ -157,20 +312,12 @@ export const EventsIndexPage = () => {
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-50">
-            {loading ? (
-              <tr>
-                <td colSpan={6} className="px-5 py-8 text-center text-sm text-slate-400">
-                  Loading...
-                </td>
-              </tr>
-            ) : events.length === 0 ? (
-              <tr>
-                <td colSpan={6} className="px-5 py-8 text-center text-sm text-slate-400">
-                  No events found
-                </td>
-              </tr>
-            ) : (
+          <tbody
+            className={`divide-y divide-slate-50 transition-opacity duration-150 ${
+              loading && events.length > 0 ? 'opacity-60' : 'opacity-100'
+            }`}
+          >
+            {events.length > 0 ? (
               events.map(event => (
                 <tr key={event.id} className="transition-colors hover:bg-slate-50/50">
                   <td className="px-5 py-3.5 text-xs text-slate-500">
@@ -180,11 +327,29 @@ export const EventsIndexPage = () => {
                     {getBadge(event.event_name)}
                   </td>
                   <td className="px-5 py-3.5">
-                    <div className="text-sm font-medium text-slate-700">{event.user.name}</div>
-                    <div className="text-xs text-slate-400">{event.user.email}</div>
+                    <button
+                      type="button"
+                      onClick={() => applyUserFilter(event.user)}
+                      aria-label={`Filter by user ${displayUserName(event.user)}`}
+                      className="cursor-pointer rounded text-left underline-offset-2 transition hover:text-indigo-600 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                    >
+                      <div className="text-sm font-medium text-slate-700">{event.user.name}</div>
+                      <div className="text-xs text-slate-400">{event.user.email}</div>
+                    </button>
                   </td>
                   <td className="px-5 py-3.5 text-sm text-slate-600">
-                    {event.project?.name ?? '—'}
+                    {event.project ? (
+                      <button
+                        type="button"
+                        onClick={() => applyProjectFilter(event.project!)}
+                        aria-label={`Filter by project ${event.project.name}`}
+                        className="cursor-pointer rounded text-left underline-offset-2 transition hover:text-indigo-600 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                      >
+                        {event.project.name}
+                      </button>
+                    ) : (
+                      '—'
+                    )}
                   </td>
                   <td className="px-5 py-3.5 text-sm text-slate-600">
                     {event.task?.name ?? '—'}
@@ -196,6 +361,31 @@ export const EventsIndexPage = () => {
                   </td>
                 </tr>
               ))
+            ) : loading ? (
+              <tr>
+                <td colSpan={6} className="px-5 py-8 text-center text-sm text-slate-400">
+                  Loading...
+                </td>
+              </tr>
+            ) : (
+              <tr>
+                <td colSpan={6} className="px-5 py-8 text-center text-sm text-slate-400">
+                  {hasAnyFilter ? (
+                    <div className="space-y-2">
+                      <p>No events match the active filters.</p>
+                      <button
+                        type="button"
+                        onClick={clearAllFilters}
+                        className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+                      >
+                        Clear all filters
+                      </button>
+                    </div>
+                  ) : (
+                    'No events found'
+                  )}
+                </td>
+              </tr>
             )}
           </tbody>
         </table>
@@ -211,7 +401,7 @@ export const EventsIndexPage = () => {
             <button
               className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
               disabled={meta.page <= 1}
-              onClick={() => setFilters(prev => ({ ...prev, page: (prev.page ?? 1) - 1 }))}
+              onClick={() => setPage(meta.page - 1)}
             >
               Previous
             </button>
@@ -221,7 +411,7 @@ export const EventsIndexPage = () => {
             <button
               className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
               disabled={meta.page >= meta.total_pages}
-              onClick={() => setFilters(prev => ({ ...prev, page: (prev.page ?? 1) + 1 }))}
+              onClick={() => setPage(meta.page + 1)}
             >
               Next
             </button>

--- a/app/javascript/admin/pages/events/EventsIndexPage.tsx
+++ b/app/javascript/admin/pages/events/EventsIndexPage.tsx
@@ -65,7 +65,7 @@ export const EventsIndexPage = () => {
   const filters = useMemo<EventLogListParams>(() => {
     const params = new URLSearchParams(searchParamsKey)
     return {
-      page: Number(params.get('page')) || 1,
+      page: Math.max(1, Number(params.get('page')) || 1),
       user_id: Number(params.get('user_id')) || undefined,
       project_id: Number(params.get('project_id')) || undefined,
       event_name: params.get('event_name') || undefined,
@@ -333,8 +333,10 @@ export const EventsIndexPage = () => {
                       aria-label={`Filter by user ${displayUserName(event.user)}`}
                       className="cursor-pointer rounded text-left underline-offset-2 transition hover:text-indigo-600 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
                     >
-                      <div className="text-sm font-medium text-slate-700">{event.user.name}</div>
-                      <div className="text-xs text-slate-400">{event.user.email}</div>
+                      <div className="text-sm font-medium text-slate-700">{displayUserName(event.user)}</div>
+                      {event.user.name?.trim() && (
+                        <div className="text-xs text-slate-400">{event.user.email}</div>
+                      )}
                     </button>
                   </td>
                   <td className="px-5 py-3.5 text-sm text-slate-600">

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,5 +10,8 @@ Capybara.automatic_label_click = true
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include SystemTestHelpers
 
-  driven_by :selenium, using: (ENV["CI"] ? :headless_chrome : :chrome), screen_size: [1400, 1400]
+  # Default to headless so system tests don't steal focus. Set HEADED=1 locally
+  # to see the browser (e.g. for debugging); CI always runs headless.
+  headed = ENV["HEADED"] == "1" && ENV["CI"].blank?
+  driven_by :selenium, using: (headed ? :chrome : :headless_chrome), screen_size: [1400, 1400]
 end


### PR DESCRIPTION
## Summary

Closes #273. Adds click-to-filter UX to the Admin Event Log page with full URL sync and polished loading transitions.

- **Click-to-filter from rows**: clicking a user/project cell applies that entity as a filter; active chips above the table show what's applied, with ✕ to clear.
- **URL as source of truth**: `useSearchParams` drives all filters (`user_id`, `project_id`, `event_name`, `from`, `to`, `page`). Shareable/bookmarkable URLs, browser back/forward traverses filter history.
- **Flicker-free transitions**: `useRef` click cache eliminates the chip "Loading…" flash on filter change; stale-while-revalidate table keeps previous rows visible (dimmed) during refetch instead of blanking the table.
- **"Clear all filters" button** (top-row + empty-state) resets everything in one click.
- **Out-of-range page auto-clamp** for stale/bookmarked URLs (`?page=999`).

### Drive-by fixes
- `AdminLayout.test.tsx`: pre-existing stale `navSections` assertion + duplicate imports from PR #10 (`bb5b8af`). Surfaced because this PR actually runs `npm test` locally.
- `.github/workflows/test.yml`: adds a **vitest CI job** so frontend unit tests are enforced going forward. Closes the gap that let the above stale assertion slip through.
- `test/application_system_test_case.rb`: defaults system tests to headless locally (opt into headed via `HEADED=1`) to reduce focus-stealing flakes.

### Deliberately out of scope
- Numeric ID inputs / searchable autocomplete — declined during planning in favor of click-to-filter only.
- Admin timezone policy for `from`/`to` parsing — tracked separately as #286 (discovered while implementing this PR; requires a standalone policy decision).

## Test plan

- [ ] `npm test` passes (vitest, frontend unit suite)
- [ ] `bin/rails test:all` passes (full Rails suite)
- [ ] Click a user name in a row → URL updates to `?user_id=N`, chip appears, event list filters
- [ ] Click a project name → URL gains `&project_id=N`, project chip appears
- [ ] Click `—` on a row without a project → no-op
- [ ] Click same row twice → only one fetch, no duplicate history entry
- [ ] Click user A, then user B → chip replaces (not stacks), history walks A→B on Back
- [ ] ✕ on a chip clears that filter only, other chips stay
- [ ] "Clear all filters" resets every filter including `event_name`/`from`/`to`, hides the button
- [ ] Share URL `/admin/events?user_id=N&event_name=task_created` → chip shows `Loading…` briefly, then the real user name; event list matches
- [ ] URL with out-of-range page (`?page=999`) auto-clamps to last page without pushing a bad history entry
- [ ] Pagination Next/Prev preserves filter params; `page` removed from URL on page 1
- [ ] Empty result state shows "Clear all filters" button only when a filter is active
- [ ] Stale-while-revalidate: filter change does not blank the table; previous rows stay visible dimmed until new data arrives
- [ ] Accessibility: clickable cells receive focus-visible ring on Tab; `aria-label` falls back to email / `User #id` for nameless users
- [ ] Browser back/forward walks filter history correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)