### PR TITLE
feat: add I2 subagent delegation with project-specific codex-review

### DIFF
--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -3,6 +3,8 @@ name: rails-developer
 description: "Rails 8 backend implementer. Handles controllers, models, services, migrations, and Rails tests under delegation from the orchestrator."
 tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
 disallowedTools: Agent
+skills:
+  - hobo-codex-review-rails
 model: sonnet
 color: blue
 maxTurns: 30
@@ -43,7 +45,8 @@ If a must-read file does not exist, record it under Deviations and continue with
 4. **Minimal implementation (Green).** Write the smallest code that turns the tests green. Respect existing patterns (capability-based `can(resource, action)` authorization, `current_user`-scoped resource access, no direct ID access).
 5. **Refactor.** Remove duplication and improve clarity without adding scope. Keep changes within the Plan Excerpt scope.
 6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`).
-7. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
+7. **Review & fix (single pass).** After domain tests pass, run `/codex-review` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
+8. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
 
 ## Scope discipline
 
@@ -81,6 +84,7 @@ Final line: <verbatim last line of the domain test suite output>
 <Dual-purpose section. Use BOTH when appropriate:
  - For sequential patterns (rails → react): the API contract the React agent needs — URL, HTTP method, params, response shape, authorization requirements, error codes.
  - For single-domain, investigation-only, or terminal runs with no downstream agent: follow-up candidates, suspected issues, maintenance risks, or observations worth flagging for the orchestrator.
+ - `/codex-review` results: list what was fixed and what was deferred (with reason) so the orchestrator can triage remaining items.
  - Use "not applicable" only when neither case applies.>
 ```
 

--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -45,7 +45,7 @@ If a must-read file does not exist, record it under Deviations and continue with
 4. **Minimal implementation (Green).** Write the smallest code that turns the tests green. Respect existing patterns (capability-based `can(resource, action)` authorization, `current_user`-scoped resource access, no direct ID access).
 5. **Refactor.** Remove duplication and improve clarity without adding scope. Keep changes within the Plan Excerpt scope.
 6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`).
-7. **Review & fix (single pass).** After domain tests pass, run `/codex-review` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
+7. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-rails` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
 8. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
 
 ## Scope discipline

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -42,7 +42,7 @@ If a must-read file does not exist, record it under Deviations and continue with
 5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA.
 6. **Request route registration.** App.tsx is owned by the orchestrator. Report the required route entry in Handoff Notes for orchestrator (path, element, guards).
 7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`).
-8. **Review & fix (single pass).** After domain tests pass, run `/codex-review` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
+8. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-react` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
 9. **Return in the required format** (see below).
 
 ## Scope discipline

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -3,6 +3,7 @@ name: react-developer
 description: "React Admin SPA (app/javascript/admin/) implementer. Handles pages, components, API client functions, and React tests under delegation from the orchestrator."
 tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
 disallowedTools: Agent
+skills: hobo-codex-review-react
 model: sonnet
 color: green
 maxTurns: 30
@@ -40,7 +41,8 @@ If a must-read file does not exist, record it under Deviations and continue with
 5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA.
 6. **Request route registration.** App.tsx is owned by the orchestrator. Report the required route entry in Handoff Notes for orchestrator (path, element, guards).
 7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`).
-8. **Return in the required format** (see below).
+8. **Review & fix (single pass).** After domain tests pass, run `/codex-review` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
+9. **Return in the required format** (see below).
 
 ## Scope discipline
 
@@ -79,6 +81,7 @@ Final line: <verbatim last line of the test output>
  - Route registration details for App.tsx (path, element, guards) the orchestrator must add.
  - Any other orchestrator-owned edits still required (shared files in the Denylist).
  - Follow-up candidates, suspected issues, or observations worth flagging.
+ - `/codex-review` results: list what was fixed and what was deferred (with reason) so the orchestrator can triage remaining items.
  - Use "not applicable" only when none of the above applies.>
 ```
 

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -3,7 +3,8 @@ name: react-developer
 description: "React Admin SPA (app/javascript/admin/) implementer. Handles pages, components, API client functions, and React tests under delegation from the orchestrator."
 tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
 disallowedTools: Agent
