### PR TITLE
feat(admin): add System Info page to Admin panel

### DIFF
--- a/app/controllers/api/v1/admin/system_infos_controller.rb
+++ b/app/controllers/api/v1/admin/system_infos_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module V1
+    module Admin
+      class SystemInfosController < ApplicationController
+        def show
+          render json: {
+            ruby_version: RUBY_VERSION,
+            rails_version: Rails::VERSION::STRING,
+            environment: Rails.env,
+            database: database_info,
+            runtime: runtime_info,
+          }
+        end
+
+        private
+
+          def database_info
+            {
+              adapter: ActiveRecord::Base.connection.adapter_name.downcase,
+              version: database_version,
+            }
+          end
+
+          def database_version
+            ActiveRecord::Base.connection.select_value("SELECT sqlite_version()")
+          rescue StandardError
+            nil
+          end
+
+          def runtime_info
+            {
+              memory_mb: memory_mb,
+              uptime_seconds: uptime_seconds,
+              pool: pool_info,
+            }
+          end
+
+          def memory_mb
+            (`ps -o rss= -p #{Process.pid}`.to_i / 1024.0).round(1)
+          rescue StandardError
+            nil
+          end
+
+          def uptime_seconds
+            (Process.clock_gettime(Process::CLOCK_MONOTONIC) - SystemBootTime::MONOTONIC_STARTED_AT).to_i
+          end
+
+          def pool_info
+            stat = ActiveRecord::Base.connection_pool.stat
+            {
+              size: stat[:size],
+              connections: stat[:connections],
+              busy: stat[:busy],
+              idle: stat[:idle],
+              waiting: stat[:waiting],
+            }
+          end
+      end
+    end
+  end
+end

--- a/app/javascript/admin/App.tsx
+++ b/app/javascript/admin/App.tsx
@@ -32,6 +32,7 @@ import { SuggestionConfigsIndexPage } from './pages/suggestion-configs/Suggestio
 import { SuggestionConfigNewPage } from './pages/suggestion-configs/SuggestionConfigNewPage'
 import { SuggestionConfigDetailPage } from './pages/suggestion-configs/SuggestionConfigDetailPage'
 import { EventsIndexPage } from './pages/events/EventsIndexPage'
+import { SystemInfoPage } from './pages/SystemInfoPage'
 
 const App = () => (
   <BrowserRouter>
@@ -178,6 +179,11 @@ const App = () => (
           <Route path="events" element={
             <ProtectedRoute requiredCapability={{ resource: 'EventLog', action: 'read' }}>
               <EventsIndexPage />
+            </ProtectedRoute>
+          } />
+          <Route path="system-info" element={
+            <ProtectedRoute requiredCapability={{ resource: 'Admin', action: 'read' }}>
+              <SystemInfoPage />
             </ProtectedRoute>
           } />
         </Route>

--- a/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
@@ -21,9 +21,9 @@ describe('navSections', () => {
     ])
   })
 
