### PR TITLE
feat(admin): add pagination to all admin index endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem "rack-attack"
 
 gem "ice_cube"
 
+gem "pagy", "~> 9.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,7 @@ GEM
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     os (1.1.4)
+    pagy (9.4.0)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -459,6 +460,7 @@ DEPENDENCIES
   jbuilder
   minitest-rails (~> 8.1.0)
   mocha
+  pagy (~> 9.0)
   puma (>= 5.0)
   rack-attack
   rails (~> 8.1.0)

--- a/app/controllers/api/v1/admin/admin_accounts_controller.rb
+++ b/app/controllers/api/v1/admin/admin_accounts_controller.rb
@@ -9,16 +9,11 @@ module Api
         before_action :validate_and_set_roles, only: %i[create]
 
         def index
-          admin_accounts = User.admin_accounts.includes(:roles).search(params[:q]).order(:id)
-          last_logins = AdminLoginHistory
-                        .where(user_id: admin_accounts.select(:id))
-                        .group(:user_id)
-                        .maximum(:created_at)
-          render json: admin_accounts.map { |account|
-            account.as_json(
-              only: %i[id email name created_at updated_at],
-              include: { roles: { only: %i[id name] } },
-            ).merge(last_sign_in_at: last_logins[account.id])
+          scope = User.admin_accounts.includes(:roles).search(params[:q]).order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            admin_accounts: serialize_admin_accounts(records),
+            meta: pagination_meta(pagy),
           }
         end
 
@@ -67,6 +62,19 @@ module Api
         end
 
         private
+
+          def serialize_admin_accounts(records)
+            last_logins = AdminLoginHistory
+                          .where(user_id: records.map(&:id))
+                          .group(:user_id)
+                          .maximum(:created_at)
+            records.map do |account|
+              account.as_json(
+                only: %i[id email name created_at updated_at],
+                include: { roles: { only: %i[id name] } },
+              ).merge(last_sign_in_at: last_logins[account.id])
+            end
+          end
 
           def set_admin_account
             @admin_account = User.admin_accounts.find_by(id: params[:id])

--- a/app/controllers/api/v1/admin/application_controller.rb
+++ b/app/controllers/api/v1/admin/application_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     module Admin
       class ApplicationController < ::ApplicationController
+        include Paginatable
+
         protect_from_forgery with: :exception
 
         skip_before_action :require_login

--- a/app/controllers/api/v1/admin/llm_models_controller.rb
+++ b/app/controllers/api/v1/admin/llm_models_controller.rb
@@ -9,8 +9,12 @@ module Api
         before_action -> { require_capability!("LlmProvider", "delete") }, only: %i[destroy]
 
         def index
-          models = @llm_provider.llm_models.order(:id)
-          render json: models.as_json
+          scope = @llm_provider.llm_models.order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            llm_models: records.as_json,
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/api/v1/admin/llm_providers_controller.rb
+++ b/app/controllers/api/v1/admin/llm_providers_controller.rb
@@ -7,8 +7,12 @@ module Api
         before_action -> { require_capability!("LlmProvider", "write") }, only: %i[update]
 
         def index
-          providers = LlmProvider.order(:id)
-          render json: providers.as_json(except: :api_key_encrypted)
+          scope = LlmProvider.order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            llm_providers: records.as_json(except: :api_key_encrypted),
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/api/v1/admin/permissions_controller.rb
+++ b/app/controllers/api/v1/admin/permissions_controller.rb
@@ -5,8 +5,12 @@ module Api
         before_action :set_permission, only: [:show]
 
         def index
-          permissions = Permission.order(:id)
-          render json: permissions.as_json(only: %i[id resource_type action description])
+          scope = Permission.order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            permissions: records.as_json(only: %i[id resource_type action description]),
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/api/v1/admin/prompt_sets_controller.rb
+++ b/app/controllers/api/v1/admin/prompt_sets_controller.rb
@@ -7,8 +7,12 @@ module Api
         before_action -> { require_capability!("LlmProvider", "write") }, only: %i[create update]
 
         def index
-          prompt_sets = PromptSet.includes(:prompts).order(:id)
-          render json: prompt_sets.as_json(include: { prompts: { except: %i[created_at updated_at] } })
+          scope = PromptSet.includes(:prompts).order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            prompt_sets: records.as_json(include: { prompts: { except: %i[created_at updated_at] } }),
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -7,8 +7,12 @@ module Api
         before_action :protect_system_role, only: %i[update destroy]
 
         def index
-          roles = Role.order(:id)
-          render json: roles.as_json(only: %i[id name description system_role created_at updated_at])
+          scope = Role.order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            roles: records.as_json(only: %i[id name description system_role created_at updated_at]),
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/api/v1/admin/suggestion_configs_controller.rb
+++ b/app/controllers/api/v1/admin/suggestion_configs_controller.rb
@@ -7,8 +7,12 @@ module Api
         before_action -> { require_capability!("LlmProvider", "write") }, only: %i[create update]
 
         def index
-          configs = SuggestionConfig.includes(entries: %i[llm_model prompt_set]).order(id: :desc)
-          render json: configs.map { |c| config_json(c) }
+          scope = SuggestionConfig.includes(entries: %i[llm_model prompt_set]).order(id: :desc)
+          pagy, records = paginate(scope)
+          render json: {
+            suggestion_configs: records.map { |c| config_json(c) },
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -7,8 +7,12 @@ module Api
         before_action -> { require_capability!("User", "write") }, only: %i[create update]
 
         def index
-          users = User.non_admin_accounts.search(params[:q]).order(:id)
-          render json: users.as_json(only: %i[id email name created_at updated_at])
+          scope = User.non_admin_accounts.search(params[:q]).order(:id)
+          pagy, records = paginate(scope)
+          render json: {
+            users: records.as_json(only: %i[id email name created_at updated_at]),
+            meta: pagination_meta(pagy),
+          }
         end
 
         def show

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -8,7 +8,7 @@ module Paginatable
   private
 
     def paginate(collection)
-      pagy(collection, limit: per_page_param)
+      pagy(collection, limit: per_page_param, page: page_param)
     end
 
     def pagination_meta(pagy)
@@ -18,6 +18,10 @@ module Paginatable
         total_count: pagy.count,
         total_pages: pagy.pages,
       }
+    end
+
+    def page_param
+      [params.fetch(:page, 1).to_i, 1].max
     end
 
     def per_page_param

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,26 @@
+module Paginatable
+  extend ActiveSupport::Concern
+
+  included do
+    include Pagy::Backend
+  end
+
+  private
+
+    def paginate(collection)
+      pagy(collection, limit: per_page_param)
+    end
+
+    def pagination_meta(pagy)
+      {
+        page: pagy.page,
+        per_page: pagy.limit,
+        total_count: pagy.count,
+        total_pages: pagy.pages,
+      }
+    end
+
+    def per_page_param
+      params.fetch(:per_page, 25).to_i.clamp(1, 100)
+    end
+end

