### PR TITLE
docs(delegation): overhaul I2 fork-join contract from issue #295 retro

### DIFF
--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -23,7 +23,7 @@ You are the **rails-developer** subagent for the `hobo` codebase. You implement 
 
 Before touching any file, read these in order:
 
-1. The orchestrator-provided payload (Issue / Goal / Plan Excerpt / Allowlist / Denylist / Domain Tests / Done When / Required Return Format).
+1. The orchestrator-provided payload (Issue / Goal / Plan Excerpt / Scope / Denylist / Domain Tests / Done When / Required Return Format).
 2. `docs/process/DELEGATION.md` — the delegation contract you operate under.
 3. `CLAUDE.md` (root) — especially the Admin Panel section and "Adding a new Admin feature" checklist when the task is an Admin API.
 4. `docs/conventions/TESTING.md` — domain test suite commands and testing discipline.
@@ -34,23 +34,25 @@ If a must-read file does not exist, record it under Deviations and continue with
 
 ## Procedure
 
-1. **Parse the payload.** Restate the Goal, Allowlist, Denylist, and Domain Tests in a one-line summary (internal — do not include in return unless Deviations).
+1. **Parse the payload.** Restate the Goal, Scope (expected files), Denylist, and Domain Tests in a one-line summary (internal — do not include in return unless Deviations).
 2. **Understand before editing.** Read any existing files you will modify. Use Grep / Glob to locate related patterns. Always read the target code before proposing changes.
 3. **Write tests first (Red).** Add or extend Minitest tests under `test/` that express the acceptance criteria in the Plan Excerpt. For Admin API controllers, include **all four authorization patterns**:
    - Unauthenticated → **401**