-  it('NAVIGATION contains Dashboard, Event Logs, and Users', () => {
+  it('NAVIGATION contains Dashboard, Event Logs, System Info, and Users', () => {
     const nav = navSections.find((s) => s.label === 'NAVIGATION')!
-    expect(nav.items.map((i) => i.label)).toEqual(['Dashboard', 'Event Logs', 'Users'])
+    expect(nav.items.map((i) => i.label)).toEqual(['Dashboard', 'Event Logs', 'System Info', 'Users'])
   })
 
   it('ADMIN contains Admin Accounts, Roles, and Permissions', () => {

--- a/app/javascript/admin/components/AdminLayout.tsx
+++ b/app/javascript/admin/components/AdminLayout.tsx
@@ -36,6 +36,16 @@ export const navSections: { label: string; items: NavItem[] }[] = [
         ),
       },
       {
+        to: '/admin/system-info',
+        label: 'System Info',
+        requiredCapability: { resource: 'Admin', action: 'read' },
+        icon: (
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+          </svg>
+        ),
+      },
+      {
         to: '/admin/users',
         label: 'Users',
         requiredCapability: { resource: 'User', action: 'read' },

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -521,3 +521,28 @@ export const suggestionConfigsApi = {
   update: (id: number, data: UpdateSuggestionConfigInput) =>
     api.patch<SuggestionConfig>(`/suggestion_configs/${id}`, { suggestion_config: data }),
 }
+
+export interface SystemInfoData {
+  ruby_version: string
+  rails_version: string
+  environment: string
+  database: {
+    adapter: string
+    version: string | null
+  }
+  runtime: {
+    memory_mb: number | null
+    uptime_seconds: number
+    pool: {
+      size: number
+      connections: number
+      busy: number
+      idle: number
+      waiting: number
+    }
+  }
+}
+
+export const systemInfoApi = {
+  get: () => api.get<SystemInfoData>('/system_info'),
+}

--- a/app/javascript/admin/pages/SystemInfoPage.tsx
+++ b/app/javascript/admin/pages/SystemInfoPage.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { systemInfoApi, SystemInfoData } from '../lib/api'
+
+export const SystemInfoPage = () => {
+  const [data, setData] = useState<SystemInfoData | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    systemInfoApi
+      .get()
+      .then((info) => setData(info))
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load system info'))
+  }, [])
+
+  if (error) return <p className="text-rose-500">{error}</p>
+  if (!data) return <p className="text-slate-400">Loading...</p>
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400" style={{ fontFamily: 'DM Mono, monospace' }}>SYSTEM</p>
+        <h1 className="text-2xl font-bold text-slate-800" style={{ fontFamily: 'Syne, sans-serif' }}>System Info</h1>
+        <p className="mt-0.5 text-xs text-slate-400">Runtime environment details</p>
+      </div>
+
+      {/* Runtime */}
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <h2 className="text-sm font-semibold text-slate-700" style={{ fontFamily: 'Syne, sans-serif' }}>Runtime</h2>
+        </div>
+        <dl className="divide-y divide-slate-50">
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>ruby_version</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.ruby_version}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>rails_version</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.rails_version}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>environment</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.environment}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>memory_mb</dt>
+            <dd className="text-xs font-medium text-slate-800">
+              {data.runtime.memory_mb != null ? data.runtime.memory_mb.toFixed(1) : '—'}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>uptime_seconds</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.runtime.uptime_seconds}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Database */}
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <h2 className="text-sm font-semibold text-slate-700" style={{ fontFamily: 'Syne, sans-serif' }}>Database</h2>
+        </div>
+        <dl className="divide-y divide-slate-50">
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>adapter</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.database.adapter}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>version</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.database.version ?? '—'}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Connection Pool */}
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <h2 className="text-sm font-semibold text-slate-700" style={{ fontFamily: 'Syne, sans-serif' }}>Connection Pool</h2>
+        </div>
+        <dl className="divide-y divide-slate-50">
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>size</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.runtime.pool.size}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>connections</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.runtime.pool.connections}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>busy</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.runtime.pool.busy}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>idle</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.runtime.pool.idle}</dd>
+          </div>
+          <div className="flex items-center justify-between px-5 py-3">
+            <dt className="text-xs text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>waiting</dt>
+            <dd className="text-xs font-medium text-slate-800">{data.runtime.pool.waiting}</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/config/initializers/system_boot_time.rb
+++ b/config/initializers/system_boot_time.rb
@@ -1,0 +1,3 @@
+module SystemBootTime
+  MONOTONIC_STARTED_AT = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
         end
         resources :prompt_sets, only: %i[index show create update]
         resources :suggestion_configs, only: %i[index show create update]
+        resource :system_info, only: [:show]
         resource :session, only: %i[show create destroy], controller: "sessions"
       end
     end