--- a/app/javascript/admin/components/Pagination.tsx
+++ b/app/javascript/admin/components/Pagination.tsx
@@ -12,8 +12,8 @@ export interface PaginationProps {
 export default function Pagination({ meta, page, perPage, onPageChange, onPerPageChange }: PaginationProps) {
   if (meta.total_count === 0) return null
 
-  const start = (page - 1) * perPage + 1
-  const end = Math.min(page * perPage, meta.total_count)
+  const start = (meta.page - 1) * meta.per_page + 1
+  const end = Math.min(meta.page * meta.per_page, meta.total_count)
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3">

--- a/app/javascript/admin/components/Pagination.tsx
+++ b/app/javascript/admin/components/Pagination.tsx
@@ -1,0 +1,56 @@
+import type { PaginationMeta } from '../lib/api'
+import { PER_PAGE_OPTIONS } from '../hooks/usePagination'
+
+export interface PaginationProps {
+  meta: PaginationMeta
+  page: number
+  perPage: number
+  onPageChange: (page: number) => void
+  onPerPageChange: (perPage: number) => void
+}
+
+export default function Pagination({ meta, page, perPage, onPageChange, onPerPageChange }: PaginationProps) {
+  if (meta.total_count === 0) return null
+
+  const start = (page - 1) * perPage + 1
+  const end = Math.min(page * perPage, meta.total_count)
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <p className="text-xs text-slate-400">
+        Showing {start}–{end} of {meta.total_count}
+      </p>
+      <div className="flex items-center gap-2">
+        <select
+          value={perPage}
+          onChange={e => onPerPageChange(Number(e.target.value))}
+          className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+          aria-label="Rows per page"
+        >
+          {PER_PAGE_OPTIONS.map(n => (
+            <option key={n} value={n}>{n} / page</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+          className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span className="flex items-center px-2 text-xs text-slate-500">
+          {page} / {meta.total_pages}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= meta.total_pages}
+          className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/admin/hooks/usePagination.ts
+++ b/app/javascript/admin/hooks/usePagination.ts
@@ -36,7 +36,7 @@ export function usePagination(): UsePaginationResult {
           else next.set('page', String(n))
           return next
         },
-        { replace: false }
+        { replace: true }
       )
     },
     [setSearchParams]
@@ -53,7 +53,7 @@ export function usePagination(): UsePaginationResult {
           else next.set('per_page', String(valid))
           return next
         },
-        { replace: false }
+        { replace: true }
       )
     },
     [setSearchParams]

--- a/app/javascript/admin/hooks/usePagination.ts
+++ b/app/javascript/admin/hooks/usePagination.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import type { PaginationMeta } from '../lib/api'
+
+export const PER_PAGE_OPTIONS = [25, 50, 100] as const
+export type PerPageOption = typeof PER_PAGE_OPTIONS[number]
+
+const DEFAULT_PER_PAGE: PerPageOption = 25
+
+function isValidPerPage(n: number): n is PerPageOption {
+  return (PER_PAGE_OPTIONS as readonly number[]).includes(n)
+}
+
+export interface UsePaginationResult {
+  page: number
+  perPage: PerPageOption
+  setPage: (n: number) => void
+  setPerPage: (n: number) => void
+  resetPage: () => void
+  clampPage: (meta: PaginationMeta) => void
+}
+
+export function usePagination(): UsePaginationResult {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const page = Math.max(1, Number(searchParams.get('page')) || 1)
+  const rawPerPage = Number(searchParams.get('per_page')) || DEFAULT_PER_PAGE
+  const perPage: PerPageOption = isValidPerPage(rawPerPage) ? rawPerPage : DEFAULT_PER_PAGE
+
+  const setPage = useCallback(
+    (n: number) => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (n <= 1) next.delete('page')
+          else next.set('page', String(n))
+          return next
+        },
+        { replace: false }
+      )
+    },
+    [setSearchParams]
+  )
+
+  const setPerPage = useCallback(
+    (n: number) => {
+      const valid: PerPageOption = isValidPerPage(n) ? n : DEFAULT_PER_PAGE
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          next.delete('page')
+          if (valid === DEFAULT_PER_PAGE) next.delete('per_page')
+          else next.set('per_page', String(valid))
+          return next
+        },
+        { replace: false }
+      )
+    },
+    [setSearchParams]
+  )
+
+  const resetPage = useCallback(() => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev)
+        next.delete('page')
+        return next
+      },
+      { replace: false }
+    )
+  }, [setSearchParams])
+
+  const clampPage = useCallback(
+    (meta: PaginationMeta) => {
+      if (meta.total_pages > 0 && page > meta.total_pages) {
+        setSearchParams(
+          prev => {
+            const next = new URLSearchParams(prev)
+            if (meta.total_pages <= 1) next.delete('page')
+            else next.set('page', String(meta.total_pages))
+            return next
+          },
+          { replace: true }
+        )
+      }
+    },
+    [page, setSearchParams]
+  )
+
+  return { page, perPage, setPage, setPerPage, resetPage, clampPage }
+}
+
+export function useClampPage(meta: PaginationMeta | null, clampPage: (m: PaginationMeta) => void): void {
+  useEffect(() => {
+    if (meta) clampPage(meta)
+  }, [meta, clampPage])
+}

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -8,6 +8,9 @@ export interface PaginationMeta {
   total_pages: number
 }
 
