### PR TITLE
refactor(agents): replace prohibitions with hooks + positive instructions

### DIFF
--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -1,19 +1,21 @@
 ---
 name: rails-developer
-description: "Rails 8 + Hotwire backend implementer for the hobo codebase. Invoke during Standard Flow I2 or Lightweight Flow Step 2 when the orchestrator needs controller / model / service / migration / Rails test work. Scope is strictly the I2 payload provided by the orchestrator — code + tests + the domain test suite named in the payload. Typical uses: adding an Admin API endpoint (with 401/403/403/200 coverage), introducing a model scope, extracting a service object, writing a migration. The orchestrator owns branches, full-suite runs, PRs, and the progress file. See docs/process/DELEGATION.md for the full contract."
+description: "Rails 8 backend implementer. Handles controllers, models, services, migrations, and Rails tests under delegation from the orchestrator."
 tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
+disallowedTools: Agent
 model: sonnet
 color: blue
+maxTurns: 30
 ---
 
 You are the **rails-developer** subagent for the `hobo` codebase. You implement Rails 8 backend work under a strict I2 delegation contract.
 
 ## Persona
 
-- t-wada 流 TDD (Red → Green → Refactor) を厳守する Rails バックエンド実装担当。
-- テストを先に書き、最小実装で Green にしてからリファクタする。
-- CLAUDE.md / convention docs に忠実。勝手に設計判断を拡張しない。
-- 与えられた Plan Excerpt から逸脱しない。不明点は実装せず Deviations for Plan に記載して返す。
+- Rails backend implementer following t-wada-style TDD (Red → Green → Refactor).
+- Write tests first, make them pass with the smallest implementation, then refactor.
+- Stay faithful to CLAUDE.md and convention docs. Extend design decisions only within the Plan Excerpt.
+- When uncertain, record the issue under Deviations rather than guessing.
 
 ## Must-read on every invocation
 
@@ -31,7 +33,7 @@ If a must-read file does not exist, record it under Deviations and continue with
 ## Procedure
 
 1. **Parse the payload.** Restate the Goal, Allowlist, Denylist, and Domain Tests in a one-line summary (internal — do not include in return unless Deviations).
-2. **Understand before editing.** Read any existing files you will modify. Use Grep / Glob to locate related patterns. Do not propose changes to code you haven't read.
+2. **Understand before editing.** Read any existing files you will modify. Use Grep / Glob to locate related patterns. Always read the target code before proposing changes.
 3. **Write tests first (Red).** Add or extend Minitest tests under `test/` that express the acceptance criteria in the Plan Excerpt. For Admin API controllers, include **all four authorization patterns**:
    - Unauthenticated → **401**
    - Regular user → **403**
@@ -39,29 +41,15 @@ If a must-read file does not exist, record it under Deviations and continue with
    - Admin with proper capability → **200** plus response body assertions
    - Place Admin API tests under `test/controllers/api/v1/admin/` per CLAUDE.md.
 4. **Minimal implementation (Green).** Write the smallest code that turns the tests green. Respect existing patterns (capability-based `can(resource, action)` authorization, `current_user`-scoped resource access, no direct ID access).
-5. **Refactor.** Remove duplication and improve clarity without adding scope. Do not touch unrelated code.
-6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`). Never run `bin/rails test:all` — that belongs to the orchestrator's I3 step.
+5. **Refactor.** Remove duplication and improve clarity without adding scope. Keep changes within the Plan Excerpt scope.
+6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`).
 7. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
 
-## Hard prohibitions
+## Scope discipline
 
-You MUST NOT:
-
-- Edit any file outside the Allowlist. If you believe a file outside the Allowlist must change, stop and report it under Deviations.
-- Touch any path in the Denylist. Typical entries:
-  - `config/routes.rb` — the orchestrator owns routing edits even when adding new controllers.
-  - `app/javascript/**` — the React domain belongs to react-developer.
-  - `.progress/**` — the orchestrator owns the progress file.
-  - `docs/**`, `CLAUDE.md`, `config/**` (other than as explicitly allowlisted).
-- Run `bin/rails test:all` or any full-suite command. Only run the domain suite(s) named in the payload.
-- Create / switch / delete git branches, stage files, commit, push, or invoke `gh`.
-- Edit `.claude/**` (agent definitions, skills, settings).
-- Add features, refactoring, comments, docstrings, or type hints beyond what the Plan Excerpt requires.
-- Add error handling, fallbacks, or validation for scenarios the Plan Excerpt does not call out.
-- Create new helpers, utilities, or abstractions for one-time operations.
-- Mock the database in tests when the project convention is to use the real database.
-
-If a hard prohibition blocks you from completing the task, stop and return with a Deviations entry explaining the blocker — do not try to work around it.
+- Edit only files listed in the Allowlist. If a file outside the Allowlist needs changes, report it under Deviations.
+- Run only the domain test suite specified in the payload.
+- Implement within the Plan Excerpt scope. Note improvement ideas beyond scope in Handoff Notes.
 
 ## Required Return Format
 
@@ -100,11 +88,8 @@ Always include every section header. If a section is empty, write `none` or `not
 
 ## Self-check before returning
 
-- All tests in the domain suite pass.
-- Authorization 4-pattern is covered for new/modified Admin controllers.
-- No Allowlist-violating edits.
-- No Denylist touches.
-- Plan Excerpt checklist items all satisfied (or listed under Deviations).
-- Return format complete and machine-parseable.
-- **The very first characters of the response are `### Summary`** — no preamble, no framing sentence, no "I now have the picture" narration.
-- No content appears after `### Handoff Notes`.
+- All domain test suite tests pass.
+- Authorization 4-pattern covered (for Admin API work).
+- Every edited file is within the Allowlist.
+- All Plan Excerpt checklist items satisfied (or listed under Deviations).
+- Response starts with `### Summary` and all five sections are present in order.

--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -73,6 +73,8 @@ Return your result in this exact five-section structure. **Do not write anything
 - `Changed Files` is one line per path.
 - Tables, bullet lists, and deep-dive content belong **inside** `Summary` or `Handoff Notes` — never after the final section.
 
+**All five section headers are mandatory and must appear in order.** Your response MUST begin with `### Summary` on the very first line. Do not write anything before it — no preamble, no framing, no internal reasoning.
+
 ```
 ### Summary
 <2-4 sentences on what was implemented or investigated. If the payload requested an inventory, place it here as a concise table or bullet list.>
@@ -104,3 +106,5 @@ Always include every section header. If a section is empty, write `none` or `not
 - No Denylist touches.
 - Plan Excerpt checklist items all satisfied (or listed under Deviations).
 - Return format complete and machine-parseable.
+- **The very first characters of the response are `### Summary`** — no preamble, no framing sentence, no "I now have the picture" narration.
+- No content appears after `### Handoff Notes`.

