### PR TITLE
docs(delegation): improve I2 subagent delegation based on #204 learnings

### DIFF
--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -7,7 +7,7 @@ skills:
   - hobo-codex-review-rails
 model: sonnet
 color: blue
-maxTurns: 30
+maxTurns: 50
 ---
 
 You are the **rails-developer** subagent for the `hobo` codebase. You implement Rails 8 backend work under a strict I2 delegation contract.
@@ -53,6 +53,14 @@ If a must-read file does not exist, record it under Deviations and continue with
 - Edit only files listed in the Allowlist. If a file outside the Allowlist needs changes, report it under Deviations.
 - Run only the domain test suite specified in the payload.
 - Implement within the Plan Excerpt scope. Note improvement ideas beyond scope in Handoff Notes.
+
+## Turn Budget Management
+
+- Reserve at least 3-5 turns for domain test execution and review.
+- After completing each implementation unit (a controller, a test file, a component), evaluate whether starting the next unit is safe. Once all Plan Excerpt items are implemented, prioritize running tests and returning immediately rather than pursuing polish.
+- If domain tests pass and all Plan Excerpt items are satisfied, return the structured response promptly — do not spend remaining turns on optional improvements.
+- A partial result with test output and Handoff Notes is far more valuable than exhausting all turns mid-implementation without returning.
+- If tests fail and you cannot fix them quickly, return with failing output in Test Result and describe what remains in Handoff Notes.
 
 ## Required Return Format
 

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -7,7 +7,7 @@ skills:
   - hobo-codex-review-react
 model: sonnet
 color: green
-maxTurns: 30
+maxTurns: 50
 ---
 
 You are the **react-developer** subagent for the `hobo` codebase. You implement React Admin SPA work under a strict I2 delegation contract.
@@ -50,6 +50,14 @@ If a must-read file does not exist, record it under Deviations and continue with
 - Edit only files listed in the Allowlist. If a file outside the Allowlist needs changes, report it under Deviations.
 - Run only the domain test suite specified in the payload.
 - Implement within the Plan Excerpt scope. Note improvement ideas beyond scope in Handoff Notes for orchestrator.
+
+## Turn Budget Management
+
+- Reserve at least 3-5 turns for domain test execution and review.
+- After completing each implementation unit (a controller, a test file, a component), evaluate whether starting the next unit is safe. Once all Plan Excerpt items are implemented, prioritize running tests and returning immediately rather than pursuing polish.
+- If domain tests pass and all Plan Excerpt items are satisfied, return the structured response promptly — do not spend remaining turns on optional improvements.
+- A partial result with test output and Handoff Notes is far more valuable than exhausting all turns mid-implementation without returning.
+- If tests fail and you cannot fix them quickly, return with failing output in Test Result and describe what remains in Handoff Notes.
 
 ## Required Return Format
 

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -31,7 +31,9 @@ At the start of I2 (after I1 branch creation), the orchestrator reads the approv
 Plan touches...
 ├── Rails backend only               → delegate to rails-developer (single)
 ├── React SPA only                   → delegate to react-developer (single)
-├── Rails + React (typical Admin)    → sequential: rails-developer → react-developer
+├── Rails + React (typical Admin)
+│   ├── React needs Rails API output → sequential: rails-developer → react-developer
+│   └── React can work from plan alone → fork-join: parallel rails + react
 ├── Independent Rails + React blocks → parallel: two Agent calls in one message
 └── Neither / too entangled / simple → orchestrator implements directly
 ```
@@ -103,9 +105,40 @@ Step 5: orchestrator verifies return
 Step 6: orchestrator edits app/javascript/admin/App.tsx to register the route
 ```
 
+### Fork-join (parallel Rails + React)
+
+Use when the Plan Excerpt covers both Rails and React within the same feature, but the React agent can implement from the plan alone — it does **not** need to see the Rails agent's implementation output (e.g., the API contract is fully specified in the Plan Excerpt).
+
+**Decision criterion**: "Can react-developer's payload be fully constructed from the Plan Excerpt alone, without any runtime output from rails-developer?" → Yes means fork-join is safe.
+
+**Preconditions**:
+- The orchestrator has prepared shared infrastructure files (e.g., `config/routes.rb`) before dispatching.
+- The API contract (URL, method, request/response shapes) is explicitly stated in both agents' Plan Excerpts.
+- Each agent's Denylist includes the other agent's Allowlist (file-level mutual exclusion).
+
+**Procedure**:
+1. Orchestrator edits shared files (`config/routes.rb`, etc.).
+2. Dispatch two Agent calls in a **single message** so they run concurrently.
+3. Wait for both agents to return (join).
+4. Verify both results: type alignment between API client and controller, no conflicts.
+5. Edit remaining shared files (`app/javascript/admin/App.tsx`, etc.).
+
+**Example**: Issue #204 was a candidate for this pattern — the API contract for all eight Admin endpoints was fully specified in the plan, so react-developer could have worked in parallel with rails-developer.
+
 ### Parallel (independent domains)
 
 Use when Rails and React changes do not depend on each other (e.g., a new background job plus an unrelated Admin page refactor). Dispatch two Agent tool calls in a **single message** so they run concurrently.