+// TODO: Non-index pages fetch dropdown data with per_page: 100 hard cap.
+//       Add a Sentry warning when meta.total_count > fetched length so we
+//       notice before items are silently omitted from selection UIs.
 export interface PaginationParams {
   page?: number
   per_page?: number

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -1,5 +1,17 @@
 export type ResourceType = 'User' | 'Project' | 'Task' | 'Comment' | 'Admin' | 'LlmProvider' | 'EventLog'
 export type Action = 'read' | 'write' | 'delete' | 'manage'
+
+export interface PaginationMeta {
+  page: number
+  per_page: number
+  total_count: number
+  total_pages: number
+}
+
+export interface PaginationParams {
+  page?: number
+  per_page?: number
+}
 export type Capabilities = Record<ResourceType, Record<Action, boolean>>
 
 export interface SessionUser {
@@ -159,12 +171,19 @@ export const api = {
   },
 }
 
+export interface UserListResponse {
+  users: User[]
+  meta: PaginationMeta
+}
+
 export const usersApi = {
-  list: (params?: { q?: string }, options?: { signal?: AbortSignal }) => {
+  list: (params?: { q?: string } & PaginationParams, options?: { signal?: AbortSignal }) => {
     const query = new URLSearchParams()
     if (params?.q) query.set('q', params.q)
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
     const qs = query.toString()
-    return api.get<User[]>(qs ? `/users?${qs}` : '/users', options)
+    return api.get<UserListResponse>(qs ? `/users?${qs}` : '/users', options)
   },
   get: (id: number) => api.get<User>(`/users/${id}`),
   create: (data: CreateUserInput) => api.post<User>('/users', { user: data }),
@@ -193,12 +212,19 @@ export interface AdminAccountDetail extends User {
   permission_matrix: PermissionMatrix
 }
 
+export interface AdminAccountListResponse {
+  admin_accounts: User[]
+  meta: PaginationMeta
+}
+
 export const adminAccountsApi = {
-  list: (params?: { q?: string }, options?: { signal?: AbortSignal }) => {
+  list: (params?: { q?: string } & PaginationParams, options?: { signal?: AbortSignal }) => {
     const query = new URLSearchParams()
     if (params?.q) query.set('q', params.q)
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
     const qs = query.toString()
-    return api.get<User[]>(qs ? `/admin_accounts?${qs}` : '/admin_accounts', options)
+    return api.get<AdminAccountListResponse>(qs ? `/admin_accounts?${qs}` : '/admin_accounts', options)
   },
   get: (id: number) => api.get<AdminAccountDetail>(`/admin_accounts/${id}`),
   create: (data: CreateAdminAccountInput) =>
@@ -212,8 +238,19 @@ export const adminAccountsApi = {
     api.patch<Role[]>(`/admin_accounts/${id}/roles`, { role_ids: roleIds }),
 }
 
+export interface RoleListResponse {
+  roles: Role[]
+  meta: PaginationMeta
+}
+
 export const rolesApi = {
-  list: () => api.get<Role[]>('/roles'),
+  list: (params?: PaginationParams, options?: { signal?: AbortSignal }) => {
+    const query = new URLSearchParams()
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
+    const qs = query.toString()
+    return api.get<RoleListResponse>(qs ? `/roles?${qs}` : '/roles', options)
+  },
   get: (id: number) => api.get<Role>(`/roles/${id}`),
   create: (data: CreateRoleInput) => api.post<Role>('/roles', { role: data }),
   update: (id: number, data: UpdateRoleInput) => api.patch<Role>(`/roles/${id}`, { role: data }),
@@ -223,8 +260,19 @@ export const rolesApi = {
     api.patch<Permission[]>(`/roles/${id}/permissions`, { permission_ids: permissionIds }),
 }
 
+export interface PermissionListResponse {
+  permissions: Permission[]
+  meta: PaginationMeta
+}
+
 export const permissionsApi = {
-  list: () => api.get<Permission[]>('/permissions'),
+  list: (params?: PaginationParams, options?: { signal?: AbortSignal }) => {
+    const query = new URLSearchParams()
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
+    const qs = query.toString()
+    return api.get<PermissionListResponse>(qs ? `/permissions?${qs}` : '/permissions', options)
+  },
   get: (id: number) => api.get<Permission>(`/permissions/${id}`),
 }
 
@@ -279,8 +327,19 @@ export interface AvailableModel {
   display_name?: string
 }
 
+export interface LlmProviderListResponse {
+  llm_providers: LlmProvider[]
+  meta: PaginationMeta
+}
+
 export const llmProvidersApi = {
-  list: () => api.get<LlmProvider[]>('/llm_providers'),
+  list: (params?: PaginationParams, options?: { signal?: AbortSignal }) => {
+    const query = new URLSearchParams()
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
+    const qs = query.toString()
+    return api.get<LlmProviderListResponse>(qs ? `/llm_providers?${qs}` : '/llm_providers', options)
+  },
   get: (id: number) => api.get<LlmProvider>(`/llm_providers/${id}`),
   update: (id: number, data: UpdateLlmProviderInput) => api.patch<LlmProvider>(`/llm_providers/${id}`, { llm_provider: data }),
   getAvailableModels: (id: number) => api.get<AvailableModel[]>(`/llm_providers/${id}/available_models`),
@@ -356,8 +415,19 @@ export interface UpdateSuggestionConfigInput {
   entries_attributes: EntryInput[]
 }
 
+export interface LlmModelListResponse {
+  llm_models: LlmModel[]
+  meta: PaginationMeta
+}
+
 export const llmModelsApi = {
-  list: (providerId: number) => api.get<LlmModel[]>(`/llm_providers/${providerId}/llm_models`),
+  list: (providerId: number, params?: PaginationParams, options?: { signal?: AbortSignal }) => {
+    const query = new URLSearchParams()
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
+    const qs = query.toString()
+    return api.get<LlmModelListResponse>(qs ? `/llm_providers/${providerId}/llm_models?${qs}` : `/llm_providers/${providerId}/llm_models`, options)
+  },
   get: (providerId: number, id: number) => api.get<LlmModel>(`/llm_providers/${providerId}/llm_models/${id}`),
   create: (providerId: number, data: CreateLlmModelInput) =>
     api.post<LlmModel>(`/llm_providers/${providerId}/llm_models`, { llm_model: data }),
@@ -367,8 +437,19 @@ export const llmModelsApi = {
     api.delete<void>(`/llm_providers/${providerId}/llm_models/${id}`),
 }
 
+export interface PromptSetListResponse {
+  prompt_sets: PromptSet[]
+  meta: PaginationMeta
+}
+
 export const promptSetsApi = {
-  list: () => api.get<PromptSet[]>('/prompt_sets'),
+  list: (params?: PaginationParams, options?: { signal?: AbortSignal }) => {
+    const query = new URLSearchParams()
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
+    const qs = query.toString()
+    return api.get<PromptSetListResponse>(qs ? `/prompt_sets?${qs}` : '/prompt_sets', options)
+  },
   get: (id: number) => api.get<PromptSet>(`/prompt_sets/${id}`),
   create: (data: CreatePromptSetInput) => api.post<PromptSet>('/prompt_sets', { prompt_set: data }),
   update: (id: number, data: UpdatePromptSetInput) => api.patch<PromptSet>(`/prompt_sets/${id}`, { prompt_set: data }),
@@ -385,12 +466,8 @@ export interface EventLog {
   task: { id: number; name: string } | null
 }
 
-export interface EventLogMeta {
-  page: number
-  per_page: number
-  total_count: number
-  total_pages: number
-}
+// EventLogMeta is structurally identical to PaginationMeta.
+export type EventLogMeta = PaginationMeta
 
 export interface EventLogListResponse {
   events: EventLog[]
@@ -422,8 +499,19 @@ export const eventsApi = {
   },
 }
 
+export interface SuggestionConfigListResponse {
+  suggestion_configs: SuggestionConfig[]
+  meta: PaginationMeta
+}
+
 export const suggestionConfigsApi = {
-  list: () => api.get<SuggestionConfig[]>('/suggestion_configs'),
+  list: (params?: PaginationParams, options?: { signal?: AbortSignal }) => {
+    const query = new URLSearchParams()
+    if (params?.page) query.set('page', String(params.page))
+    if (params?.per_page) query.set('per_page', String(params.per_page))
+    const qs = query.toString()
+    return api.get<SuggestionConfigListResponse>(qs ? `/suggestion_configs?${qs}` : '/suggestion_configs', options)
+  },
   get: (id: number) => api.get<SuggestionConfig>(`/suggestion_configs/${id}`),
   create: (data: CreateSuggestionConfigInput) =>
     api.post<SuggestionConfig>('/suggestion_configs', { suggestion_config: data }),

--- a/app/javascript/admin/pages/DashboardPage.tsx
+++ b/app/javascript/admin/pages/DashboardPage.tsx
@@ -12,7 +12,7 @@ export const DashboardPage = () => {
   useEffect(() => {
     Promise.all([
       dashboardApi.get(),
-      llmProvidersApi.list({ per_page: 100 }),
+      llmProvidersApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
     ])
       .then(([dashData, provData]) => {
         setData(dashData)

--- a/app/javascript/admin/pages/DashboardPage.tsx
+++ b/app/javascript/admin/pages/DashboardPage.tsx
@@ -12,7 +12,7 @@ export const DashboardPage = () => {
   useEffect(() => {
     Promise.all([
       dashboardApi.get(),
-      llmProvidersApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
+      llmProvidersApi.list({ per_page: 100 }),
     ])
       .then(([dashData, provData]) => {
         setData(dashData)

--- a/app/javascript/admin/pages/DashboardPage.tsx
+++ b/app/javascript/admin/pages/DashboardPage.tsx
@@ -12,11 +12,11 @@ export const DashboardPage = () => {
   useEffect(() => {
     Promise.all([
       dashboardApi.get(),
-      llmProvidersApi.list(),
+      llmProvidersApi.list({ per_page: 100 }),
     ])
       .then(([dashData, provData]) => {
         setData(dashData)
-        setProviders(provData)
+        setProviders(provData.llm_providers)
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load dashboard'))
   }, [])

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
@@ -14,8 +14,8 @@ export const AdminAccountNewPage = () => {
   const [loadingRoles, setLoadingRoles] = useState(true)
 
   useEffect(() => {
-    rolesApi.list()
-      .then(data => setRoles(data))
+    rolesApi.list({ per_page: 100 })
+      .then(response => setRoles(response.roles))
       .catch(() => setError('Failed to load roles'))
       .finally(() => setLoadingRoles(false))
   }, [])

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
@@ -14,7 +14,7 @@ export const AdminAccountNewPage = () => {
   const [loadingRoles, setLoadingRoles] = useState(true)
 
   useEffect(() => {
-    rolesApi.list({ per_page: 100 })
+    rolesApi.list({ per_page: 100 }) // low-cardinality; won't exceed 100
       .then(response => setRoles(response.roles))
       .catch(() => setError('Failed to load roles'))
       .finally(() => setLoadingRoles(false))

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
@@ -14,7 +14,7 @@ export const AdminAccountNewPage = () => {
   const [loadingRoles, setLoadingRoles] = useState(true)
 
   useEffect(() => {
-    rolesApi.list({ per_page: 100 }) // low-cardinality; won't exceed 100
+    rolesApi.list({ per_page: 100 })
       .then(response => setRoles(response.roles))
       .catch(() => setError('Failed to load roles'))
       .finally(() => setLoadingRoles(false))

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
@@ -13,7 +13,7 @@ export const AdminAccountRolesEditPage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
+      rolesApi.list({ per_page: 100 }),
       adminAccountsApi.getRoles(Number(id)),
     ])
       .then(([rolesResponse, accountRoles]) => {

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
@@ -13,7 +13,7 @@ export const AdminAccountRolesEditPage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list({ per_page: 100 }),
+      rolesApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
       adminAccountsApi.getRoles(Number(id)),
     ])
       .then(([rolesResponse, accountRoles]) => {

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
@@ -13,11 +13,11 @@ export const AdminAccountRolesEditPage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list(),
+      rolesApi.list({ per_page: 100 }),
       adminAccountsApi.getRoles(Number(id)),
     ])
-      .then(([roles, accountRoles]) => {
-        setAllRoles(roles)
+      .then(([rolesResponse, accountRoles]) => {
+        setAllRoles(rolesResponse.roles)
         setSelectedRoleIds(accountRoles.map(r => r.id))
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load roles'))

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountsIndexPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountsIndexPage.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { adminAccountsApi, User } from '../../lib/api'
+import { adminAccountsApi, User, type PaginationMeta } from '../../lib/api'
 import { useAuth } from '../../contexts/AuthContext'
 import Avatar from '../../components/Avatar'
 import Badge from '../../components/Badge'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const AdminAccountsIndexPage = () => {
   const { can } = useAuth()
   const [accounts, setAccounts] = useState<User[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
   const [deleteError, setDeleteError] = useState('')
   const [loading, setLoading] = useState(true)
@@ -16,18 +19,35 @@ export const AdminAccountsIndexPage = () => {
   const canWrite = can('User', 'write')
   const canDelete = can('User', 'delete')
 
+  const { page, perPage, setPage, setPerPage, resetPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
+
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300)
     return () => clearTimeout(timer)
   }, [searchQuery])
 
+  const prevDebouncedQueryRef = useRef(debouncedQuery)
+  useEffect(() => {
+    if (prevDebouncedQueryRef.current !== debouncedQuery) {
+      prevDebouncedQueryRef.current = debouncedQuery
+      resetPage()
+    }
+  }, [debouncedQuery, resetPage])
+
   useEffect(() => {
     const controller = new AbortController()
     setError('')
     setLoading(true)
-    adminAccountsApi.list(debouncedQuery ? { q: debouncedQuery } : undefined, { signal: controller.signal })
-      .then(data => {
-        if (!controller.signal.aborted) setAccounts(data)
+    adminAccountsApi.list(
+      { q: debouncedQuery || undefined, page, per_page: perPage },
+      { signal: controller.signal }
+    )
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setAccounts(response.admin_accounts)
+          setMeta(response.meta)
+        }
       })
       .catch(err => {
         if (!controller.signal.aborted) {
@@ -38,7 +58,7 @@ export const AdminAccountsIndexPage = () => {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [debouncedQuery])
+  }, [debouncedQuery, page, perPage])
 
   const handleRevoke = async (id: number) => {
     if (!confirm('Are you sure you want to revoke admin access? This user will become a regular user.')) return
@@ -193,6 +213,16 @@ export const AdminAccountsIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/llm-providers/LlmModelsIndexPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmModelsIndexPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { llmModelsApi, LlmModel, type PaginationMeta } from '../../lib/api'
 import Badge from '../../components/Badge'
@@ -12,28 +12,33 @@ export const LlmModelsIndexPage = () => {
   const [models, setModels] = useState<LlmModel[]>([])
   const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
+  const [refreshKey, setRefreshKey] = useState(0)
 
   const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
   useClampPage(meta, clampPage)
 
-  const loadModels = useCallback(() => {
-    llmModelsApi.list(providerId, { page, per_page: perPage })
-      .then(response => {
-        setModels(response.llm_models)
-        setMeta(response.meta)
-      })
-      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load models'))
-  }, [providerId, page, perPage])
-
   useEffect(() => {
-    loadModels()
-  }, [loadModels])
+    const controller = new AbortController()
+    llmModelsApi.list(providerId, { page, per_page: perPage }, { signal: controller.signal })
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setModels(response.llm_models)
+          setMeta(response.meta)
+        }
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : 'Failed to load models')
+        }
+      })
+    return () => controller.abort()
+  }, [providerId, page, perPage, refreshKey])
 
   const handleDelete = async (modelId: number) => {
     if (!window.confirm('Are you sure you want to delete this model?')) return
     try {
       await llmModelsApi.delete(providerId, modelId)
-      loadModels()
+      setRefreshKey(k => k + 1)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete model')
     }

--- a/app/javascript/admin/pages/llm-providers/LlmModelsIndexPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmModelsIndexPage.tsx
@@ -1,20 +1,29 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { llmModelsApi, LlmModel } from '../../lib/api'
+import { llmModelsApi, LlmModel, type PaginationMeta } from '../../lib/api'
 import Badge from '../../components/Badge'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const LlmModelsIndexPage = () => {
   const { id } = useParams<{ id: string }>()
   const providerId = Number(id)
 
   const [models, setModels] = useState<LlmModel[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
 
+  const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
+
   const loadModels = useCallback(() => {
-    llmModelsApi.list(providerId)
-      .then(setModels)
+    llmModelsApi.list(providerId, { page, per_page: perPage })
+      .then(response => {
+        setModels(response.llm_models)
+        setMeta(response.meta)
+      })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load models'))
-  }, [providerId])
+  }, [providerId, page, perPage])
 
   useEffect(() => {
     loadModels()
@@ -114,6 +123,16 @@ export const LlmModelsIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/llm-providers/LlmProvidersIndexPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmProvidersIndexPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { llmProvidersApi, LlmProvider } from '../../lib/api'
+import { llmProvidersApi, LlmProvider, type PaginationMeta } from '../../lib/api'
 import Badge from '../../components/Badge'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 const providerColors: Record<string, string> = {
   OpenAI: 'from-emerald-400 to-teal-500',
@@ -16,13 +18,28 @@ function providerGradient(name: string): string {
 
 export const LlmProvidersIndexPage = () => {
   const [providers, setProviders] = useState<LlmProvider[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
 
+  const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
+
   useEffect(() => {
-    llmProvidersApi.list()
-      .then(setProviders)
-      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load providers'))
-  }, [])
+    const controller = new AbortController()
+    llmProvidersApi.list({ page, per_page: perPage }, { signal: controller.signal })
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setProviders(response.llm_providers)
+          setMeta(response.meta)
+        }
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : 'Failed to load providers')
+        }
+      })
+    return () => controller.abort()
+  }, [page, perPage])
 
   if (error) return <p className="text-rose-500">{error}</p>
 
@@ -86,6 +103,16 @@ export const LlmProvidersIndexPage = () => {
           </div>
         ))}
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/permissions/PermissionsIndexPage.tsx
+++ b/app/javascript/admin/pages/permissions/PermissionsIndexPage.tsx
@@ -1,25 +1,38 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { permissionsApi, type Permission } from '../../lib/api'
+import { permissionsApi, type Permission, type PaginationMeta } from '../../lib/api'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const PermissionsIndexPage = () => {
   const [permissions, setPermissions] = useState<Permission[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
 
+  const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
+
   useEffect(() => {
-    const fetchPermissions = async () => {
-      try {
-        const data = await permissionsApi.list()
-        setPermissions(data)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load permissions')
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchPermissions()
-  }, [])
+    const controller = new AbortController()
+    setLoading(true)
+    permissionsApi.list({ page, per_page: perPage }, { signal: controller.signal })
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setPermissions(response.permissions)
+          setMeta(response.meta)
+        }
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : 'Failed to load permissions')
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => controller.abort()
+  }, [page, perPage])
 
   if (loading) return <p>Loading...</p>
 
@@ -63,6 +76,16 @@ export const PermissionsIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/prompt-sets/PromptSetsIndexPage.tsx
+++ b/app/javascript/admin/pages/prompt-sets/PromptSetsIndexPage.tsx
@@ -1,19 +1,37 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { PromptSet, promptSetsApi } from '../../lib/api'
+import { PromptSet, promptSetsApi, type PaginationMeta } from '../../lib/api'
 import Badge from '../../components/Badge'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const PromptSetsIndexPage = () => {
   const [promptSets, setPromptSets] = useState<PromptSet[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
+  const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
+
   useEffect(() => {
-    promptSetsApi.list()
-      .then(setPromptSets)
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false))
-  }, [])
+    const controller = new AbortController()
+    setLoading(true)
+    promptSetsApi.list({ page, per_page: perPage }, { signal: controller.signal })
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setPromptSets(response.prompt_sets)
+          setMeta(response.meta)
+        }
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) setError(err.message)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => controller.abort()
+  }, [page, perPage])
 
   if (loading) return <p className="text-sm text-slate-400">Loading…</p>
   if (error) return <p className="text-sm text-rose-500">{error}</p>
@@ -81,6 +99,16 @@ export const PromptSetsIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/roles/RolePermissionPage.tsx
+++ b/app/javascript/admin/pages/roles/RolePermissionPage.tsx
@@ -15,7 +15,7 @@ export const RolePermissionPage = () => {
     const fetchData = async () => {
       try {
         const [allResponse, assigned] = await Promise.all([
-          permissionsApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
+          permissionsApi.list({ per_page: 100 }),
           rolesApi.getPermissions(Number(id)),
         ])
         setAllPermissions(allResponse.permissions)

--- a/app/javascript/admin/pages/roles/RolePermissionPage.tsx
+++ b/app/javascript/admin/pages/roles/RolePermissionPage.tsx
@@ -14,11 +14,11 @@ export const RolePermissionPage = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [all, assigned] = await Promise.all([
-          permissionsApi.list(),
+        const [allResponse, assigned] = await Promise.all([
+          permissionsApi.list({ per_page: 100 }),
           rolesApi.getPermissions(Number(id)),
         ])
-        setAllPermissions(all)
+        setAllPermissions(allResponse.permissions)
         setAssignedIds(new Set(assigned.map(p => p.id)))
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load permissions')

--- a/app/javascript/admin/pages/roles/RolePermissionPage.tsx
+++ b/app/javascript/admin/pages/roles/RolePermissionPage.tsx
@@ -15,7 +15,7 @@ export const RolePermissionPage = () => {
     const fetchData = async () => {
       try {
         const [allResponse, assigned] = await Promise.all([
-          permissionsApi.list({ per_page: 100 }),
+          permissionsApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
           rolesApi.getPermissions(Number(id)),
         ])
         setAllPermissions(allResponse.permissions)

--- a/app/javascript/admin/pages/roles/RolesIndexPage.tsx
+++ b/app/javascript/admin/pages/roles/RolesIndexPage.tsx
@@ -1,27 +1,39 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { rolesApi, type Role } from '../../lib/api'
+import { rolesApi, type Role, type PaginationMeta } from '../../lib/api'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const RolesIndexPage = () => {
   const navigate = useNavigate()
   const [roles, setRoles] = useState<Role[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
 
-  const fetchRoles = async () => {
-    try {
-      const data = await rolesApi.list()
-      setRoles(data)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load roles')
-    } finally {
-      setLoading(false)
-    }
-  }
+  const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
 
   useEffect(() => {
-    fetchRoles()
-  }, [])
+    const controller = new AbortController()
+    setLoading(true)
+    rolesApi.list({ page, per_page: perPage }, { signal: controller.signal })
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setRoles(response.roles)
+          setMeta(response.meta)
+        }
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : 'Failed to load roles')
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => controller.abort()
+  }, [page, perPage])
 
   const handleDelete = async (id: number, name: string) => {
     if (!window.confirm(`Are you sure you want to delete the role "${name}"?`)) return
@@ -97,6 +109,16 @@ export const RolesIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
@@ -24,16 +24,16 @@ export const SuggestionConfigNewPage = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const [providers, ps] = await Promise.all([
-          llmProvidersApi.list(),
-          promptSetsApi.list(),
+        const [providersResponse, psResponse] = await Promise.all([
+          llmProvidersApi.list({ per_page: 100 }),
+          promptSetsApi.list({ per_page: 100 }),
         ])
-        const activeProviders = providers.filter((p: LlmProvider) => p.active)
-        const allModels = await Promise.all(
-          activeProviders.map((p: LlmProvider) => llmModelsApi.list(p.id))
+        const activeProviders = providersResponse.llm_providers.filter((p: LlmProvider) => p.active)
+        const allModelResponses = await Promise.all(
+          activeProviders.map((p: LlmProvider) => llmModelsApi.list(p.id, { per_page: 100 }))
         )
-        setModels(allModels.flat().filter((m: LlmModel) => m.active))
-        setPromptSets(ps.filter((p: PromptSet) => p.active))
+        setModels(allModelResponses.flatMap(r => r.llm_models).filter((m: LlmModel) => m.active))
+        setPromptSets(psResponse.prompt_sets.filter((p: PromptSet) => p.active))
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load data')
       }

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
@@ -24,7 +24,6 @@ export const SuggestionConfigNewPage = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
-        // All three resources are low-cardinality; won't exceed 100
         const [providersResponse, psResponse] = await Promise.all([
           llmProvidersApi.list({ per_page: 100 }),
           promptSetsApi.list({ per_page: 100 }),

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
@@ -24,6 +24,7 @@ export const SuggestionConfigNewPage = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
+        // All three resources are low-cardinality; won't exceed 100
         const [providersResponse, psResponse] = await Promise.all([
           llmProvidersApi.list({ per_page: 100 }),
           promptSetsApi.list({ per_page: 100 }),

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigsIndexPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigsIndexPage.tsx
@@ -1,19 +1,37 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { SuggestionConfig, suggestionConfigsApi } from '../../lib/api'
+import { SuggestionConfig, suggestionConfigsApi, type PaginationMeta } from '../../lib/api'
 import Badge from '../../components/Badge'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const SuggestionConfigsIndexPage = () => {
   const [configs, setConfigs] = useState<SuggestionConfig[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
+  const { page, perPage, setPage, setPerPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
+
   useEffect(() => {
-    suggestionConfigsApi.list()
-      .then(setConfigs)
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false))
-  }, [])
+    const controller = new AbortController()
+    setLoading(true)
+    suggestionConfigsApi.list({ page, per_page: perPage }, { signal: controller.signal })
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setConfigs(response.suggestion_configs)
+          setMeta(response.meta)
+        }
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) setError(err.message)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => controller.abort()
+  }, [page, perPage])
 
   if (loading) return <p className="text-sm text-slate-400">Loading…</p>
   if (error) return <p className="text-sm text-rose-500">{error}</p>
@@ -85,6 +103,16 @@ export const SuggestionConfigsIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/users/UserRolePage.tsx
+++ b/app/javascript/admin/pages/users/UserRolePage.tsx
@@ -13,11 +13,11 @@ export const UserRolePage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list(),
+      rolesApi.list({ per_page: 100 }),
       usersApi.getRoles(Number(id)),
     ])
-      .then(([roles, userRoles]) => {
-        setAllRoles(roles)
+      .then(([rolesResponse, userRoles]) => {
+        setAllRoles(rolesResponse.roles)
         setSelectedRoleIds(userRoles.map(r => r.id))
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load roles'))

--- a/app/javascript/admin/pages/users/UserRolePage.tsx
+++ b/app/javascript/admin/pages/users/UserRolePage.tsx
@@ -13,7 +13,7 @@ export const UserRolePage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
+      rolesApi.list({ per_page: 100 }),
       usersApi.getRoles(Number(id)),
     ])
       .then(([rolesResponse, userRoles]) => {

--- a/app/javascript/admin/pages/users/UserRolePage.tsx
+++ b/app/javascript/admin/pages/users/UserRolePage.tsx
@@ -13,7 +13,7 @@ export const UserRolePage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list({ per_page: 100 }),
+      rolesApi.list({ per_page: 100 }), // low-cardinality; won't exceed 100
       usersApi.getRoles(Number(id)),
     ])
       .then(([rolesResponse, userRoles]) => {

--- a/app/javascript/admin/pages/users/UsersIndexPage.tsx
+++ b/app/javascript/admin/pages/users/UsersIndexPage.tsx
@@ -1,27 +1,47 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { usersApi, User } from '../../lib/api'
+import { usersApi, User, type PaginationMeta } from '../../lib/api'
 import Avatar from '../../components/Avatar'
+import Pagination from '../../components/Pagination'
+import { usePagination, useClampPage } from '../../hooks/usePagination'
 
 export const UsersIndexPage = () => {
   const [users, setUsers] = useState<User[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
+
+  const { page, perPage, setPage, setPerPage, resetPage, clampPage } = usePagination()
+  useClampPage(meta, clampPage)
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300)
     return () => clearTimeout(timer)
   }, [searchQuery])
 
+  const prevDebouncedQueryRef = useRef(debouncedQuery)
+  useEffect(() => {
+    if (prevDebouncedQueryRef.current !== debouncedQuery) {
+      prevDebouncedQueryRef.current = debouncedQuery
+      resetPage()
+    }
+  }, [debouncedQuery, resetPage])
+
   useEffect(() => {
     const controller = new AbortController()
     setError('')
     setLoading(true)
-    usersApi.list(debouncedQuery ? { q: debouncedQuery } : undefined, { signal: controller.signal })
-      .then(data => {
-        if (!controller.signal.aborted) setUsers(data)
+    usersApi.list(
+      { q: debouncedQuery || undefined, page, per_page: perPage },
+      { signal: controller.signal }
+    )
+      .then(response => {
+        if (!controller.signal.aborted) {
+          setUsers(response.users)
+          setMeta(response.meta)
+        }
       })
       .catch(err => {
         if (!controller.signal.aborted) {
@@ -32,7 +52,7 @@ export const UsersIndexPage = () => {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [debouncedQuery])
+  }, [debouncedQuery, page, perPage])
 
   const handleDelete = async (id: number) => {
     if (!confirm('Are you sure you want to delete this user?')) return
@@ -130,6 +150,16 @@ export const UsersIndexPage = () => {
           </tbody>
         </table>
       </div>
+
+      {meta && (
+        <Pagination
+          meta={meta}
+          page={page}
+          perPage={perPage}
+          onPageChange={setPage}
+          onPerPageChange={setPerPage}
+        />
+      )}
     </div>
   )
 }

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,5 @@
+require "pagy/extras/overflow"
+
+Pagy::DEFAULT[:limit] = 25
+Pagy::DEFAULT[:max_limit] = 100
+Pagy::DEFAULT[:overflow] = :last_page

--- a/test/controllers/api/v1/admin/admin_accounts_controller_test.rb
+++ b/test/controllers/api/v1/admin/admin_accounts_controller_test.rb
@@ -27,7 +27,8 @@ module Api
           get api_v1_admin_admin_accounts_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
+          assert json.key?("admin_accounts")
+          assert json.key?("meta")
         end
 
         test "GET index only returns users with admin permissions" do
@@ -35,7 +36,7 @@ module Api
           get api_v1_admin_admin_accounts_path
           assert_response :success
           json = response.parsed_body
-          emails = json.pluck("email")
+          emails = json["admin_accounts"].pluck("email")
 
           # Admin accounts (have roles with Admin:read)
           assert_includes emails, users(:admin_user).email
@@ -52,7 +53,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_admin_accounts_path
           assert_response :success
-          admin_account = response.parsed_body.first
+          admin_account = response.parsed_body["admin_accounts"].first
           assert admin_account.key?("roles")
           assert_kind_of Array, admin_account["roles"]
           role = admin_account["roles"].first
@@ -64,7 +65,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_admin_accounts_path
           assert_response :success
-          admin_account = response.parsed_body.first
+          admin_account = response.parsed_body["admin_accounts"].first
           assert admin_account.key?("id")
           assert admin_account.key?("email")
           assert admin_account.key?("name")
@@ -77,7 +78,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_admin_accounts_path, params: { q: "Admin User" }
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["admin_accounts"]
           assert json.any? { |u| u["email"] == users(:admin_user).email }
           assert json.none? { |u| u["email"] == users(:regular_user).email }
         end
@@ -86,7 +87,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_admin_accounts_path, params: { q: "norole" }
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["admin_accounts"]
           assert_empty json
         end
 
@@ -332,7 +333,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_admin_accounts_path
           assert_response :success
-          admin_account = response.parsed_body.first
+          admin_account = response.parsed_body["admin_accounts"].first
           assert admin_account.key?("last_sign_in_at")
         end
 

--- a/test/controllers/api/v1/admin/llm_models_controller_test.rb
+++ b/test/controllers/api/v1/admin/llm_models_controller_test.rb
@@ -24,8 +24,9 @@ module Api
           get api_v1_admin_llm_provider_llm_models_path(provider)
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          names = json.pluck("name")
+          assert json.key?("llm_models")
+          assert json.key?("meta")
+          names = json["llm_models"].pluck("name")
           assert_includes names, llm_models(:gpt_turbo).name
           assert_includes names, llm_models(:gpt4).name
         end
@@ -35,7 +36,7 @@ module Api
           provider = llm_providers(:openai)
           get api_v1_admin_llm_provider_llm_models_path(provider)
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["llm_models"]
           provider_ids = json.pluck("llm_provider_id").uniq
           assert_equal [provider.id], provider_ids
         end
@@ -50,7 +51,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_llm_provider_llm_models_path(llm_providers(:openai))
           assert_response :success
-          model = response.parsed_body.first
+          model = response.parsed_body["llm_models"].first
           assert model.key?("id")
           assert model.key?("name")
           assert model.key?("display_name")

--- a/test/controllers/api/v1/admin/llm_providers_controller_test.rb
+++ b/test/controllers/api/v1/admin/llm_providers_controller_test.rb
@@ -23,8 +23,9 @@ module Api
           get api_v1_admin_llm_providers_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          names = json.pluck("name")
+          assert json.key?("llm_providers")
+          assert json.key?("meta")
+          names = json["llm_providers"].pluck("name")
           assert_includes names, llm_providers(:openai).name
           assert_includes names, llm_providers(:anthropic).name
         end
@@ -33,7 +34,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_llm_providers_path
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["llm_providers"]
           json.each do |provider|
             assert_not provider.key?("api_key_encrypted")
           end
@@ -43,7 +44,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_llm_providers_path
           assert_response :success
-          provider = response.parsed_body.first
+          provider = response.parsed_body["llm_providers"].first
           assert provider.key?("id")
           assert provider.key?("name")
           assert provider.key?("active")

--- a/test/controllers/api/v1/admin/permissions_controller_test.rb
+++ b/test/controllers/api/v1/admin/permissions_controller_test.rb
@@ -21,15 +21,16 @@ module Api
           get api_v1_admin_permissions_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          assert json.length.positive?
+          assert json.key?("permissions")
+          assert json.key?("meta")
+          assert json["permissions"].length.positive?
         end
 
         test "GET index response includes expected fields" do
           login_as_admin_api
           get api_v1_admin_permissions_path
           assert_response :success
-          perm = response.parsed_body.first
+          perm = response.parsed_body["permissions"].first
           assert perm.key?("id")
           assert perm.key?("resource_type")
           assert perm.key?("action")

--- a/test/controllers/api/v1/admin/prompt_sets_controller_test.rb
+++ b/test/controllers/api/v1/admin/prompt_sets_controller_test.rb
@@ -28,8 +28,9 @@ module Api
           get api_v1_admin_prompt_sets_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          names = json.pluck("name")
+          assert json.key?("prompt_sets")
+          assert json.key?("meta")
+          names = json["prompt_sets"].pluck("name")
           assert_includes names, prompt_sets(:general).name
           assert_includes names, prompt_sets(:coding).name
         end
@@ -44,7 +45,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_prompt_sets_path
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["prompt_sets"]
           ps = json.find { |p| p["name"] == prompt_sets(:general).name }
           assert ps.key?("prompts")
           assert_kind_of Array, ps["prompts"]

--- a/test/controllers/api/v1/admin/roles_controller_test.rb
+++ b/test/controllers/api/v1/admin/roles_controller_test.rb
@@ -21,8 +21,9 @@ module Api
           get api_v1_admin_roles_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          names = json.pluck("name")
+          assert json.key?("roles")
+          assert json.key?("meta")
+          names = json["roles"].pluck("name")
           assert_includes names, "admin"
         end
 
@@ -30,7 +31,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_roles_path
           assert_response :success
-          role = response.parsed_body.first
+          role = response.parsed_body["roles"].first
           assert role.key?("id")
           assert role.key?("name")
           assert role.key?("description")

--- a/test/controllers/api/v1/admin/suggestion_configs_controller_test.rb
+++ b/test/controllers/api/v1/admin/suggestion_configs_controller_test.rb
@@ -33,8 +33,9 @@ module Api
           get api_v1_admin_suggestion_configs_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          ids = json.pluck("id")
+          assert json.key?("suggestion_configs")
+          assert json.key?("meta")
+          ids = json["suggestion_configs"].pluck("id")
           assert_includes ids, suggestion_configs(:active_config).id
           assert_includes ids, suggestion_configs(:inactive_config).id
         end
@@ -49,7 +50,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_suggestion_configs_path
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["suggestion_configs"]
           ids = json.pluck("id")
           assert_equal ids.sort.reverse, ids
         end
@@ -58,7 +59,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_suggestion_configs_path
           assert_response :success
-          json = response.parsed_body
+          json = response.parsed_body["suggestion_configs"]
           active = json.find { |c| c["id"] == suggestion_configs(:active_config).id }
           assert active.key?("entries")
           assert_kind_of Array, active["entries"]

--- a/test/controllers/api/v1/admin/users_controller_test.rb
+++ b/test/controllers/api/v1/admin/users_controller_test.rb
@@ -23,8 +23,9 @@ module Api
           get api_v1_admin_users_path
           assert_response :success
           json = response.parsed_body
-          assert_kind_of Array, json
-          emails = json.pluck("email")
+          assert json.key?("users")
+          assert json.key?("meta")
+          emails = json["users"].pluck("email")
           # Non-admin users should be included
           assert_includes emails, users(:regular_user).email
           assert_includes emails, users(:no_role_user).email
@@ -39,7 +40,7 @@ module Api
           login_as_admin_api
           get api_v1_admin_users_path
           assert_response :success
-          user = response.parsed_body.first
+          user = response.parsed_body["users"].first
           assert user.key?("id")
           assert user.key?("email")
           assert user.key?("name")
@@ -52,8 +53,44 @@ module Api
           login_as_admin_api
           get api_v1_admin_users_path
           assert_response :success
-          user = response.parsed_body.first
+          user = response.parsed_body["users"].first
           assert_not user.key?("roles")
+        end
+
+        test "GET index response includes pagination meta" do
+          login_as_admin_api
+          get api_v1_admin_users_path
+          assert_response :success
+          meta = response.parsed_body["meta"]
+          assert meta.key?("page")
+          assert meta.key?("per_page")
+          assert meta.key?("total_count")
+          assert meta.key?("total_pages")
+          assert_equal 1, meta["page"]
+        end
+
+        test "GET index respects page and per_page params" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { page: 2, per_page: 1 }
+          assert_response :success
+          meta = response.parsed_body["meta"]
+          assert_equal 2, meta["page"]
+          assert_equal 1, meta["per_page"]
+        end
+
+        test "GET index clamps per_page edge cases" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { per_page: 0 }
+          assert_response :success
+          assert_equal 1, response.parsed_body["meta"]["per_page"]
+
+          get api_v1_admin_users_path, params: { per_page: -1 }
+          assert_response :success
+          assert_equal 1, response.parsed_body["meta"]["per_page"]
+
+          get api_v1_admin_users_path, params: { per_page: 999 }
+          assert_response :success
+          assert_equal 100, response.parsed_body["meta"]["per_page"]
         end
 
         # show
@@ -195,25 +232,27 @@ module Api
           login_as_admin_api
           get api_v1_admin_users_path, params: { q: "Regular" }
           assert_response :success
-          json = response.parsed_body
-          assert json.all? { |u| u["name"]&.downcase&.include?("regular") || u["email"]&.downcase&.include?("regular") }
+          users = response.parsed_body["users"]
+          assert users.all? { |u|
+            u["name"]&.downcase&.include?("regular") || u["email"]&.downcase&.include?("regular")
+          }
         end
 
         test "GET index with q param filters non-admin users by email" do
           login_as_admin_api
           get api_v1_admin_users_path, params: { q: "norole@" }
           assert_response :success
-          json = response.parsed_body
-          assert_equal 1, json.size
-          assert_equal "norole@example.com", json.first["email"]
+          users = response.parsed_body["users"]
+          assert_equal 1, users.size
+          assert_equal "norole@example.com", users.first["email"]
         end
 
         test "GET index with q param does not return admin accounts" do
           login_as_admin_api
           get api_v1_admin_users_path, params: { q: "admin" }
           assert_response :success
-          json = response.parsed_body
-          assert json.none? { |u| u["email"] == users(:admin_user).email }
+          user_list = response.parsed_body["users"]
+          assert user_list.none? { |u| u["email"] == users(:admin_user).email }
         end
 
         # boundary: admin accounts are not accessible via UsersController
@@ -242,7 +281,7 @@ module Api
           get api_v1_admin_users_path, params: { q: "" }
           assert_response :success
           non_admin_count = User.non_admin_accounts.count
-          assert_equal non_admin_count, response.parsed_body.size
+          assert_equal non_admin_count, response.parsed_body["users"].size
         end
       end
     end

--- a/test/controllers/api/v1/admin/users_controller_test.rb
+++ b/test/controllers/api/v1/admin/users_controller_test.rb
@@ -78,6 +78,17 @@ module Api
           assert_equal 1, meta["per_page"]
         end
 
+        test "GET index clamps page edge cases" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { page: 0 }
+          assert_response :success
+          assert_equal 1, response.parsed_body["meta"]["page"]
+
+          get api_v1_admin_users_path, params: { page: -1 }
+          assert_response :success
+          assert_equal 1, response.parsed_body["meta"]["page"]
+        end
+
         test "GET index clamps per_page edge cases" do
           login_as_admin_api
           get api_v1_admin_users_path, params: { per_page: 0 }


### PR DESCRIPTION
## Summary
- Introduce `pagy` gem with `Paginatable` concern to paginate all 8 admin index endpoints (`Users`, `AdminAccounts`, `Roles`, `Permissions`, `LlmProviders`, `LlmModels`, `PromptSets`, `SuggestionConfigs`)
- Each endpoint now returns `{ resource_key: [...], meta: { page, per_page, total_count, total_pages } }` format
- Frontend gets shared `usePagination` hook, `Pagination` component with per-page selector (25/50/100), URL state management, and out-of-range page clamping
- Non-index pages (Dashboard, forms, dropdowns) updated to handle new response format

## Test plan
- [x] `bin/rails test:admin` — 433 runs, 0 failures
- [x] `npx vitest run` — 40 tests, 0 failures
- [x] `bin/rails test:all` — 883 runs, 0 failures, 0 errors
- [ ] Manual browser testing: verify pagination UI on all 8 admin index pages
- [ ] Verify search + pagination interaction on Users and Admin Accounts pages
- [ ] Verify per_page selector (25/50/100) and URL state persistence
- [ ] Verify non-index pages (dropdowns, forms) still work correctly

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)