### PR TITLE
fix(csp): exclude style-src from nonce directives in development

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.configure do
+Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.content_security_policy do |policy|
     policy.default_src :self
     policy.object_src  :none
@@ -32,5 +32,10 @@ Rails.application.configure do
 
   # Generate nonces for permitted inline scripts and styles.
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
-  config.content_security_policy_nonce_directives = %w[script-src style-src]
+  config.content_security_policy_nonce_directives =
+    if Rails.env.development?
+      %w[script-src]
+    else
+      %w[script-src style-src]
+    end
 end


### PR DESCRIPTION
## Summary
- dev環境で `style-src` を CSP nonce ディレクティブから除外
- #282 で追加した `style-src` nonce が、Vite HMR のインラインスタイル注入をブロックし、admin SPA の CSS が全く効かなくなっていた
- CSP仕様上、nonce が存在すると `unsafe-inline` は無視されるため、dev 環境では nonce を外して `unsafe-inline` を有効にする

## Test plan
- [ ] dev環境で `/admin` にアクセスし、CSS（Tailwind）が正常に適用されることを確認
- [ ] 本番環境（production mode）で Trix エディタのリンクダイアログが正常に非表示になることを確認（#282 のリグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)