-skills: hobo-codex-review-react
+skills:
+  - hobo-codex-review-react
 model: sonnet
 color: green
 maxTurns: 30

--- a/.claude/skills/hobo-codex-review-architecture/SKILL.md
+++ b/.claude/skills/hobo-codex-review-architecture/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: hobo-codex-review-architecture
+context: fork
+description: Architecture-level code review using Codex CLI for the hobo project. Reviews cross-cutting concerns — domain model integrity, security model consistency, Rails/React boundary alignment, route design, and overall cohesion. Intended for orchestrator use at I4. Triggers are "アーキテクチャレビュー", "全体レビュー", "設計レビュー", "/codex-review-architecture"
+---
+
+# Codex Review — Architecture (hobo)
+
+Architecture-level code review using Codex CLI. Intended for orchestrator use at I4 (Local Review) to catch cross-cutting issues that domain-specific reviews miss.
+
+## Command
+
+codex review "<request>"
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--uncommitted` | Review staged, unstaged, and untracked changes |
+| `--base <BRANCH>` | Review changes against the given base branch |
+| `--commit <SHA>` | Review the changes introduced by a commit |
+| `--title <TITLE>` | Optional commit title to display in the review summary |
+
+## Review focus
+
+- Domain model integrity: changes preserve the core model (projects → tasks → comments, assign, complete, inbox)
+- Security model consistency: `current_user`-scoped access everywhere, no direct ID access, admin capability checks present and correct
+- Rails/React boundary alignment: API contract between Rails controllers and React SPA is consistent (routes, params, response shapes, error codes)
+- Route design: RESTful, no orphan routes, proper namespace nesting (`Api::V1::Admin::`)
+- Separation of concerns: Hotwire for user-facing views, React for admin — no mixing
+- Cross-domain coupling: changes in one domain should not create hidden dependencies on the other
+- Performance: N+1 queries, missing eager loading, unnecessary database round-trips
+- Test coverage gaps: missing edge cases, untested authorization paths
+
+## Execution procedure
+
+1. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`). For I4, typically use `--base main` to review all branch changes.
+2. Build `<request>` incorporating the Review focus checklist above and referencing the key project docs:
+   - `CLAUDE.md` (architecture overview, security model, admin panel rules)
+   - `docs/conventions/ROUTING.md`
+   - `docs/conventions/TESTING.md`
+3. Run the `codex review` command from the project directory.
+4. Report findings grouped by severity (critical / high / medium / low).

--- a/.claude/skills/hobo-codex-review-architecture/SKILL.md
+++ b/.claude/skills/hobo-codex-review-architecture/SKILL.md
@@ -34,7 +34,8 @@ codex review "<request>"
 
 ## Execution procedure
 
-1. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`). For I4, typically use `--base main` to review all branch changes.
+1. Verify `codex` CLI is available (`which codex`). If not found, report "codex CLI not installed — review skipped" and stop.
+2. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`). For I4, typically use `--base main` to review all branch changes.
 2. Build `<request>` incorporating the Review focus checklist above and referencing the key project docs:
    - `CLAUDE.md` (architecture overview, security model, admin panel rules)
    - `docs/conventions/ROUTING.md`