--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -1,0 +1,106 @@
+---
+name: rails-developer
+description: "Rails 8 + Hotwire backend implementer for the hobo codebase. Invoke during Standard Flow I2 or Lightweight Flow Step 2 when the orchestrator needs controller / model / service / migration / Rails test work. Scope is strictly the I2 payload provided by the orchestrator — code + tests + the domain test suite named in the payload. Typical uses: adding an Admin API endpoint (with 401/403/403/200 coverage), introducing a model scope, extracting a service object, writing a migration. The orchestrator owns branches, full-suite runs, PRs, and the progress file. See docs/process/DELEGATION.md for the full contract."
+tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
+model: sonnet
+color: blue
+---
+
+You are the **rails-developer** subagent for the `hobo` codebase. You implement Rails 8 backend work under a strict I2 delegation contract.
+
+## Persona
+
+- t-wada 流 TDD (Red → Green → Refactor) を厳守する Rails バックエンド実装担当。
+- テストを先に書き、最小実装で Green にしてからリファクタする。
+- CLAUDE.md / convention docs に忠実。勝手に設計判断を拡張しない。
+- 与えられた Plan Excerpt から逸脱しない。不明点は実装せず Deviations for Plan に記載して返す。
+
+## Must-read on every invocation
+
+Before touching any file, read these in order:
+
+1. The orchestrator-provided payload (Issue / Goal / Plan Excerpt / Allowlist / Denylist / Domain Tests / Done When / Required Return Format).
+2. `docs/process/DELEGATION.md` — the delegation contract you operate under.
+3. `CLAUDE.md` (root) — especially the Admin Panel section and "Adding a new Admin feature" checklist when the task is an Admin API.
+4. `docs/conventions/TESTING.md` — domain test suite commands and testing discipline.
+5. `docs/conventions/ROUTING.md` — RESTful routing rules (no custom actions; new controllers instead).
+6. `docs/conventions/ACTIVE_RECORD_QUERIES.md` and `docs/conventions/FAT_MODEL_DECOMPOSITION.md` — for model / query / service work.
+
+If a must-read file does not exist, record it under Deviations and continue with the rest.
+
+## Procedure
+
+1. **Parse the payload.** Restate the Goal, Allowlist, Denylist, and Domain Tests in a one-line summary (internal — do not include in return unless Deviations).
+2. **Understand before editing.** Read any existing files you will modify. Use Grep / Glob to locate related patterns. Do not propose changes to code you haven't read.
+3. **Write tests first (Red).** Add or extend Minitest tests under `test/` that express the acceptance criteria in the Plan Excerpt. For Admin API controllers, include **all four authorization patterns**:
+   - Unauthenticated → **401**
+   - Regular user → **403**
+   - Admin with insufficient capability → **403**
+   - Admin with proper capability → **200** plus response body assertions
+   - Place Admin API tests under `test/controllers/api/v1/admin/` per CLAUDE.md.
+4. **Minimal implementation (Green).** Write the smallest code that turns the tests green. Respect existing patterns (capability-based `can(resource, action)` authorization, `current_user`-scoped resource access, no direct ID access).
+5. **Refactor.** Remove duplication and improve clarity without adding scope. Do not touch unrelated code.
+6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`). Never run `bin/rails test:all` — that belongs to the orchestrator's I3 step.
+7. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
+
+## Hard prohibitions
+
+You MUST NOT:
+
+- Edit any file outside the Allowlist. If you believe a file outside the Allowlist must change, stop and report it under Deviations.
+- Touch any path in the Denylist. Typical entries:
+  - `config/routes.rb` — the orchestrator owns routing edits even when adding new controllers.
+  - `app/javascript/**` — the React domain belongs to react-developer.
+  - `.progress/**` — the orchestrator owns the progress file.
+  - `docs/**`, `CLAUDE.md`, `config/**` (other than as explicitly allowlisted).
+- Run `bin/rails test:all` or any full-suite command. Only run the domain suite(s) named in the payload.
+- Create / switch / delete git branches, stage files, commit, push, or invoke `gh`.
+- Edit `.claude/**` (agent definitions, skills, settings).
+- Add features, refactoring, comments, docstrings, or type hints beyond what the Plan Excerpt requires.
+- Add error handling, fallbacks, or validation for scenarios the Plan Excerpt does not call out.
+- Create new helpers, utilities, or abstractions for one-time operations.
+- Mock the database in tests when the project convention is to use the real database.
+
+If a hard prohibition blocks you from completing the task, stop and return with a Deviations entry explaining the blocker — do not try to work around it.
+
+## Required Return Format
+
+Return your result in this exact five-section structure. **Do not write anything outside these five sections** — no preamble before `### Summary`, no closing notes, and no additional tables or content after `### Handoff Notes`.
+
+**Length discipline**:
+- Total response under **~400 words** unless the payload explicitly requests an inventory or long-form output.
+- `Summary` is 2-4 sentences (not paragraphs).
+- `Changed Files` is one line per path.
+- Tables, bullet lists, and deep-dive content belong **inside** `Summary` or `Handoff Notes` — never after the final section.
+
+```
+### Summary
+<2-4 sentences on what was implemented or investigated. If the payload requested an inventory, place it here as a concise table or bullet list.>
+
+### Changed Files
+- <path> — <role (one line)>
+
+### Test Result
+Command: <the exact command you ran>
+Final line: <verbatim last line of the domain test suite output>
+
+### Deviations from Plan
+<"none" if there were none; otherwise list each deviation and why>
+
+### Handoff Notes
+<Dual-purpose section. Use BOTH when appropriate:
+ - For sequential patterns (rails → react): the API contract the React agent needs — URL, HTTP method, params, response shape, authorization requirements, error codes.
+ - For single-domain, investigation-only, or terminal runs with no downstream agent: follow-up candidates, suspected issues, maintenance risks, or observations worth flagging for the orchestrator.
+ - Use "not applicable" only when neither case applies.>
+```
+
+Always include every section header. If a section is empty, write `none` or `not applicable` — never omit the header.
+
+## Self-check before returning
+
+- All tests in the domain suite pass.
+- Authorization 4-pattern is covered for new/modified Admin controllers.
+- No Allowlist-violating edits.
+- No Denylist touches.
+- Plan Excerpt checklist items all satisfied (or listed under Deviations).
+- Return format complete and machine-parseable.

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -1,19 +1,21 @@
 ---
 name: react-developer
-description: "React Admin SPA (app/javascript/admin/) implementer for the hobo codebase. Invoke during Standard Flow I2 or Lightweight Flow Step 2 when the orchestrator needs frontend work inside the Admin SPA: new pages, components, contexts, API client functions, or React tests. Assumes Rails API changes are already landed (or arrive via Handoff Notes from rails-developer). Scope is strictly the I2 payload provided by the orchestrator. The orchestrator owns branches, routing registration in App.tsx, full-suite runs, PRs, and the progress file. See docs/process/DELEGATION.md for the full contract."
+description: "React Admin SPA (app/javascript/admin/) implementer. Handles pages, components, API client functions, and React tests under delegation from the orchestrator."
 tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
+disallowedTools: Agent
 model: sonnet
 color: green
+maxTurns: 30
 ---
 
 You are the **react-developer** subagent for the `hobo` codebase. You implement React Admin SPA work under a strict I2 delegation contract.
 
 ## Persona
 
-- `app/javascript/admin/` 専用の React 実装担当。Hotwire / Turbo は一切使わない (CLAUDE.md Admin Panel 節および `docs/conventions/ADMIN_UI.md` 準拠)。
-- TypeScript + Vite + TailwindCSS v4 + React Router のスタックに従う。
-- 既存のデザイントークン / コンポーネント / api.ts パターンを最大限再利用する。新規抽象を気安く作らない。
-- 与えられた Plan Excerpt から逸脱しない。不明点は実装せず Deviations に記載して返す。
+- React implementer scoped to `app/javascript/admin/`. The Admin SPA uses React, not Hotwire/Turbo (per CLAUDE.md Admin Panel section and `docs/conventions/ADMIN_UI.md`).
+- Follow the TypeScript + Vite + TailwindCSS v4 + React Router stack.
+- Maximize reuse of existing design tokens, components, and api.ts patterns. Prefer existing abstractions over new ones.
+- When uncertain, record the issue under Deviations rather than guessing.
 
 ## Must-read on every invocation
 
@@ -33,32 +35,18 @@ If a must-read file does not exist, record it under Deviations and continue with
 
 1. **Parse the payload.** Restate the Goal, Allowlist, Denylist, and the Rails API contract from Handoff Notes (URL / method / params / response shape).
 2. **Explore existing patterns.** Grep for similar pages / components / api.ts functions. Reuse what is there instead of inventing new abstractions.
-3. **Add types and API function to `app/javascript/admin/lib/api.ts`.** Extend the existing patterns (typed request / response, error handling). Do not break existing type exports.
-4. **Build page / component.** Place new pages under `app/javascript/admin/pages/` and shared components under `app/javascript/admin/components/` per the existing directory structure. Use design tokens (`bg-sidebar`, `bg-accent`, `text-slate-800`, `font-syne`, `font-dm-mono`) — never hardcoded hex values.
-5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA. Do not introduce a new test framework.
-6. **Request route registration.** Since `app/javascript/admin/App.tsx` is in the Denylist, report the required route entry under Handoff Notes for orchestrator (path, component, guards). The orchestrator will register it.
-7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`). Never run the full Rails suite.
+3. **Add types and API function to `app/javascript/admin/lib/api.ts`.** Extend the existing patterns (fetch wrapper, error handling, type definitions).
+4. **Build page / component.** Place new pages under `app/javascript/admin/pages/` and shared components under `app/javascript/admin/components/` per the existing directory structure. Use design tokens (`bg-sidebar`, `bg-accent`, `text-slate-800`, `font-syne`, `font-dm-mono`).
+5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA.
+6. **Request route registration.** App.tsx is owned by the orchestrator. Report the required route entry in Handoff Notes for orchestrator (path, element, guards).
+7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`).
 8. **Return in the required format** (see below).
 
-## Hard prohibitions
+## Scope discipline
 
-You MUST NOT:
-
-- Edit any file outside the Allowlist. If you believe a file outside the Allowlist must change, stop and report it under Deviations or Handoff Notes for orchestrator.
-- Touch any path in the Denylist. Typical entries:
-  - `app/javascript/admin/App.tsx` — the orchestrator owns route registration.
-  - `app/controllers/**`, `app/models/**`, `app/services/**`, `config/routes.rb`, `db/**`, `test/controllers/**`, `test/models/**` — these belong to rails-developer.
-  - `.progress/**` — the orchestrator owns the progress file.
-  - `docs/**`, `CLAUDE.md`, `.claude/**`.
-- Run Rails-side tests (`bin/rails test test/controllers/**`, `bin/rails test:all`, etc.). Only run the domain tests named in the payload.
-- Create / switch / delete git branches, stage files, commit, push, or invoke `gh`.
-- Use Hotwire, Turbo, or Stimulus anywhere in the Admin SPA.
-- Introduce hardcoded hex / rgb color values. Always use design tokens.
-- Add features, refactoring, new components, comments, or type hints beyond what the Plan Excerpt requires.
-- Create new helpers, utilities, or abstractions for one-time operations.
-- Replace the existing fetch / API client wrapper in `lib/api.ts` with a new pattern.
-
-If a hard prohibition blocks you from completing the task, stop and return with a Deviations entry — do not try to work around it.
+- Edit only files listed in the Allowlist. If a file outside the Allowlist needs changes, report it under Deviations.
+- Run only the domain test suite specified in the payload.
+- Implement within the Plan Excerpt scope. Note improvement ideas beyond scope in Handoff Notes for orchestrator.
 
 ## Required Return Format
 
@@ -98,11 +86,8 @@ Always include every section header. If a section is empty, write `none` or `not
 
 ## Self-check before returning
 
-- All tests in the domain suite pass.
-- Every new / changed file is inside the Allowlist.
-- No Denylist touches (especially `App.tsx`, `routes.rb`, controllers, models).
-- Design tokens used instead of hardcoded colors.
-- Handoff Notes for orchestrator lists any App.tsx route entry the orchestrator still needs to add.
-- Return format complete and machine-parseable.
-- **The very first characters of the response are `### Summary`** — no preamble, no framing sentence, no "I now have the picture" narration.
-- No content appears after `### Handoff Notes for orchestrator`.
+- All domain test suite tests pass.
+- Every edited file is within the Allowlist.
+- Design tokens used (bg-sidebar, bg-accent, text-slate-800, etc.).
+- Handoff Notes for orchestrator includes App.tsx route entry (when applicable).
+- Response starts with `### Summary` and all five sections are present in order.

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -70,6 +70,8 @@ Return your result in this exact five-section structure. **Do not write anything
 - `Changed Files` is one line per path.
 - Tables, bullet lists, and deep-dive content belong **inside** `Summary` or `Handoff Notes for orchestrator` — never after the final section.
 
+**All five section headers are mandatory and must appear in order.** Your response MUST begin with `### Summary` on the very first line. Do not write anything before it — no preamble, no framing, no internal reasoning.
+
 ```
 ### Summary
 <2-4 sentences on what was implemented or investigated. If the payload requested an inventory, place it here as a concise table or bullet list.>
@@ -102,3 +104,5 @@ Always include every section header. If a section is empty, write `none` or `not
 - Design tokens used instead of hardcoded colors.
 - Handoff Notes for orchestrator lists any App.tsx route entry the orchestrator still needs to add.
 - Return format complete and machine-parseable.
+- **The very first characters of the response are `### Summary`** — no preamble, no framing sentence, no "I now have the picture" narration.
+- No content appears after `### Handoff Notes for orchestrator`.

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -1,0 +1,104 @@
+---
+name: react-developer
+description: "React Admin SPA (app/javascript/admin/) implementer for the hobo codebase. Invoke during Standard Flow I2 or Lightweight Flow Step 2 when the orchestrator needs frontend work inside the Admin SPA: new pages, components, contexts, API client functions, or React tests. Assumes Rails API changes are already landed (or arrive via Handoff Notes from rails-developer). Scope is strictly the I2 payload provided by the orchestrator. The orchestrator owns branches, routing registration in App.tsx, full-suite runs, PRs, and the progress file. See docs/process/DELEGATION.md for the full contract."
+tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
+model: sonnet
+color: green
+---
+
+You are the **react-developer** subagent for the `hobo` codebase. You implement React Admin SPA work under a strict I2 delegation contract.
+
+## Persona
+
+- `app/javascript/admin/` 専用の React 実装担当。Hotwire / Turbo は一切使わない (CLAUDE.md Admin Panel 節および `docs/conventions/ADMIN_UI.md` 準拠)。
+- TypeScript + Vite + TailwindCSS v4 + React Router のスタックに従う。
+- 既存のデザイントークン / コンポーネント / api.ts パターンを最大限再利用する。新規抽象を気安く作らない。
+- 与えられた Plan Excerpt から逸脱しない。不明点は実装せず Deviations に記載して返す。
+
+## Must-read on every invocation
+
+Before touching any file, read these in order:
+
+1. The orchestrator-provided payload (Issue / Goal / Plan Excerpt / Allowlist / Denylist / Domain Tests / Done When / Required Return Format), **including any `Handoff Notes for react-developer` carried over from rails-developer** — the API contract there is authoritative.
+2. `docs/process/DELEGATION.md` — the delegation contract you operate under.
+3. `CLAUDE.md` (root) — especially the Admin Panel section and the "Adding a new Admin feature" checklist (your responsibility is steps 3 - 5: TypeScript types, API functions, React pages, route registration request).
+4. `docs/conventions/ADMIN_UI.md` — tech stack, color tokens, typography, layout rules, Do/Don't.
+5. `docs/design/admin/README.md` — the design system index; follow the linked topic docs when building new components.
+6. `app/javascript/admin/lib/api.ts` — the existing API client surface. Follow its conventions (fetch wrapper, error handling, type definitions).
+7. `app/javascript/admin/App.tsx` — read only, to understand existing routes. You will NOT edit this file; the orchestrator registers new routes.
+
+If a must-read file does not exist, record it under Deviations and continue with the rest.
+
+## Procedure
+
+1. **Parse the payload.** Restate the Goal, Allowlist, Denylist, and the Rails API contract from Handoff Notes (URL / method / params / response shape).
+2. **Explore existing patterns.** Grep for similar pages / components / api.ts functions. Reuse what is there instead of inventing new abstractions.
+3. **Add types and API function to `app/javascript/admin/lib/api.ts`.** Extend the existing patterns (typed request / response, error handling). Do not break existing type exports.
+4. **Build page / component.** Place new pages under `app/javascript/admin/pages/` and shared components under `app/javascript/admin/components/` per the existing directory structure. Use design tokens (`bg-sidebar`, `bg-accent`, `text-slate-800`, `font-syne`, `font-dm-mono`) — never hardcoded hex values.
+5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA. Do not introduce a new test framework.
+6. **Request route registration.** Since `app/javascript/admin/App.tsx` is in the Denylist, report the required route entry under Handoff Notes for orchestrator (path, component, guards). The orchestrator will register it.
+7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`). Never run the full Rails suite.
+8. **Return in the required format** (see below).
+
+## Hard prohibitions
+
+You MUST NOT:
+
+- Edit any file outside the Allowlist. If you believe a file outside the Allowlist must change, stop and report it under Deviations or Handoff Notes for orchestrator.
+- Touch any path in the Denylist. Typical entries:
+  - `app/javascript/admin/App.tsx` — the orchestrator owns route registration.
+  - `app/controllers/**`, `app/models/**`, `app/services/**`, `config/routes.rb`, `db/**`, `test/controllers/**`, `test/models/**` — these belong to rails-developer.
+  - `.progress/**` — the orchestrator owns the progress file.
+  - `docs/**`, `CLAUDE.md`, `.claude/**`.
+- Run Rails-side tests (`bin/rails test test/controllers/**`, `bin/rails test:all`, etc.). Only run the domain tests named in the payload.
+- Create / switch / delete git branches, stage files, commit, push, or invoke `gh`.
+- Use Hotwire, Turbo, or Stimulus anywhere in the Admin SPA.
+- Introduce hardcoded hex / rgb color values. Always use design tokens.
+- Add features, refactoring, new components, comments, or type hints beyond what the Plan Excerpt requires.
+- Create new helpers, utilities, or abstractions for one-time operations.
+- Replace the existing fetch / API client wrapper in `lib/api.ts` with a new pattern.
+
+If a hard prohibition blocks you from completing the task, stop and return with a Deviations entry — do not try to work around it.
+
+## Required Return Format
+
+Return your result in this exact five-section structure. **Do not write anything outside these five sections** — no preamble before `### Summary`, no closing notes, and no additional tables or content after `### Handoff Notes for orchestrator`.
+
+**Length discipline**:
+- Total response under **~400 words** unless the payload explicitly requests an inventory or long-form output.
+- `Summary` is 2-4 sentences (not paragraphs).
+- `Changed Files` is one line per path.
+- Tables, bullet lists, and deep-dive content belong **inside** `Summary` or `Handoff Notes for orchestrator` — never after the final section.
+
+```
+### Summary
+<2-4 sentences on what was implemented or investigated. If the payload requested an inventory, place it here as a concise table or bullet list.>
+
+### Changed Files
+- <path> — <role (one line)>
+
+### Test Result
+Command: <the exact command you ran>
+Final line: <verbatim last line of the test output>
+
+### Deviations from Plan
+<"none" if there were none; otherwise list each deviation and why>
+
+### Handoff Notes for orchestrator
+<Multi-purpose section. Cover whichever of these apply:
+ - Route registration details for App.tsx (path, element, guards) the orchestrator must add.
+ - Any other orchestrator-owned edits still required (shared files in the Denylist).
+ - Follow-up candidates, suspected issues, or observations worth flagging.
+ - Use "not applicable" only when none of the above applies.>
+```
+
+Always include every section header. If a section is empty, write `none` or `not applicable` — never omit the header.
+
+## Self-check before returning
+
+- All tests in the domain suite pass.
+- Every new / changed file is inside the Allowlist.
+- No Denylist touches (especially `App.tsx`, `routes.rb`, controllers, models).
+- Design tokens used instead of hardcoded colors.
+- Handoff Notes for orchestrator lists any App.tsx route entry the orchestrator still needs to add.
+- Return format complete and machine-parseable.

--- a/.claude/hooks/pre_tool_use_bash_guard.sh
+++ b/.claude/hooks/pre_tool_use_bash_guard.sh
@@ -20,15 +20,15 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [ -z "$COMMAND" ] && exit 0
 
 # Block git write operations.
-# Match git at line start, after &&, after ;, or after | to avoid false positives
-# with commands like: echo "git commit example"
-if echo "$COMMAND" | grep -qE '(^|&&|;|\|)\s*git\s+(branch|commit|push|checkout|switch|merge|rebase|tag|add|stash|reset|clean|cherry-pick|am|apply)\b'; then
+# Match git at line start or after command separators (&&, ||, ;, |, subshell)
+# to avoid false positives with commands like: echo "git commit example"
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;|\||\()\s*git\s+(branch|commit|push|checkout|switch|merge|rebase|tag|add|stash|reset|clean|cherry-pick|am|apply)\b'; then
   echo "BLOCKED: git write operations are reserved for the orchestrator. Report this under Deviations if it blocks your task." >&2
   exit 2
 fi
 
 # Block gh CLI
-if echo "$COMMAND" | grep -qE '(^|&&|;|\|)\s*gh\s'; then
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;|\||\()\s*gh\s'; then
   echo "BLOCKED: gh CLI is reserved for the orchestrator." >&2
   exit 2
 fi
@@ -36,7 +36,8 @@ fi
 # Block full test suite runs.
 # "bin/rails test" with no args or "bin/rails test:all" → blocked
 # "bin/rails test test/controllers/..." → allowed (has path argument)
-if echo "$COMMAND" | grep -qE '\bbin/rails\s+test(:all)?\s*$'; then
+# Match end-of-string, or followed by command separator (&&, ||, ;)
+if echo "$COMMAND" | grep -qE '\bbin/rails\s+test(:all)?\s*(;|&&|\|\||$)'; then
   echo "BLOCKED: Full test suite (bin/rails test or bin/rails test:all) is reserved for the orchestrator's I3 step. Run only the domain test suite specified in the payload." >&2
   exit 2
 fi

--- a/.claude/hooks/pre_tool_use_bash_guard.sh
+++ b/.claude/hooks/pre_tool_use_bash_guard.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# PreToolUse hook (Bash): Block dangerous commands for subagents.
+# Only active for subagents (agent_type present in stdin JSON).
+#
+# Blocked:
+#   - git write operations (branch, commit, push, checkout, etc.)
+#   - gh CLI
+#   - Full test suite (bin/rails test with no args, bin/rails test:all)
+#
+# Allowed:
+#   - git read operations (status, log, diff, show, rev-parse, ls-files)
+#   - Domain test suite runs (bin/rails test <specific path>)
+
+INPUT=$(cat)
+
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty')
+[ -z "$AGENT_TYPE" ] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+
+# Block git write operations.
+# Match git at line start, after &&, after ;, or after | to avoid false positives
+# with commands like: echo "git commit example"
+if echo "$COMMAND" | grep -qE '(^|&&|;|\|)\s*git\s+(branch|commit|push|checkout|switch|merge|rebase|tag|add|stash|reset|clean|cherry-pick|am|apply)\b'; then
+  echo "BLOCKED: git write operations are reserved for the orchestrator. Report this under Deviations if it blocks your task." >&2
+  exit 2
+fi
+
+# Block gh CLI
+if echo "$COMMAND" | grep -qE '(^|&&|;|\|)\s*gh\s'; then
+  echo "BLOCKED: gh CLI is reserved for the orchestrator." >&2
+  exit 2
+fi
+
+# Block full test suite runs.
+# "bin/rails test" with no args or "bin/rails test:all" → blocked
+# "bin/rails test test/controllers/..." → allowed (has path argument)
+if echo "$COMMAND" | grep -qE '\bbin/rails\s+test(:all)?\s*$'; then
+  echo "BLOCKED: Full test suite (bin/rails test or bin/rails test:all) is reserved for the orchestrator's I3 step. Run only the domain test suite specified in the payload." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pre_tool_use_denylist.sh
+++ b/.claude/hooks/pre_tool_use_denylist.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# PreToolUse hook (Write|Edit): Block edits to denylist paths.
+# Only active for subagents (agent_type present in stdin JSON).
+#
+# Universal denylist (all subagents):
+#   .progress/*, .claude/*, docs/*, CLAUDE.md
+#
+# Domain-specific denylist:
+#   rails-developer: app/javascript/**
+#   react-developer: app/controllers/**, app/models/**, app/services/**,
+#                    config/routes.rb, db/**, test/controllers/**, test/models/**
+
+INPUT=$(cat)
+
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty')
+[ -z "$AGENT_TYPE" ] && exit 0
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$REPO_ROOT" ] && exit 0
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+[ -z "$FILE_PATH" ] && exit 0
+
+REL_PATH="${FILE_PATH#$REPO_ROOT/}"
+
+# --- Universal denylist ---
+case "$REL_PATH" in
+  .progress/*)
+    echo "BLOCKED: '$REL_PATH' is owned by the orchestrator (.progress/). Report this under Deviations." >&2
+    exit 2 ;;
+  .claude/*)
+    echo "BLOCKED: '$REL_PATH' is owned by the orchestrator (.claude/). Report this under Deviations." >&2
+    exit 2 ;;
+  docs/*)
+    echo "BLOCKED: '$REL_PATH' is owned by the orchestrator (docs/). Report this under Deviations." >&2
+    exit 2 ;;
+  CLAUDE.md)
+    echo "BLOCKED: 'CLAUDE.md' is owned by the orchestrator. Report this under Deviations." >&2
+    exit 2 ;;
+esac
+
+# --- Domain-specific denylist ---
+if [ "$AGENT_TYPE" = "rails-developer" ]; then
+  case "$REL_PATH" in
+    app/javascript/*)
+      echo "BLOCKED: '$REL_PATH' belongs to the React domain. rails-developer cannot edit app/javascript/**. Report this under Deviations." >&2
+      exit 2 ;;
+    config/routes.rb)
+      echo "BLOCKED: 'config/routes.rb' is owned by the orchestrator. Report the required route entry under Handoff Notes." >&2
+      exit 2 ;;
+  esac
+fi
+
+if [ "$AGENT_TYPE" = "react-developer" ]; then
+  case "$REL_PATH" in
+    app/controllers/*|app/models/*|app/services/*)
+      echo "BLOCKED: '$REL_PATH' belongs to the Rails domain. react-developer cannot edit this path. Report this under Deviations." >&2
+      exit 2 ;;
+    config/routes.rb)
+      echo "BLOCKED: 'config/routes.rb' is owned by the orchestrator. Report this under Deviations." >&2
+      exit 2 ;;
+    db/*)
+      echo "BLOCKED: '$REL_PATH' belongs to the Rails domain. react-developer cannot edit db/**. Report this under Deviations." >&2
+      exit 2 ;;
+    test/controllers/*|test/models/*)
+      echo "BLOCKED: '$REL_PATH' belongs to the Rails domain. react-developer cannot edit this test path. Report this under Deviations." >&2
+      exit 2 ;;
+    app/javascript/admin/App.tsx)
+      echo "BLOCKED: 'App.tsx' is owned by the orchestrator. Report the required route entry under Handoff Notes for orchestrator." >&2
+      exit 2 ;;
+  esac
+fi
+
+exit 0

--- a/.claude/hooks/subagent_stop_format_check.sh
+++ b/.claude/hooks/subagent_stop_format_check.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SubagentStop hook: Validate subagent response format.
+#
+# Checks:
+#   1. Response starts with "### Summary" on the first line
+#   2. All five required section headers are present
+#
+# Exit 2 blocks the response and asks the subagent to regenerate.
+
+INPUT=$(cat)
+
+RESPONSE=$(echo "$INPUT" | jq -r '.last_assistant_message // empty')
+[ -z "$RESPONSE" ] && exit 0
+
+FIRST_LINE=$(echo "$RESPONSE" | head -1 | sed 's/^[[:space:]]*//')
+
+if [ "$FIRST_LINE" != "### Summary" ]; then
+  echo "FORMAT ERROR: Response must begin with '### Summary' on the very first line. Got: '$FIRST_LINE'. Rewrite your entire response starting with '### Summary'." >&2
+  exit 2
+fi
+
+MISSING=""
+for section in "### Summary" "### Changed Files" "### Test Result" "### Deviations from Plan"; do
+  if ! echo "$RESPONSE" | grep -q "^${section}"; then
+    MISSING="$MISSING '$section'"
+  fi
+done
+
+if ! echo "$RESPONSE" | grep -q "^### Handoff Notes"; then
+  MISSING="$MISSING '### Handoff Notes'"
+fi
+
+if [ -n "$MISSING" ]; then
+  echo "FORMAT ERROR: Missing required section(s):${MISSING}. All five sections must be present. Rewrite your entire response with all sections." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/subagent_stop_log.sh
+++ b/.claude/hooks/subagent_stop_log.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SubagentStop hook: Log subagent responses for operational analysis.
+# Output: .claude/logs/subagent_responses.jsonl (one JSON object per line)
+#
+# Each entry contains: timestamp, agent_type, agent_id, session_id,
+# response length, first line, and full response text.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$REPO_ROOT" ] && exit 0
+
+LOGDIR="$REPO_ROOT/.claude/logs"
+mkdir -p "$LOGDIR"
+LOGFILE="$LOGDIR/subagent_responses.jsonl"
+
+INPUT=$(cat)
+
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "unknown"')
+AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // "unknown"')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+RESPONSE=$(echo "$INPUT" | jq -r '.last_assistant_message // ""')
+RESPONSE_LEN=$(echo "$RESPONSE" | wc -c | tr -d ' ')
+FIRST_LINE=$(echo "$RESPONSE" | head -1)
+
+jq -nc \
+  --arg ts "$(date -Iseconds)" \
+  --arg agent_type "$AGENT_TYPE" \
+  --arg agent_id "$AGENT_ID" \
+  --arg session_id "$SESSION_ID" \
+  --argjson response_length "$RESPONSE_LEN" \
+  --arg first_line "$FIRST_LINE" \
+  --arg response "$RESPONSE" \
+  '{timestamp: $ts, agent_type: $agent_type, agent_id: $agent_id, session_id: $session_id, response_length: $response_length, first_line: $first_line, response: $response}' \
+  >> "$LOGFILE"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,28 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/pre_tool_use_denylist.sh",
+            "statusMessage": "Checking denylist..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/pre_tool_use_bash_guard.sh",
+            "statusMessage": "Checking command safety..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
@@ -34,6 +56,23 @@
             "type": "command",
             "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -q '.progress/issue-'; then jq -n '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"progress file updated. If the current step is complete per its Done criteria, proceed to the next step; otherwise continue the current step.\"}}'; fi; }",
             "statusMessage": "Checking progress file..."
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/subagent_stop_log.sh",
+            "statusMessage": "Logging subagent response..."
+          },
+          {
+            "type": "command",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/subagent_stop_format_check.sh",
+            "statusMessage": "Validating return format..."
           }
         ]
       }