--- a/test/controllers/api/v1/admin/system_infos_controller_test.rb
+++ b/test/controllers/api/v1/admin/system_infos_controller_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+module Api
+  module V1
+    module Admin
+      class SystemInfosControllerTest < ActionDispatch::IntegrationTest
+        # 1. Unauthenticated → 401
+        test "GET show returns 401 when not logged in" do
+          get api_v1_admin_system_info_path
+          assert_response :unauthorized
+        end
+
+        # 2. Regular user (non-admin session) → 401
+        test "GET show returns 401 when logged in as regular user" do
+          login_as(users(:regular_user))
+          get api_v1_admin_system_info_path
+          assert_response :unauthorized
+        end
+
+        # 3. Admin without Admin:read capability → 403
+        test "GET show returns 403 when admin session has no Admin:read" do
+          user = users(:admin_user)
+          login_as_admin_api(user)
+          user.roles.clear
+          get api_v1_admin_system_info_path
+          assert_response :forbidden
+        end
+
+        # 4. Admin with Admin:read → 200 + full JSON shape
+        test "GET show returns 200 with system info when logged in as admin" do
+          login_as_admin_api
+          get api_v1_admin_system_info_path
+          assert_response :success
+          json = response.parsed_body
+
+          # Top-level keys — no surplus
+          assert_equal %w[database environment rails_version ruby_version runtime], json.keys.sort
+
+          assert_equal RUBY_VERSION, json["ruby_version"]
+          assert_equal Rails::VERSION::STRING, json["rails_version"]
+          assert_equal Rails.env, json["environment"]
+        end
+
+        test "GET show database section has correct keys and values" do
+          login_as_admin_api
+          get api_v1_admin_system_info_path
+          assert_response :success
+          db = response.parsed_body["database"]
+
+          assert_equal %w[adapter version], db.keys.sort
+          assert_kind_of String, db["adapter"]
+          assert(db["version"].nil? || db["version"].is_a?(String))
+        end
+
+        test "GET show runtime section has correct structure" do
+          login_as_admin_api
+          get api_v1_admin_system_info_path
+          assert_response :success
+          runtime = response.parsed_body["runtime"]
+
+          assert runtime.key?("memory_mb")
+          assert runtime.key?("uptime_seconds")
+          assert runtime.key?("pool")
+
+          assert(runtime["memory_mb"].nil? || runtime["memory_mb"].is_a?(Numeric))
+        end
+
+        test "GET show uptime_seconds is a non-negative integer" do
+          login_as_admin_api
+          get api_v1_admin_system_info_path
+          assert_response :success
+          uptime = response.parsed_body["runtime"]["uptime_seconds"]
+
+          assert_kind_of Integer, uptime
+          assert uptime >= 0
+        end
+
+        test "GET show pool contains exactly 5 keys without dead or checkout_timeout" do
+          login_as_admin_api
+          get api_v1_admin_system_info_path
+          assert_response :success
+          pool = response.parsed_body["runtime"]["pool"]
+
+          assert_equal %w[busy connections idle size waiting], pool.keys.sort
+          assert_not pool.key?("dead"), "pool must not include 'dead'"
+          assert_not pool.key?("checkout_timeout"), "pool must not include 'checkout_timeout'"
+        end
+
+        test "GET show pool values are integers" do
+          login_as_admin_api
+          get api_v1_admin_system_info_path
+          assert_response :success
+          pool = response.parsed_body["runtime"]["pool"]
+
+          %w[size connections busy idle waiting].each do |key|
+            assert_kind_of Integer, pool[key], "pool.#{key} should be an Integer"
+          end
+        end
+
+        test "GET show returns memory_mb nil when ps command fails" do
+          login_as_admin_api
+          SystemInfosController.any_instance.stubs(:memory_mb).returns(nil)
+          get api_v1_admin_system_info_path
+          assert_response :success
+          assert_nil response.parsed_body["runtime"]["memory_mb"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `/admin/system-info` 読み取り専用ページを追加。Ruby/Rails/DB/runtime 情報を Admin ユーザー向けに表示
- `GET /api/v1/admin/system_info` エンドポイント（Admin:read 必須、認可は base controller の `require_admin_access` に委譲）
- 本タスクは **fork-join I2 delegation pattern のパイロット** としても実施。API contract を plan で verbatim 確定し、`rails-developer` と `react-developer` を並列発火、post-join で type-contract を grep ベース検証

## Context
Closes #295

## Changes
### Backend
- `config/routes.rb` — admin namespace に `resource :system_info, only: [:show]`
- `app/controllers/api/v1/admin/system_infos_controller.rb` — 新 read-only controller
- `config/initializers/system_boot_time.rb` — monotonic boot 時刻を freeze
- `test/controllers/api/v1/admin/system_infos_controller_test.rb` — 10 tests / 32 assertions（4-pattern auth + shape + nullable + pool 5-key drift guard）

### Frontend
- `app/javascript/admin/lib/api.ts` — `SystemInfoData` interface + `systemInfoApi.get()`
- `app/javascript/admin/pages/SystemInfoPage.tsx` — DashboardPage pattern を踏襲
- `app/javascript/admin/App.tsx` — `/admin/system-info` route（`requiredCapability: { resource: 'Admin', action: 'read' }`）
- `app/javascript/admin/components/AdminLayout.tsx` — NAVIGATION に "System Info" 追加
- `app/javascript/admin/__tests__/components/AdminLayout.test.tsx` — nav assertion 更新

## Security
- 認可は `Api::V1::Admin::ApplicationController#require_admin_access` で 1 本化（Admin session 必須 → 無ければ 401、Admin:read 無ければ 403）
- `ps -o rss= -p <pid>` の `<pid>` は `Process.pid`（Integer）のみ補間 → command injection surface 無し
- DB バージョンは `SELECT sqlite_version()` literal、例外は `rescue StandardError` で吸収し null 返却
- `runtime.pool` は 5 キー固定（`dead` / `checkout_timeout` 意図的除外）— controller test に drift detection assertion

## Test plan
- [x] `bin/rails test test/controllers/api/v1/admin/system_infos_controller_test.rb` — 10 runs, 32 assertions, 0 failures
- [x] `bin/rails test:all` — 894 runs, 2160 assertions, 0 failures, 0 errors, 2 skips (pre-existing)
- [x] `npm test` — 40 tests passed
- [x] Manual smoke: `bin/dev` 起動、Admin ログイン、ナビから遷移、全フィールド表示確認
- [ ] CI full suite pass
- [ ] 自動 code review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)