--- a/.claude/skills/hobo-codex-review-architecture/SKILL.md
+++ b/.claude/skills/hobo-codex-review-architecture/SKILL.md
@@ -36,9 +36,9 @@ codex review "<request>"
 
 1. Verify `codex` CLI is available (`which codex`). If not found, report "codex CLI not installed — review skipped" and stop.
 2. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`). For I4, typically use `--base main` to review all branch changes.
-2. Build `<request>` incorporating the Review focus checklist above and referencing the key project docs:
+3. Build `<request>` incorporating the Review focus checklist above and referencing the key project docs:
    - `CLAUDE.md` (architecture overview, security model, admin panel rules)
    - `docs/conventions/ROUTING.md`
    - `docs/conventions/TESTING.md`
-3. Run the `codex review` command from the project directory.
-4. Report findings grouped by severity (critical / high / medium / low).
+4. Run the `codex review` command from the project directory.
+5. Report findings grouped by severity (critical / high / medium / low).

--- a/.claude/skills/hobo-codex-review-rails/SKILL.md
+++ b/.claude/skills/hobo-codex-review-rails/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: hobo-codex-review-rails
+context: fork
+description: Rails backend code review using Codex CLI with hobo project conventions. Focuses on RESTful routing, ActiveRecord query patterns, fat model decomposition, authorization (require_capability!, current_user scoping), and test coverage. Triggers are "Railsレビュー", "バックエンドレビュー", "/codex-review-rails"
+---
+
+# Codex Review — Rails (hobo)
+
+Project-specific Rails backend code review using Codex CLI.
+
+## Command
+
+codex review "<request>"
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--uncommitted` | Review staged, unstaged, and untracked changes |
+| `--base <BRANCH>` | Review changes against the given base branch |
+| `--commit <SHA>` | Review the changes introduced by a commit |
+| `--title <TITLE>` | Optional commit title to display in the review summary |
+
+## Review focus
+
+- RESTful routing: single responsibility controllers, no custom actions — create new controllers instead (see `docs/conventions/ROUTING.md`)
+- ActiveRecord queries: correct use of `present?`/`exists?`/`count`/`size`/`length`, eager loading, N+1 avoidance (see `docs/conventions/ACTIVE_RECORD_QUERIES.md`)
+- Fat model decomposition: concerns, service objects, proper separation of domain logic from controllers (see `docs/conventions/FAT_MODEL_DECOMPOSITION.md`)
+- Authorization: `require_capability!` on all admin endpoints, `current_user`-scoped resource access, no direct ID access, no privilege escalation
+- Admin API test coverage: 4-pattern (401 unauthenticated / 403 regular user / 403 insufficient capability / 200 proper capability)
+- Model-level validations, not controller-level
+- Strong parameters, no mass assignment vulnerabilities
+
+## Execution procedure
+
+1. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
+2. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
+   - `docs/conventions/ROUTING.md`
+   - `docs/conventions/ACTIVE_RECORD_QUERIES.md`
+   - `docs/conventions/FAT_MODEL_DECOMPOSITION.md`
+   - `docs/conventions/TESTING.md`
+3. Run the `codex review` command from the project directory.
+4. Report findings grouped by severity (critical / high / medium / low).

--- a/.claude/skills/hobo-codex-review-rails/SKILL.md
+++ b/.claude/skills/hobo-codex-review-rails/SKILL.md
@@ -33,7 +33,8 @@ codex review "<request>"
 
 ## Execution procedure
 
-1. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
+1. Verify `codex` CLI is available (`which codex`). If not found, report "codex CLI not installed — review skipped" and stop.
+2. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
 2. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
    - `docs/conventions/ROUTING.md`
    - `docs/conventions/ACTIVE_RECORD_QUERIES.md`

--- a/.claude/skills/hobo-codex-review-rails/SKILL.md
+++ b/.claude/skills/hobo-codex-review-rails/SKILL.md
@@ -35,10 +35,10 @@ codex review "<request>"
 
 1. Verify `codex` CLI is available (`which codex`). If not found, report "codex CLI not installed — review skipped" and stop.
 2. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
-2. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
+3. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
    - `docs/conventions/ROUTING.md`
    - `docs/conventions/ACTIVE_RECORD_QUERIES.md`
    - `docs/conventions/FAT_MODEL_DECOMPOSITION.md`
    - `docs/conventions/TESTING.md`
-3. Run the `codex review` command from the project directory.
-4. Report findings grouped by severity (critical / high / medium / low).
+4. Run the `codex review` command from the project directory.
+5. Report findings grouped by severity (critical / high / medium / low).

--- a/.claude/skills/hobo-codex-review-react/SKILL.md
+++ b/.claude/skills/hobo-codex-review-react/SKILL.md
@@ -33,7 +33,8 @@ codex review "<request>"
 
 ## Execution procedure
 
-1. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
+1. Verify `codex` CLI is available (`which codex`). If not found, report "codex CLI not installed — review skipped" and stop.
+2. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
 2. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
    - `docs/conventions/ADMIN_UI.md`
    - `docs/design/admin/README.md`