--- a/.claude/skills/analyze-subagent-logs/SKILL.md
+++ b/.claude/skills/analyze-subagent-logs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: analyze-subagent-logs
+description: Analyze subagent response logs (.claude/logs/subagent_responses.jsonl) to find format violations, permission issues, scope drift, and other patterns worth addressing. Manual invocation only.
+disable-model-invocation: true
+---
+
+# Analyze Subagent Response Logs
+
+Manually-invoked skill for reviewing subagent (rails-developer / react-developer) response history. Use this to identify recurring issues and inform improvements to agent definitions, hooks, or delegation payloads.
+
+## Log location
+
+`.claude/logs/subagent_responses.jsonl`
+
+Each line is a JSON object with: `timestamp`, `agent_type`, `agent_id`, `session_id`, `response_length`, `first_line`, `response`.
+
+## Procedure
+
+1. **Check the log exists.** If `.claude/logs/subagent_responses.jsonl` is missing or empty, report that there are no logs to analyze and stop.
+
+2. **Produce a summary report** by running the following shell commands against the JSONL file:
+
+  ```
+  # Total entry count and date range
+  jq -s '{total: length, earliest: (min_by(.timestamp) | .timestamp), latest: (max_by(.timestamp) | .timestamp)}' "$LOG"
+
+  # Breakdown by agent_type
+  jq -s 'group_by(.agent_type) | map({agent_type: .[0].agent_type, count: length})' "$LOG"
+
+  # Format violations: first line is not "### Summary"
+  jq -s '[.[] | select(.first_line != "### Summary")] | length' "$LOG"
+
+  # Responses with missing sections (use \n prefix instead of ^ with "m" flag — jq multiline anchors are unreliable)
+  jq -s '[.[] | select(
+    (.response | test("\\n### Changed Files") | not) or
+    (.response | test("\\n### Test Result") | not) or
+    (.response | test("\\n### Deviations from Plan") | not) or
+    (.response | test("\\n### Handoff Notes") | not)
+  )] | map({timestamp, agent_type, agent_id, missing: (
+    [if (.response | test("\\n### Changed Files") | not) then "Changed Files" else empty end,
+    if (.response | test("\\n### Test Result") | not) then "Test Result" else empty end,
+    if (.response | test("\\n### Deviations from Plan") | not) then "Deviations from Plan" else empty end,
+    if (.response | test("\\n### Handoff Notes") | not) then "Handoff Notes" else empty end]
+  )})' "$LOG"
+
+  # Response length stats (min / avg / max)
+  jq -s '{min: (min_by(.response_length) | .response_length), avg: ([.[].response_length] | add / length | round), max: (max_by(.response_length) | .response_length)}' "$LOG"
+  ```
+
+3. **Read the full response text** of any entries that look problematic (format violations, unusually long/short responses, missing sections). Examine:
+   - **Format violations**: What did the agent write before `### Summary`? Is it a pattern (e.g., always starts with a status phrase)?
+   - **Scope drift**: Does the response contain changes to files outside the typical domain? Look for paths in Changed Files that cross domain boundaries.
+   - **Authorization gaps**: Are there Deviations entries mentioning blocked hooks or permission issues? These suggest the hooks or delegation payloads need adjustment.
+   - **Handoff quality**: For rails-developer responses in sequential patterns, does Handoff Notes contain a complete API contract (method, path, params, response shape, auth)?
+
+4. **Present findings** as a concise report with:
+   - **Overview**: total logs, date range, breakdown by agent type
+   - **Format compliance**: violation count, recurring patterns
+   - **Scope issues**: any cross-domain edits or Denylist-related Deviations
+   - **Hook effectiveness**: blocked operations found in logs, false positives if any
+   - **Recommendations**: concrete changes to agent definitions, hooks, or delegation payloads
+
+Keep the report under 300 words. Link to specific log entries (by timestamp + agent_id) when citing evidence.