-   - Regular user → **403**
+   - Regular user → **401** (admin and user sessions are separate — `Api::V1::Admin::ApplicationController#require_admin_access` returns 401 when `admin_logged_in?` is false, **not** 403)
    - Admin with insufficient capability → **403**
    - Admin with proper capability → **200** plus response body assertions
    - Place Admin API tests under `test/controllers/api/v1/admin/` per CLAUDE.md.
 4. **Minimal implementation (Green).** Write the smallest code that turns the tests green. Respect existing patterns (capability-based `can(resource, action)` authorization, `current_user`-scoped resource access, no direct ID access).
 5. **Refactor.** Remove duplication and improve clarity without adding scope. Keep changes within the Plan Excerpt scope.
 6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`).
-7. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-rails` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
+7. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-rails` against the diff once. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
 8. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
 
 ## Scope discipline
 
-- Edit only files listed in the Allowlist. If a file outside the Allowlist needs changes, report it under Deviations.
+- **Domain boundaries, not file allowlists.** Your domain is `app/controllers/**`, `app/models/**`, `app/services/**`, `app/jobs/**`, `db/migrate/**`, `test/controllers/**`, `test/models/**`, `test/services/**`, `test/jobs/**`, and non-React parts of `test/system/**` (see `docs/process/DELEGATION.md` → Shared File Ownership). You may create, modify, or delete files anywhere inside your domain as the implementation requires.
+- **The `Scope` section in the payload is a hint, not a hard constraint.** It lists the files the orchestrator expects you to touch. If you need a concern, service, helper, or migration that wasn't listed, add it — that is not a Deviation. Record meaningful additions in `Changed Files` and, if they materially change the approach, note the reasoning in `Handoff Notes`.
+- **You MUST NOT edit anything in the `Denylist`.** Reading Denylist files to understand existing patterns is expected and encouraged; only writes are forbidden. If you genuinely need to edit a Denylist file, stop and report it under Deviations.
 - Run only the domain test suite specified in the payload.
 - Implement within the Plan Excerpt scope. Note improvement ideas beyond scope in Handoff Notes.
 
@@ -101,7 +103,7 @@ Always include every section header. If a section is empty, write `none` or `not
 ## Self-check before returning
 
 - All domain test suite tests pass.
-- Authorization 4-pattern covered (for Admin API work).
-- Every edited file is within the Allowlist.
+- Authorization 4-pattern covered (for Admin API work): 401 / 401 / 403 / 200.
+- No edited file violates the Denylist (additions within your domain are allowed even when outside the payload's `Scope` hint).
 - All Plan Excerpt checklist items satisfied (or listed under Deviations).
 - Response starts with `### Summary` and all five sections are present in order.

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -23,31 +23,34 @@ You are the **react-developer** subagent for the `hobo` codebase. You implement 
 
 Before touching any file, read these in order:
 
-1. The orchestrator-provided payload (Issue / Goal / Plan Excerpt / Allowlist / Denylist / Domain Tests / Done When / Required Return Format), **including any `Handoff Notes for react-developer` carried over from rails-developer** — the API contract there is authoritative.
+1. The orchestrator-provided payload (Issue / Goal / Plan Excerpt / Scope / Denylist / Domain Tests / Done When / Required Return Format), **including any `Handoff Notes for react-developer` carried over from rails-developer** — the API contract there is authoritative.
 2. `docs/process/DELEGATION.md` — the delegation contract you operate under.
-3. `CLAUDE.md` (root) — especially the Admin Panel section and the "Adding a new Admin feature" checklist (your responsibility is steps 3 - 5: TypeScript types, API functions, React pages, route registration request).
+3. `CLAUDE.md` (root) — especially the Admin Panel section and the "Adding a new Admin feature" checklist. Your responsibility covers steps 3 - 5 (TypeScript types, API functions, React pages) **and** the route registration in `App.tsx` and the nav entry in `AdminLayout.tsx`.
 4. `docs/conventions/ADMIN_UI.md` — tech stack, color tokens, typography, layout rules, Do/Don't.
 5. `docs/design/admin/README.md` — the design system index; follow the linked topic docs when building new components.
 6. `app/javascript/admin/lib/api.ts` — the existing API client surface. Follow its conventions (fetch wrapper, error handling, type definitions).
-7. `app/javascript/admin/App.tsx` — read only, to understand existing routes. You will NOT edit this file; the orchestrator registers new routes.
+7. `app/javascript/admin/App.tsx` — read first to understand existing routes and guards. You **own** route registration for your feature and will edit this file as part of your work.
+8. `app/javascript/admin/components/layouts/AdminLayout.tsx` — read first to understand the nav item pattern. You own nav additions for your feature.
 
 If a must-read file does not exist, record it under Deviations and continue with the rest.
 
 ## Procedure
 
-1. **Parse the payload.** Restate the Goal, Allowlist, Denylist, and the Rails API contract from Handoff Notes (URL / method / params / response shape).
+1. **Parse the payload.** Restate the Goal, Scope (expected files), Denylist, and the Rails API contract from Handoff Notes (URL / method / params / response shape).
 2. **Explore existing patterns.** Grep for similar pages / components / api.ts functions. Reuse what is there instead of inventing new abstractions.
 3. **Add types and API function to `app/javascript/admin/lib/api.ts`.** Extend the existing patterns (fetch wrapper, error handling, type definitions).
 4. **Build page / component.** Place new pages under `app/javascript/admin/pages/` and shared components under `app/javascript/admin/components/` per the existing directory structure. Use design tokens (`bg-sidebar`, `bg-accent`, `text-slate-800`, `font-syne`, `font-dm-mono`).
 5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA.
-6. **Request route registration.** App.tsx is owned by the orchestrator. Report the required route entry in Handoff Notes for orchestrator (path, element, guards).
+6. **Register the route and nav item.** Add the route to `app/javascript/admin/App.tsx` (path, element, guards) and the nav entry to `app/javascript/admin/components/layouts/AdminLayout.tsx`, following the existing patterns. For fork-join, the orchestrator has already created a stub route + temporary controller in `config/routes.rb`; your job is the frontend wiring.
 7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`).
-8. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-react` against the diff once. Fix actionable findings within the Allowlist scope, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
+8. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-react` against the diff once. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
 9. **Return in the required format** (see below).
 
 ## Scope discipline
 
-- Edit only files listed in the Allowlist. If a file outside the Allowlist needs changes, report it under Deviations.
+- **Domain boundaries, not file allowlists.** Your domain is the entire `app/javascript/admin/**` tree — pages, components (including `components/layouts/AdminLayout.tsx`), contexts, `lib/api.ts`, `App.tsx`, and `**/__tests__/**`. You may create, modify, or delete files anywhere inside your domain as the implementation requires.
+- **The `Scope` section in the payload is a hint, not a hard constraint.** It lists the files the orchestrator expects you to touch. If you need a new component, hook, or type file that wasn't listed, add it — that is not a Deviation. Record meaningful additions in `Changed Files` and, if they materially change the approach, note the reasoning in `Handoff Notes for orchestrator`.
+- **You MUST NOT edit anything in the `Denylist`.** Reading Denylist files (e.g., Rails controllers to understand the API contract) is expected and encouraged; only writes are forbidden. If you genuinely need to edit a Denylist file, stop and report it under Deviations.
 - Run only the domain test suite specified in the payload.
 - Implement within the Plan Excerpt scope. Note improvement ideas beyond scope in Handoff Notes for orchestrator.
 
@@ -99,7 +102,7 @@ Always include every section header. If a section is empty, write `none` or `not
 ## Self-check before returning
 
 - All domain test suite tests pass.
-- Every edited file is within the Allowlist.
+- No edited file violates the Denylist (additions within `app/javascript/admin/**` are allowed even when outside the payload's `Scope` hint).
 - Design tokens used (bg-sidebar, bg-accent, text-slate-800, etc.).
-- Handoff Notes for orchestrator includes App.tsx route entry (when applicable).
+- Route registered in `App.tsx` and nav item added to `AdminLayout.tsx` (when applicable), and both files listed in `Changed Files`.
 - Response starts with `### Summary` and all five sections are present in order.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The admin panel (`/admin`) is a React SPA. When modifying the Admin area, do NOT
 
 **Tests** — place under `test/controllers/api/v1/admin/`, always cover:
 1. **Unauthenticated access** → 401
-2. **Regular user access** → 403
+2. **Regular user access** → 401 (`Api::V1::Admin::ApplicationController#require_admin_access` returns 401 when `admin_logged_in?` is false — admin and user sessions are separate)
 3. **Admin with insufficient capability** → 403
 4. **Admin with proper capability** → 200 + response body assertions
 

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -170,11 +170,11 @@ This table defines each agent's **domain**. An agent may freely edit any file in
 
 | Path | Owner |
 |---|---|
-| `config/routes.rb` | orchestrator (stub route at Pre-Fork; rails-developer may refine within an already-registered namespace) |
+| `config/routes.rb` | orchestrator (see Fork-join Procedure Step 1 for the Pre-Fork stub) |
 | `.progress/issue-*.md` | orchestrator |
 | `CLAUDE.md`, `docs/**` | orchestrator |
 | `.claude/**` (agents / skills / settings) | orchestrator |
-| `app/controllers/**`, `app/models/**`, `app/services/**`, `app/jobs/**`, `db/migrate/**`, `test/controllers/**`, `test/models/**`, `test/services/**`, `test/jobs/**`, `test/system/**` (non-React) | rails-developer |
+| `app/controllers/**`, `app/models/**`, `app/services/**`, `app/jobs/**`, `db/migrate/**`, `test/controllers/**`, `test/models/**`, `test/services/**`, `test/jobs/**`, `test/system/**` (non-React) | rails-developer (orchestrator may stub a temporary controller under `app/controllers/api/v1/admin/**` at Pre-Fork for fork-join — rails-developer then overwrites it with the real implementation) |
 | `app/javascript/admin/**` — including `App.tsx` (route registration), `components/layouts/AdminLayout.tsx` (nav item), `pages/**`, `components/**`, `contexts/**`, `lib/api.ts`, `**/__tests__/**` | react-developer |
 
 When a task requires editing an orchestrator-owned file, the orchestrator performs the edit itself before or after the delegation, never inside the subagent payload. For fork-join, the orchestrator's Pre-Fork edit is limited to the `config/routes.rb` stub + a temporary controller (see Fork-join Procedure Step 1).

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -16,7 +16,7 @@ Two subagents are bundled with this repository:
 | Writing the code and tests that fulfill the approved Plan Excerpt | Planning Phase (P1 - P5) |
 | Running the **domain test suite** for the changed area | Running the full test suite (I3) |
 | Reporting results in the required return format | Creating branches (I1) |
-| Staying inside the Allowlist / Denylist | Running `/codex-review` (I4) |
+| Respecting the Denylist (Scope is a guide, not a constraint) | Running `/codex-review` (I4) |
 | | Creating PRs (I5) or Review Response (I6) |
 | | Updating `.progress/issue-*.md` |
 | | Editing `CLAUDE.md` or `docs/**` |
@@ -54,14 +54,18 @@ Every subagent invocation **MUST** pass a payload containing all of the followin
 ## Plan Excerpt
 <copy the relevant portion of the approved plan here — do not paraphrase>
 
-## Allowlist (files this agent may edit)
+## Scope (expected files — guide, not constraint)
 - <explicit paths; globs permitted>
+# Note: Scope is an expected-files hint. You may add or remove files within
+# your own domain (see Shared File Ownership) as the implementation requires.
+# Anything in the Denylist below remains off-limits for editing.
 
-## Denylist (files this agent MUST NOT touch)
+## Denylist (MUST NOT edit — reading is allowed and encouraged)
 - config/routes.rb              # orchestrator edits this separately
-- app/javascript/admin/App.tsx  # orchestrator edits this separately
 - .progress/**
 - <paths owned by the other domain agent>
+# Reading Denylist files to understand existing patterns is expected;
+# only writes/edits/deletes are forbidden.
 
 ## Domain Tests to Run
 bin/rails test <path>            # for rails-developer
@@ -69,9 +73,9 @@ bin/rails test <path>            # for rails-developer
 
 ## Done When
 - Domain tests green
-- (Rails) Authorization 4-pattern coverage (401 / 403 / 403 / 200)
+- (Rails) Authorization 4-pattern coverage (401 / 401 / 403 / 200)
 - Every checklist item in Plan Excerpt is satisfied
-- No Denylist violations
+- No Denylist violations (additions within your own domain are allowed)
 
 ## Required Return Format
 ### Summary                 # 2-4 sentences; inventories belong HERE
@@ -89,6 +93,15 @@ bin/rails test <path>            # for rails-developer
 
 The Required Return Format section is copied verbatim from the agent definition so subagents return machine-parseable results.
 
+### Payload Quality Rules
+
+A payload is an **instruction** to the agent, not the orchestrator's thinking log. Clean, verified payloads are the single biggest lever on delegation quality.
+
+- **No unverified assumptions.** Anything about fixture permission structure, helper existence, existing routes, or conventions must be confirmed with `grep` / `read` **before** dispatch. Include only facts you verified.
+- **No reasoning residue.** Phrases like "wait, actually..." or "let me reconsider..." belong to your working memory, never to the payload. If you catch yourself writing them, rewrite the payload to state the final conclusion only.
+- **Pre-existing errors go into `Done When`.** If there are known-broken type errors, flaky tests, or warnings in the area the agent will touch, list them under `Done When` as "the following pre-existing errors may be ignored" so the agent does not spend turns chasing them.
+- **Copy, don't paraphrase.** When quoting the Plan Excerpt or an API contract, copy verbatim from the approved plan. Paraphrasing introduces drift between what the user approved and what the agent implements.
+
 ## Invocation Patterns
 
 ### Sequential (Rails → React, typical Admin feature)
@@ -100,9 +113,10 @@ Step 1: orchestrator → Agent(rails-developer) with payload
 Step 2: orchestrator verifies return (tests green, no Deviations blockers)
 Step 3: orchestrator edits config/routes.rb to register new routes
 Step 4: orchestrator → Agent(react-developer) with payload including
-        the API contract from rails-developer's Handoff Notes
-Step 5: orchestrator verifies return
-Step 6: orchestrator edits app/javascript/admin/App.tsx to register the route
+        the API contract from rails-developer's Handoff Notes.
+        react-developer owns App.tsx route registration and AdminLayout.tsx
+        nav item additions as part of its domain work.
+Step 5: orchestrator runs the Completion Verification checklist on the react return
 ```
 
 ### Fork-join (parallel Rails + React)
@@ -112,16 +126,18 @@ Use when the Plan Excerpt covers both Rails and React within the same feature, b
 **Decision criterion**: "Can react-developer's payload be fully constructed from the Plan Excerpt alone, without any runtime output from rails-developer?" → Yes means fork-join is safe.
 
 **Preconditions**:
-- The orchestrator has prepared shared infrastructure files (e.g., `config/routes.rb`) before dispatching.
 - The API contract (URL, method, request/response shapes) is explicitly stated in both agents' Plan Excerpts.
-- Each agent's Denylist includes the other agent's Allowlist (file-level mutual exclusion).
+- Each agent's Denylist includes the paths owned by the other domain (file-level mutual exclusion — see Shared File Ownership).
 
-**Procedure**:
-1. Orchestrator edits shared files (`config/routes.rb`, etc.).
-2. Dispatch two Agent calls in a **single message** so they run concurrently.
-3. Wait for both agents to return (join).
-4. Verify both results: type alignment between API client and controller, no conflicts. If post-join verification reveals type mismatches (e.g., field name divergence between Rails response and TypeScript types), treat as a sequential dependency — redispatch react-developer with the Rails agent's actual output as context.
-5. Edit remaining shared files (`app/javascript/admin/App.tsx`, etc.).
+**Procedure** (Pre-Fork is intentionally lean — keep orchestrator work to stub + verify):
+
+1. **Pre-Fork — stub route + temporary controller.** The orchestrator adds a stub route to `config/routes.rb` and creates a temporary controller returning a fixed JSON response matching the planned contract. This is the only shared-file edit the orchestrator performs before dispatch; do **not** touch `App.tsx` or `AdminLayout.tsx` here — those belong to react-developer.
+2. **Verify routing.** Run `bin/rails routes | grep <resource>` to confirm the stub is wired up correctly. Fix typos now, not after dispatch.
+3. **Dispatch** two Agent calls in a **single message** so they run concurrently:
+   - `rails-developer` overwrites the temporary controller with the real implementation and adds tests.
+   - `react-developer` owns `app/javascript/admin/App.tsx` (route registration), `app/javascript/admin/components/layouts/AdminLayout.tsx` (nav item), the page, and the `api.ts` additions.
+4. **Wait for both agents to return (join).**
+5. **Post-Join Verification** — run the Completion Verification checklist explicitly for **each** agent (see `Completion Verification` section below). If type mismatches surface between the Rails response and the TypeScript types (e.g., field name divergence), treat as a sequential dependency and redispatch react-developer with the Rails agent's actual output as context.
 
 **Example**: Issue #204 was a candidate for this pattern — the API contract for all eight Admin endpoints was fully specified in the plan, so react-developer could have worked in parallel with rails-developer.
 
@@ -131,12 +147,12 @@ Use when Rails and React changes do not depend on each other (e.g., a new backgr
 
 ### Same-type parallel dispatch
 
-Use when a single domain agent's Allowlist exceeds ~10 files. Split the work into two instances of the same agent type, each with a non-overlapping Allowlist of 5-10 files.
+Use when a single domain agent's expected Scope exceeds ~10 files. Split the work into two instances of the same agent type, each with a non-overlapping Scope of 5-10 files.
 
 **Preconditions**:
-- Common infrastructure (concerns, migrations, shared modules) is created by the orchestrator before dispatching.
-- Each instance's Allowlist does not overlap with the other (file-level mutual exclusion).
-- Each instance's Denylist includes the other instance's Allowlist plus all shared files.
+- Common infrastructure (concerns, migrations, shared modules) is created by the orchestrator before dispatching **if** both instances would otherwise need to create it concurrently. Otherwise each instance adds what it needs within its own domain.
+- Each instance's Scope does not overlap with the other (file-level mutual exclusion of expected work).
+- Each instance's Denylist includes the files the other instance is expected to own plus all shared files, so concurrent writes cannot collide.
 
 **Example**: Issue #204's Rails side could have been split into two rails-developer instances — one for Users/AdminAccounts/Roles/Permissions and another for LlmProviders/LlmModels/PromptSets/SuggestionConfigs.
 
@@ -150,19 +166,18 @@ The orchestrator may implement I2 directly when delegation would add more overhe
 
 ## Shared File Ownership
 
-Files that both domains (or both agents) might naturally want to touch are **owned by the orchestrator** and appear in every subagent's Denylist. This makes parallel dispatch structurally safe.
+This table defines each agent's **domain**. An agent may freely edit any file inside its own domain (the Scope section of the payload is a guide, not a hard limit). Files owned by another agent or by the orchestrator go into the Denylist and must not be edited — reading them is always allowed and often encouraged to understand existing patterns.
 
 | Path | Owner |
 |---|---|
-| `config/routes.rb` | orchestrator (even when a new Rails controller is added) |
-| `app/javascript/admin/App.tsx` | orchestrator (route registration) |
+| `config/routes.rb` | orchestrator (stub route at Pre-Fork; rails-developer may refine within an already-registered namespace) |
 | `.progress/issue-*.md` | orchestrator |
 | `CLAUDE.md`, `docs/**` | orchestrator |
 | `.claude/**` (agents / skills / settings) | orchestrator |
 | `app/controllers/**`, `app/models/**`, `app/services/**`, `app/jobs/**`, `db/migrate/**`, `test/controllers/**`, `test/models/**`, `test/services/**`, `test/jobs/**`, `test/system/**` (non-React) | rails-developer |
-| `app/javascript/admin/pages/**`, `app/javascript/admin/components/**`, `app/javascript/admin/contexts/**`, `app/javascript/admin/lib/api.ts`, `app/javascript/admin/**/__tests__/**` | react-developer |
+| `app/javascript/admin/**` — including `App.tsx` (route registration), `components/layouts/AdminLayout.tsx` (nav item), `pages/**`, `components/**`, `contexts/**`, `lib/api.ts`, `**/__tests__/**` | react-developer |
 
-When a task requires editing an orchestrator-owned file, the orchestrator performs the edit itself before or after the delegation, never inside the subagent payload.
+When a task requires editing an orchestrator-owned file, the orchestrator performs the edit itself before or after the delegation, never inside the subagent payload. For fork-join, the orchestrator's Pre-Fork edit is limited to the `config/routes.rb` stub + a temporary controller (see Fork-join Procedure Step 1).
 
 ## Progress File Responsibility
 
@@ -179,26 +194,35 @@ If a subagent returns with any of the following, the orchestrator falls back to 
 
 - **maxTurns exhaustion** (agent returned partial result or terminated without Required Return Format). Re-delegate once with a refined payload. The retry payload uses the same Handoff Contract template but updates:
   - **Goal**: narrowed to remaining scope only
-  - **Allowlist**: narrowed to files not yet completed
+  - **Scope**: narrowed to files not yet completed
   - **Denylist**: unchanged (same exclusions apply)
   - **Plan Excerpt**: unchanged (full context preserved)
   - Append the partial agent's Test Result and Handoff Notes as a **Prior Run Context** section at the end of the payload
 
   Maximum 1 retry; on retry failure, the orchestrator takes over I2 directly.
+- **Return Format violation** (agent returned results but not in the 5-section structure, or with truncated / preamble-leaking output). The implementation may still be correct — do **not** assume failure.
+  1. Orchestrator verifies the remaining three Completion Verification items (Denylist / Plan items / Domain tests) directly by reading changed files and re-running the domain test suite locally.
+  2. If all three pass, continue without re-dispatch. If any fails, apply the relevant Fallback case (domain tests failing / Denylist violation / Plan Excerpt deviation).
+  3. Record the Return Format violation in the PR description's Delegation Notes so the pattern surfaces over time.
 - **Fork-join partial failure** (one agent succeeds, the other fails). Keep the successful agent's result. Apply the relevant Fallback Procedure case (retry or direct implementation) only for the failed agent.
 
 Record fallback events in the PR description so patterns become visible over time.
 
 ## Completion Verification
 
-After each subagent returns, the orchestrator verifies:
+After each subagent returns, the orchestrator **MUST explicitly enumerate** every item below as pass/fail and record the result in the working log (not just "I checked"). Implicit verification is not acceptable — write down pass/fail per item so the Fallback Procedure can trigger on any miss.
 
-- [ ] Changed Files are all within the Allowlist (no Denylist violations)
+```
+Post-Join Verification (<agent name>):
+- [ ] No Denylist violations in Changed Files
+      (additions inside the agent's own domain but outside the payload Scope
+       are allowed — record the reasoning)
 - [ ] All Plan Excerpt checklist items are satisfied (or listed under Deviations)
 - [ ] Domain tests were executed and green (check Test Result section)
 - [ ] Required Return Format has all 5 sections present in order
+```
 
-If any check fails, apply the relevant Fallback Procedure case.
+If any item is **fail**, apply the relevant Fallback Procedure case before proceeding. For fork-join, run this block separately for each returned agent — a pass on one side does not excuse a miss on the other.
 
 ## Rollout Notes
 

--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -176,8 +176,8 @@ I2 (Implement) may be delegated to the bundled `rails-developer` / `react-develo
 Quick rules (see `docs/process/DELEGATION.md` for the full contract):
 
 - **Scope**: subagents handle I2 code + tests + the domain test suite in their payload. They do **not** handle branches (I1), full-suite runs (I3), local review (I4), PRs (I5), Review Response (I6), or the progress file.
-- **Handoff contract**: every invocation passes a payload with Issue / Goal / Plan Excerpt / Allowlist / Denylist / Domain Tests / Done When / Required Return Format.
-- **Shared files are orchestrator-owned**: `config/routes.rb`, `app/javascript/admin/App.tsx`, `.progress/**`, `CLAUDE.md`, `docs/**`, `.claude/**` — orchestrator edits these directly and puts them in every subagent's Denylist.
+- **Handoff contract**: every invocation passes a payload with Issue / Goal / Plan Excerpt / Scope / Denylist / Domain Tests / Done When / Required Return Format. `Scope` is an expected-files hint (not a hard limit); `Denylist` is strict (edit forbidden, reading allowed).
+- **Shared files are orchestrator-owned**: `config/routes.rb` (stub + temporary controller at Pre-Fork), `.progress/**`, `CLAUDE.md`, `docs/**`, `.claude/**` — orchestrator edits these directly and puts them in every subagent's Denylist. `App.tsx` and `AdminLayout.tsx` are owned by `react-developer`, not the orchestrator.
 - **Dispatch patterns**: sequential (Rails → React) for typical Admin features; parallel for independent work; single-domain for one-sided tasks; direct implementation when delegation overhead outweighs the benefit.
 - **Fallback**: on domain-test failure, Denylist violation, plan deviation, or blocker stop, the orchestrator re-delegates once or falls back to direct implementation.
 


### PR DESCRIPTION
## Summary

- Migrate the I2 delegation handoff from **Allowlist** to a **Scope (hint) + Denylist (strict, read-OK)** model so domain agents can self-extend within their own territory without tripping Deviation reports
- Rewrite Fork-join Procedure so Pre-Fork orchestrator work is limited to `config/routes.rb` stub + temporary controller + `rails routes` verify — `App.tsx` and `AdminLayout.tsx` move into `react-developer`'s domain
- Make Post-Join Verification **explicit** (must enumerate pass/fail per item), add a **Return Format violation** case to Fallback Procedure, and introduce **Payload Quality Rules** (no unverified assumptions, no reasoning residue, etc.)
- Fix `rails-developer.md` Admin API authorization pattern: Regular user → **401** (not 403), matching `Api::V1::Admin::ApplicationController#require_admin_access` and `DashboardControllerTest`

Closes #298

## Why

Issue #295 was our first fork-join delegation. Quality and parallel speedup were both fine, but the retrospective surfaced six concrete pain points:

1. Orchestrator Phase 0 was too heavy (orchestrator edited `App.tsx` / `AdminLayout.tsx` itself even though React agent is the natural owner)
2. Post-Join Verification was documented but performed implicitly — a Rails agent Return Format violation slipped through
3. Payload leaked orchestrator's unverified thoughts (`"wait, actually llm_admin HAS Admin:read"`)
4. `rails-developer.md` documented `Regular user → 403` which does not match the actual controller (it returns 401)
5. Return Format violations had no Fallback case — only `maxTurns exhaustion` was covered
6. Allowlist model forced Deviation reports every time an agent needed to add a concern/service/helper, stifling autonomy

This PR lands all six improvements in one coherent revision. Proposal 6 (Denylist model) is the foundation — the other five are adjusted to fit on top of it.

## Changed Files

- `docs/process/DELEGATION.md` — central contract rewrite (Scope/Denylist model, Fork-join Procedure, Completion Verification, Fallback Procedure, Payload Quality Rules, Shared File Ownership table)
- `.claude/agents/rails-developer.md` — Scope/Denylist language, auth 4-pattern corrected to 401/401/403/200 with the `require_admin_access` explanation
- `.claude/agents/react-developer.md` — Scope/Denylist language, `App.tsx` route registration and `AdminLayout.tsx` nav entry now owned by react-developer
- `docs/process/WORKFLOW.md` — sync the I2 Delegation Quick Rules section with the new contract

## Out of scope

- Real-world validation by running a new fork-join delegation under the new procedure (will happen naturally on the next Admin feature)
- Retroactive rewriting of past retrospective docs (e.g., `.progress/issue-00204.md`) still mentioning Allowlist

## Test plan

Docs-only change, no automated tests. Manual verification:

- [ ] `rg 'Allowlist' docs/process/ .claude/agents/` returns only the two intentional contrast sentences (`"not file allowlists"`)
- [ ] Fork-join Procedure reads cleanly: Step 1 stub → Step 2 verify → Step 3 dispatch → Step 4 join → Step 5 explicit Completion Verification
- [ ] `rails-developer.md` auth pattern (401/401/403/200) matches `app/controllers/api/v1/admin/application_controller.rb:18-27` and `test/controllers/api/v1/admin/dashboard_controller_test.rb:7-15`
- [ ] Completion Verification checklist in `DELEGATION.md` matches Self-check items in both agent files (no drift)
- [ ] `WORKFLOW.md` I2 Delegation Quick Rules section is consistent with `DELEGATION.md`
- [ ] Next fork-join issue: confirm the new procedure actually reduces orchestrator Pre-Fork work and catches verification misses

🤖 Generated with [Claude Code](https://claude.com/claude-code)