+
+### Same-type parallel dispatch
+
+Use when a single domain agent's Allowlist exceeds ~10 files. Split the work into two instances of the same agent type, each with a non-overlapping Allowlist of 5-10 files.
+
+**Preconditions**:
+- Common infrastructure (concerns, migrations, shared modules) is created by the orchestrator before dispatching.
+- Each instance's Allowlist does not overlap with the other (file-level mutual exclusion).
+- Each instance's Denylist includes the other instance's Allowlist plus all shared files.
+
+**Example**: Issue #204's Rails side could have been split into two rails-developer instances — one for Users/AdminAccounts/Roles/Permissions and another for LlmProviders/LlmModels/PromptSets/SuggestionConfigs.
 
 ### Single-domain
 
@@ -144,7 +177,28 @@ If a subagent returns with any of the following, the orchestrator falls back to 
 - **Plan Excerpt deviation flagged in Deviations**. Decide with the user whether the deviation is acceptable; otherwise, reset and redispatch with a clarified payload, or implement directly.
 - **Subagent stops with a blocker report**. Address the blocker in the orchestrator context.
 
+- **maxTurns exhaustion** (agent returned partial result or terminated without Required Return Format). Re-delegate once with a refined payload. The retry payload uses the same Handoff Contract template but updates:
+  - **Goal**: narrowed to remaining scope only
+  - **Allowlist**: narrowed to files not yet completed
+  - **Denylist**: unchanged (same exclusions apply)
+  - **Plan Excerpt**: unchanged (full context preserved)
+  - Append the partial agent's Test Result and Handoff Notes as a **Prior Run Context** section at the end of the payload
+
+  Maximum 1 retry; on retry failure, the orchestrator takes over I2 directly.
+- **Fork-join partial failure** (one agent succeeds, the other fails). Keep the successful agent's result. Apply the relevant Fallback Procedure case (retry or direct implementation) only for the failed agent.
+
 Record fallback events in the PR description so patterns become visible over time.
+
+## Completion Verification
+
+After each subagent returns, the orchestrator verifies:
+
+- [ ] Changed Files are all within the Allowlist (no Denylist violations)
+- [ ] All Plan Excerpt checklist items are satisfied (or listed under Deviations)
+- [ ] Domain tests were executed and green (check Test Result section)
+- [ ] Required Return Format has all 5 sections present in order
+
+If any check fails, apply the relevant Fallback Procedure case.
 
 ## Rollout Notes
 

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -120,7 +120,7 @@ Use when the Plan Excerpt covers both Rails and React within the same feature, b
 1. Orchestrator edits shared files (`config/routes.rb`, etc.).
 2. Dispatch two Agent calls in a **single message** so they run concurrently.
 3. Wait for both agents to return (join).
-4. Verify both results: type alignment between API client and controller, no conflicts.
+4. Verify both results: type alignment between API client and controller, no conflicts. If post-join verification reveals type mismatches (e.g., field name divergence between Rails response and TypeScript types), treat as a sequential dependency — redispatch react-developer with the Rails agent's actual output as context.
 5. Edit remaining shared files (`app/javascript/admin/App.tsx`, etc.).
 
 **Example**: Issue #204 was a candidate for this pattern — the API contract for all eight Admin endpoints was fully specified in the plan, so react-developer could have worked in parallel with rails-developer.

--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -90,17 +90,24 @@ P4. **Confirm the plan** — Confirm with the client if the plan can be proceede
    - → **Done when**: the client has explicitly approved the plan and plan mode is exited.
 P5. **Document the plan** — Document the plan in the issue as a comment. Include everything exactly as it is stated and approved in the plan file.
    - → **Done when**: the approved plan is posted as a comment on the issue, verbatim from the plan file.
-   - **Phase complete.** Recommended: reset the conversation context (`/clear`) here and resume Implementation Phase in a fresh conversation. On resume, follow the Entry Protocol and read `.progress/issue-XXXXX.md` to locate the current phase/step.
+   - **Phase complete.** Recommended: reset the conversation context (`/clear`) here and resume Implementation Phase in a fresh conversation.
+   - **Quick start**: Use the `/start-implementation-phase` skill to handle the Entry Protocol, progress file update, branch creation (I1), and I2 delegation classification automatically. In a new session, paste:
+     ```
+     /start-implementation-phase <issue-number>
+     ```
+     Example: `/start-implementation-phase 293`
 
 #### Implementation Phase
 
 I1. **Create a Git Branch** — Create a feature branch for the issue. ALL feature branches should be derived from the LATEST main branch.
    - → **Done when**: a feature branch derived from the latest `main` is checked out.
 I2. **Implement** — Write code and tests. During development, run the domain test suite for the area you are changing (see `docs/conventions/TESTING.md`). Do not run the full test suite at this stage.