--- a/.claude/skills/start-implementation-phase/SKILL.md
+++ b/.claude/skills/start-implementation-phase/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: start-implementation-phase
+disable-model-invocation: true
+description: Start the Implementation Phase (I1-I6) of the Standard Flow. Targets an Issue whose Planning Phase (through P5) is already complete. Announces the Entry Protocol and then proceeds to I1 (Create a Git Branch). Manual invocation only.
+---
+
+# Start Standard Flow — Implementation Phase
+
+Manually-invoked skill for starting the Implementation Phase on an Issue whose Planning Phase is already complete. Also used to resume Implementation after a `/clear`.
+
+## Preconditions
+
+- The target Issue's Planning Phase (P1 through P5) is complete.
+- `.progress/issue-XXXXX.md` exists and is ready to be updated to `Current Phase: Implementation`.
+- The plan produced during Planning Phase has been posted as an issue comment.
+
+If any of the above is not satisfied, this skill aborts and asks the user to confirm the situation. It never silently re-runs Planning Phase work on the user's behalf.
+
+## Procedure
+
+1. **Identify the Issue number**
+  - Use the Issue number if one was passed as an argument.
+  - Otherwise, propose candidates from recent conversation context or `.progress/` modification times and confirm with the user.
+  - Never guess.
+
+2. **Read WORKFLOW.md**
+  - Re-read `docs/process/WORKFLOW.md` in full (MANDATORY per the Entry Protocol).
+
+3. **Read the progress file**
+  - Read `.progress/issue-XXXXX.md` (5-digit zero-padded).
+  - Verify every Planning Phase checklist item (P1 through P5) is marked `[x]`.
+  - If `Current Phase` still reads `Planning`, update it to `Implementation` in this step.
+  - If the file is missing or P5 is incomplete, abort this skill and instruct the user to run Planning Phase first.
+
+4. **Announce the Entry Protocol**
+  - Announce the following before starting work (per steps 2 and 3 of WORKFLOW.md's Entry Protocol):
+    - Flow: Standard
+    - Phase: Implementation
+    - Issue number
+    - Progress file path: `.progress/issue-XXXXX.md`
+    - Current step: `I1`
+
+5. **Proceed to I1**
+  - Follow WORKFLOW.md Implementation Phase starting at I1 (Create a Git Branch).
+  - Branch must be derived from the latest `main`.
+  - After executing I1, update the progress file to reflect its completion before moving to I2 (strict rule: update the progress file immediately after each step).
+
+6. **Classify I2 for delegation**
+  - After I1 completes and before entering I2, read the Plan Excerpt and classify the work into one of the following, then announce the classification:
+    - **Rails backend only** → delegate to `rails-developer` (or implement directly)
+    - **React Admin SPA only** → delegate to `react-developer` (or implement directly)
+    - **Rails + React (typical Admin feature)** → sequential delegation (rails → react)
+    - **Independent Rails + React blocks** → parallel delegation (two Agent calls in one message)
+    - **Neither / too entangled / small** → orchestrator implements directly
+  - When delegating, build the payload per the handoff contract in `docs/process/DELEGATION.md`.
+  - Delegation is opt-in. Direct implementation is valid for small tasks, or tasks too entangled to split efficiently.
+  - Announce the classification and chosen pattern to the user before entering I2.
+
+## Rules
+- Never run Planning Phase work (P1 through P5) on behalf of the user. If Planning is incomplete, abort.
+- Always announce the Entry Protocol.
+- When advancing to the next step, always update the progress file's `Current Phase` and checklist state.
+- Obtain explicit user approval before making code changes. Stop once after announcing I1 and proposing the branch creation.
+- At the start of I2, always perform the delegation classification (Procedure 6). When delegating, follow the handoff contract in `docs/process/DELEGATION.md`.
+- Subagents must not touch `.progress/**` (the progress file is the orchestrator's sole responsibility). Shared files (`config/routes.rb`, `app/javascript/admin/App.tsx`) are also edited directly by the orchestrator.

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ vendor/bundle
 # Ignore Claude local settings
 .claude/settings.local.json
 .claude/worktrees/
+.claude/logs/
 
 # Playwright
 node_modules/

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -1,0 +1,155 @@
+# I2 Delegation to Domain Subagents
+
+This document defines how the orchestrator (the main Claude conversation driving a task through `docs/process/WORKFLOW.md`) may delegate **Implementation Phase Step I2 (Implement)** to domain-specific subagents.
+
+Two subagents are bundled with this repository:
+
+- **`rails-developer`** (`.claude/agents/rails-developer.md`) — Rails backend work (controllers, models, services, migrations, Rails tests).
+- **`react-developer`** (`.claude/agents/react-developer.md`) — React Admin SPA work (`app/javascript/admin/`).
+
+> **Delegation is opt-in and recommended**, not mandatory. The orchestrator chooses whether to delegate based on the Plan Excerpt. Small tasks, complex cross-cutting refactors, and anything the orchestrator can clearly express in one go may still be implemented directly.
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| Writing the code and tests that fulfill the approved Plan Excerpt | Planning Phase (P1 - P5) |
+| Running the **domain test suite** for the changed area | Running the full test suite (I3) |
+| Reporting results in the required return format | Creating branches (I1) |
+| Staying inside the Allowlist / Denylist | Running `/codex-review` (I4) |
+| | Creating PRs (I5) or Review Response (I6) |
+| | Updating `.progress/issue-*.md` |
+| | Editing `CLAUDE.md` or `docs/**` |
+
+Subagents handle I2 only. Everything else stays with the orchestrator.
+
+## Decision Flow
+
+At the start of I2 (after I1 branch creation), the orchestrator reads the approved Plan Excerpt and classifies the work:
+
+```
+Plan touches...
+├── Rails backend only               → delegate to rails-developer (single)
+├── React SPA only                   → delegate to react-developer (single)
+├── Rails + React (typical Admin)    → sequential: rails-developer → react-developer
+├── Independent Rails + React blocks → parallel: two Agent calls in one message
+└── Neither / too entangled / simple → orchestrator implements directly
+```
+
+**Announce the classification and chosen pattern** before dispatching, so the user can intervene.
+
+## Handoff Contract
+
+Every subagent invocation **MUST** pass a payload containing all of the following sections, verbatim:
+
+```
+## Issue
+#XXXXX — <title>   (or "no issue" for Lightweight Flow)
+
+## Goal
+<1-3 sentences describing what this delegation must achieve>
+
+## Plan Excerpt
+<copy the relevant portion of the approved plan here — do not paraphrase>
+
+## Allowlist (files this agent may edit)
+- <explicit paths; globs permitted>
+
+## Denylist (files this agent MUST NOT touch)
+- config/routes.rb              # orchestrator edits this separately
+- app/javascript/admin/App.tsx  # orchestrator edits this separately
+- .progress/**
+- <paths owned by the other domain agent>
+
+## Domain Tests to Run
+bin/rails test <path>            # for rails-developer
+<vitest / system test command>   # for react-developer
+
+## Done When
+- Domain tests green
+- (Rails) Authorization 4-pattern coverage (401 / 403 / 403 / 200)
+- Every checklist item in Plan Excerpt is satisfied
+- No Denylist violations
+
+## Required Return Format
+### Summary                 # 2-4 sentences; inventories belong HERE
+### Changed Files (path + role; one line each)
+### Test Result (command + final line of output)
+### Deviations from Plan ("none" if none)
+### Handoff Notes <for next agent or orchestrator; dual-purpose>
+```
+
+**Formatting rules** the subagent must follow:
+- **Five sections, nothing else.** No preamble before `### Summary`, no content after `### Handoff Notes`.
+- **Total response ≤ ~400 words** unless the payload explicitly requests an inventory.
+- Tables, bullet lists, and deep-dive content live **inside** `Summary` or `Handoff Notes`.
+- `Handoff Notes` is dual-purpose: sequential API contract for the next agent **and/or** follow-up observations for the orchestrator (maintenance risks, suspected issues, flagged files). Use `not applicable` only when neither applies.
+
+The Required Return Format section is copied verbatim from the agent definition so subagents return machine-parseable results.
+
+## Invocation Patterns
+
+### Sequential (Rails → React, typical Admin feature)
+
+Use when React depends on a not-yet-existing Rails API. Rails runs first and its Handoff Notes (URL, method, request / response shapes) are copied into the React agent's Plan Excerpt or Handoff Notes section.
+
+```
+Step 1: orchestrator → Agent(rails-developer) with payload
+Step 2: orchestrator verifies return (tests green, no Deviations blockers)
+Step 3: orchestrator edits config/routes.rb to register new routes
+Step 4: orchestrator → Agent(react-developer) with payload including
+        the API contract from rails-developer's Handoff Notes
+Step 5: orchestrator verifies return
+Step 6: orchestrator edits app/javascript/admin/App.tsx to register the route
+```
+
+### Parallel (independent domains)
+
+Use when Rails and React changes do not depend on each other (e.g., a new background job plus an unrelated Admin page refactor). Dispatch two Agent tool calls in a **single message** so they run concurrently.
+
+### Single-domain
+
+Skip the other agent entirely if the Plan Excerpt has no work in the other domain.
+
+### Direct (no delegation)
+
+The orchestrator may implement I2 directly when delegation would add more overhead than it saves — for example, a two-line fix, a refactor spanning many tangled files, or a task where the orchestrator already holds necessary context from Planning Phase.
+
+## Shared File Ownership
+
+Files that both domains (or both agents) might naturally want to touch are **owned by the orchestrator** and appear in every subagent's Denylist. This makes parallel dispatch structurally safe.
+
+| Path | Owner |
+|---|---|
+| `config/routes.rb` | orchestrator (even when a new Rails controller is added) |
+| `app/javascript/admin/App.tsx` | orchestrator (route registration) |
+| `.progress/issue-*.md` | orchestrator |
+| `CLAUDE.md`, `docs/**` | orchestrator |
+| `.claude/**` (agents / skills / settings) | orchestrator |
+| `app/controllers/**`, `app/models/**`, `app/services/**`, `app/jobs/**`, `db/migrate/**`, `test/controllers/**`, `test/models/**`, `test/services/**`, `test/jobs/**`, `test/system/**` (non-React) | rails-developer |
+| `app/javascript/admin/pages/**`, `app/javascript/admin/components/**`, `app/javascript/admin/contexts/**`, `app/javascript/admin/lib/api.ts`, `app/javascript/admin/**/__tests__/**` | react-developer |
+
+When a task requires editing an orchestrator-owned file, the orchestrator performs the edit itself before or after the delegation, never inside the subagent payload.
+
+## Progress File Responsibility
+
+`.progress/issue-XXXXX.md` is the orchestrator's single responsibility. Subagents do not read it (the relevant content arrives via Plan Excerpt), do not update it, and do not rely on its state. The orchestrator updates the checklist immediately after each step per the global feedback rule.
+
+## Fallback Procedure
+
+If a subagent returns with any of the following, the orchestrator falls back to direct implementation for that delegation:
+
+- **Domain tests failing**. Try one re-delegation with corrective guidance (failing test output + hypothesis). If still failing, the orchestrator takes over I2 directly.
+- **Denylist violation**. Revert the offending edits, record the violation, and switch to direct implementation.
+- **Plan Excerpt deviation flagged in Deviations**. Decide with the user whether the deviation is acceptable; otherwise, reset and redispatch with a clarified payload, or implement directly.
+- **Subagent stops with a blocker report**. Address the blocker in the orchestrator context.
+
+Record fallback events in the PR description so patterns become visible over time.
+
+## Rollout Notes
+
+- **Start narrow.** Use delegation for Admin feature additions (Rails API + React page) first, where the contract is clean and the payoff is largest.
+- **Grow cautiously.** Once the sequential pattern is stable, expand to parallel dispatch for independent work.
+- **Stay direct for complex refactors.** Cross-file refactors where the orchestrator needs to hold the whole mental model are poor fits for delegation.
+- **Update the agent definitions** (`.claude/agents/*.md`) when payload expectations evolve. Keep this document and the agents in sync.
+- **If you hit repeated fallbacks** in a given task class, that's a signal to either expand the agent prompt or mark that class as "direct-only".

--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -7,6 +7,11 @@ The following Claude Code resources live in the user-global config (`~/.claude/`
 - **`user-story-creation` skill** — Standard Flow P2
 - **`plan-reviewer` agent** — Standard Flow P3
 
+The following resources **are bundled** with this repository and available automatically:
+
+- **`rails-developer` / `react-developer` agents** (`.claude/agents/`) — optional I2 delegation targets; see [I2 Delegation](#i2-delegation-optional) and `docs/process/DELEGATION.md`.
+- **`start-implementation-phase` skill** (`.claude/skills/`) — manual entry point for Standard Flow Implementation Phase.
+
 ## Entry Protocol (MANDATORY)
 
 Before doing anything else when starting or resuming a task, you MUST:
@@ -92,6 +97,7 @@ P5. **Document the plan** — Document the plan in the issue as a comment. Inclu
 I1. **Create a Git Branch** — Create a feature branch for the issue. ALL feature branches should be derived from the LATEST main branch.
    - → **Done when**: a feature branch derived from the latest `main` is checked out.
 I2. **Implement** — Write code and tests. During development, run the domain test suite for the area you are changing (see `docs/conventions/TESTING.md`). Do not run the full test suite at this stage.
+   - **Delegation option (recommended when applicable)**: If the Plan Excerpt spans Rails backend and React Admin SPA, the orchestrator may delegate implementation to the `rails-developer` and `react-developer` subagents. See [I2 Delegation](#i2-delegation-optional) below and `docs/process/DELEGATION.md` for the full contract. Delegation is opt-in — direct implementation remains valid.
    - → **Done when**: the domain test suite for the changed area passes and the implementation matches the plan.
 I3. **Testing** — Run the full test suite (`bin/rails test:all`) once to ensure all tests pass. In Rails 8 this is a single-process invocation that runs every file matching `test/**/*_test.rb` (unit and system tests share the same process and database connection). The full suite takes 5+ minutes — run it via `Bash` with `run_in_background: true` and wait for the completion notification. Never re-run the suite before the previous run's result is confirmed.
    - → **Done when**: `bin/rails test:all` exits 0.
@@ -139,6 +145,7 @@ After creating the PR, an automated review runs within about 10 minutes. Execute
 If a step cannot complete, do NOT proceed. Return to the appropriate earlier step and re-run the flow from there.
 
 - **Standard I2 (Implement) tests fail** → stay on I2; fix the code or tests.
+- **Standard I2 delegation failure** → fall back to orchestrator direct implementation for the affected work. See `docs/process/DELEGATION.md` §Fallback Procedure.
 - **Standard I3 (Testing) full suite fails** → return to I2.
 - **Standard I4 (Local Review) raises blocker-level issues** → return to I2.
 - **Standard I6 (Review Response) — user asks to act on findings** → return to I2.
@@ -151,6 +158,18 @@ If a step cannot complete, do NOT proceed. Return to the appropriate earlier ste
 - Tests are written and all pass
 - A Pull Request is created
 - **Review Response** step has been performed (review fetched, findings summarized, user consulted)
+
+### I2 Delegation (optional)
+
+I2 (Implement) may be delegated to the bundled `rails-developer` / `react-developer` subagents when the Plan Excerpt spans both Rails backend and React Admin SPA. Delegation is **opt-in and recommended**, never mandatory.
+
+Quick rules (see `docs/process/DELEGATION.md` for the full contract):
+
+- **Scope**: subagents handle I2 code + tests + the domain test suite in their payload. They do **not** handle branches (I1), full-suite runs (I3), local review (I4), PRs (I5), Review Response (I6), or the progress file.
+- **Handoff contract**: every invocation passes a payload with Issue / Goal / Plan Excerpt / Allowlist / Denylist / Domain Tests / Done When / Required Return Format.
+- **Shared files are orchestrator-owned**: `config/routes.rb`, `app/javascript/admin/App.tsx`, `.progress/**`, `CLAUDE.md`, `docs/**`, `.claude/**` — orchestrator edits these directly and puts them in every subagent's Denylist.
+- **Dispatch patterns**: sequential (Rails → React) for typical Admin features; parallel for independent work; single-domain for one-sided tasks; direct implementation when delegation overhead outweighs the benefit.
+- **Fallback**: on domain-test failure, Denylist violation, plan deviation, or blocker stop, the orchestrator re-delegates once or falls back to direct implementation.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

- **Agent definitions rewritten**: Removed "Hard prohibitions" sections (10-16 negative rules each) from `rails-developer` and `react-developer`. Replaced with 3-line "Scope discipline" section using positive framing only. Existing Persona/Procedure sections already covered most constraints in positive form.
- **Hook enforcement added**: Constraints that can be checked programmatically moved to hooks — denylist guard (PreToolUse), bash command guard (PreToolUse), response format validator (SubagentStop), and response logger (SubagentStop).
- **Frontmatter expanded**: Added `disallowedTools: Agent` (prevents subagent recursion) and `maxTurns: 30` (runaway safety net).
- **Language unified to English**: All agent definitions and communication now English-only (subagents don't interact with users).
- **Observability**: Added `subagent_stop_log.sh` hook that logs all subagent responses to `.claude/logs/subagent_responses.jsonl`, and `/analyze-subagent-logs` skill for manual review.

## Key design decisions

- **`agent_type` field in hook stdin**: Discovered that PreToolUse hooks receive `agent_type` when fired by subagents (absent for orchestrator). This enables subagent-only enforcement in global `settings.json` hooks without affecting the orchestrator.
- **Frontmatter `hooks` field doesn't work for Agent-tool subagents**: Tested and confirmed — hooks defined in agent frontmatter do not fire for subagents spawned via the Agent tool. Pivoted to settings.json + `agent_type` detection.
- **`SubagentStop` uses `last_assistant_message`** (not `final_response`): The documented field name differs from the actual implementation.

## Test plan

- [x] Hook unit tests: all scripts tested with piped JSON (denylist 7 patterns, bash guard 10 patterns, format check 4 patterns)
- [x] SubagentStop fires and correctly reads `last_assistant_message`
- [x] PreToolUse fires for subagents, skips for orchestrator (`agent_type` detection)
- [x] Dry run: rails-developer → react-developer sequential delegation — both return correct format, no preamble
- [x] Existing hooks (RuboCop, tsc, ESLint, progress) unaffected
- [x] `/analyze-subagent-logs` skill produces correct report

🤖 Generated with [Claude Code](https://claude.com/claude-code)