--- a/.claude/skills/hobo-codex-review-react/SKILL.md
+++ b/.claude/skills/hobo-codex-review-react/SKILL.md
@@ -35,9 +35,9 @@ codex review "<request>"
 
 1. Verify `codex` CLI is available (`which codex`). If not found, report "codex CLI not installed — review skipped" and stop.
 2. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
-2. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
+3. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
    - `docs/conventions/ADMIN_UI.md`
    - `docs/design/admin/README.md`
    - `app/javascript/admin/lib/api.ts` (for existing patterns)
-3. Run the `codex review` command from the project directory.
-4. Report findings grouped by severity (critical / high / medium / low).
+4. Run the `codex review` command from the project directory.
+5. Report findings grouped by severity (critical / high / medium / low).

--- a/.claude/skills/hobo-codex-review-react/SKILL.md
+++ b/.claude/skills/hobo-codex-review-react/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: hobo-codex-review-react
+context: fork
+description: React Admin SPA code review using Codex CLI with hobo project conventions. Focuses on ADMIN_UI conventions, design token usage, api.ts patterns, component structure, and TypeScript correctness. Triggers are "Reactレビュー", "フロントエンドレビュー", "Admin SPAレビュー", "/codex-review-react"
+---
+
+# Codex Review — React Admin SPA (hobo)
+
+Project-specific React Admin SPA code review using Codex CLI.
+
+## Command
+
+codex review "<request>"
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--uncommitted` | Review staged, unstaged, and untracked changes |
+| `--base <BRANCH>` | Review changes against the given base branch |
+| `--commit <SHA>` | Review the changes introduced by a commit |
+| `--title <TITLE>` | Optional commit title to display in the review summary |
+
+## Review focus
+
+- ADMIN_UI conventions: layout rules, color tokens, typography, Do/Don't (see `docs/conventions/ADMIN_UI.md`)
+- Design token usage: `bg-sidebar`, `bg-accent`, `text-slate-800`, `font-syne`, `font-dm-mono` — no hardcoded hex colors (see `docs/design/admin/README.md`)
+- api.ts patterns: fetch wrapper, error handling, type definitions — follow existing conventions in `app/javascript/admin/lib/api.ts`
+- Component structure: pages under `app/javascript/admin/pages/`, shared components under `app/javascript/admin/components/`
+- TypeScript correctness: proper typing, no `any` escape hatches, interface/type definitions
+- No Hotwire/Turbo in admin — admin is React SPA only
+- Reuse existing components and abstractions before creating new ones
+
+## Execution procedure
+
+1. Determine the appropriate review scope (`--uncommitted`, `--base`, or `--commit`).
+2. Build `<request>` incorporating the Review focus checklist above and referencing the convention docs so Codex can consult them:
+   - `docs/conventions/ADMIN_UI.md`
+   - `docs/design/admin/README.md`
+   - `app/javascript/admin/lib/api.ts` (for existing patterns)
+3. Run the `codex review` command from the project directory.
+4. Report findings grouped by severity (critical / high / medium / low).


### PR DESCRIPTION
## Summary

- Add `rails-developer` and `react-developer` subagent definitions for I2 delegation with TDD workflow, strict scope discipline, and structured return format
- Add delegation contract (`docs/process/DELEGATION.md`) defining handoff payloads, invocation patterns (sequential/parallel/single-domain), shared file ownership, and fallback procedures
- Add project-specific codex-review skills (`hobo-codex-review-rails`, `hobo-codex-review-react`, `hobo-codex-review-architecture`) with domain-tailored review focus
- Add single-pass "Review & fix" step to subagent procedures — after domain tests pass, run codex-review once, fix actionable findings, re-run tests
- Add hook-based enforcement for subagent denylist, bash command guards, return format validation, and invocation logging
- Add `start-implementation-phase` and `analyze-subagent-logs` skills

## Test plan

- [x] Smoke test: `skills` frontmatter injection verified — subagents can see injected skill content
- [ ] End-to-end: delegate a real Admin feature (Rails API + React page) via sequential pattern
- [ ] Verify hook enforcement blocks denylist violations and unsafe bash commands
- [ ] Verify codex-review single-pass step runs and reports findings in Handoff Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)