+   - **Docs/config-only changes** (no application code or test files modified): domain test suite may be skipped.
    - **Delegation option (recommended when applicable)**: If the Plan Excerpt spans Rails backend and React Admin SPA, the orchestrator may delegate implementation to the `rails-developer` and `react-developer` subagents. See [I2 Delegation](#i2-delegation-optional) below and `docs/process/DELEGATION.md` for the full contract. Delegation is opt-in — direct implementation remains valid.
-   - → **Done when**: the domain test suite for the changed area passes and the implementation matches the plan.
+   - → **Done when**: the domain test suite for the changed area passes and the implementation matches the plan (or, for docs/config-only changes, the implementation matches the plan).
 I3. **Testing** — Run the full test suite (`bin/rails test:all`) once to ensure all tests pass. In Rails 8 this is a single-process invocation that runs every file matching `test/**/*_test.rb` (unit and system tests share the same process and database connection). The full suite takes 5+ minutes — run it via `Bash` with `run_in_background: true` and wait for the completion notification. Never re-run the suite before the previous run's result is confirmed.
-   - → **Done when**: `bin/rails test:all` exits 0.
+   - **Docs/config-only changes**: skip this step entirely. Proceed directly to I4.
+   - → **Done when**: `bin/rails test:all` exits 0 (or skipped for docs/config-only changes).
 I4. **Local Review** — Ask codex (`/codex-review`) for review the changes.
    - → **Done when**: `/codex-review` has responded and no blocker-level issues remain open.
 I5. **Create a Pull Request** — Create a PR and request review.
@@ -116,9 +123,11 @@ For typo fixes, simple bug fixes, and small single-file changes.
 1. **Create a Git Branch** - Create a feature branch derived from the LATEST main branch.
    - → **Done when**: a feature branch derived from the latest `main` is checked out.
 2. **Implement** - Write code and tests. Run the domain test suite for the area you are changing (see `docs/conventions/TESTING.md`).
-   - → **Done when**: the domain test suite for the changed area passes.
+   - **Docs/config-only changes** (no application code or test files modified): domain test suite may be skipped.
+   - → **Done when**: the domain test suite for the changed area passes (or, for docs/config-only changes, the implementation is complete).
 3. **Testing** - Run the full test suite (`bin/rails test`) once to ensure all tests pass. The full suite takes 5+ minutes — run it via `Bash` with `run_in_background: true` and wait for the completion notification. Never re-run the suite before the previous run's result is confirmed.
-   - → **Done when**: `bin/rails test` exits 0.
+   - **Docs/config-only changes**: skip this step entirely. Proceed directly to step 4.
+   - → **Done when**: `bin/rails test` exits 0 (or skipped for docs/config-only changes).
 4. **Create a Pull Request** - Create a PR and request review.
    - → **Done when**: the PR exists with a proper title/description and CI has been triggered.
 5. **Review Response** - Execute **all sub-steps** of the [Review Response Protocol](#review-response-protocol) in order. Do NOT skip any.
@@ -155,7 +164,7 @@ If a step cannot complete, do NOT proceed. Return to the appropriate earlier ste
 
 ### Completion Criteria
 
-- Tests are written and all pass
+- Tests are written and all pass (docs/config-only changes: test steps may be skipped)
 - A Pull Request is created
 - **Review Response** step has been performed (review fetched, findings summarized, user consulted)
 


### PR DESCRIPTION
## Summary
- Raise `maxTurns` from 30 to 50 for both `rails-developer` and `react-developer` agents
- Add **Turn Budget Management** section to both agents (reserve turns for tests, prefer partial results over exhaustion)
- Expand DELEGATION.md Decision Flow with **fork-join** pattern (parallel Rails + React when API contract is plan-defined)
- Add **same-type parallel dispatch** pattern (split large Allowlists across multiple instances)
- Add **maxTurns exhaustion retry** and **fork-join partial failure** to Fallback Procedure
- Add **Completion Verification** checklist for orchestrator post-delegation checks
- Update WORKFLOW.md with `/start-implementation-phase` quick start and docs/config-only test skip rules

Closes #293

## Test plan
- [x] Full test suite passes (884 runs, 0 failures, 0 errors)
- [ ] Verify DELEGATION.md section ordering is logically consistent
- [ ] Verify both agent definitions have identical Turn Budget Management text

🤖 Generated with [Claude Code](https://claude.com/claude-code)