### PR TITLE
chore(claude-hooks): reconcile pre_tool_use hooks with DELEGATION.md and fix git branch guard

### DIFF
--- a/.claude/hooks/pre_tool_use_bash_guard.sh
+++ b/.claude/hooks/pre_tool_use_bash_guard.sh
@@ -8,7 +8,7 @@
 #   - Full test suite (bin/rails test with no args, bin/rails test:all)
 #
 # Allowed:
-#   - git read operations (status, log, diff, show, rev-parse, ls-files)
+#   - git read operations (status, log, diff, show, rev-parse, ls-files, branch read-only usage)
 #   - Domain test suite runs (bin/rails test <specific path>)
 
 INPUT=$(cat)
@@ -22,8 +22,18 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # Block git write operations.
 # Match git at line start or after command separators (&&, ||, ;, |, subshell)
 # to avoid false positives with commands like: echo "git commit example"
-if echo "$COMMAND" | grep -qE '(^|&&|\|\||;|\||\()\s*git\s+(branch|commit|push|checkout|switch|merge|rebase|tag|add|stash|reset|clean|cherry-pick|am|apply)\b'; then
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;|\||\()\s*git\s+(commit|push|checkout|switch|merge|rebase|tag|add|stash|reset|clean|cherry-pick|am|apply)\b'; then
   echo "BLOCKED: git write operations are reserved for the orchestrator. Report this under Deviations if it blocks your task." >&2
+  exit 2
+fi
+
+# Block git branch write operations (create/delete/rename/copy).
+# Read-only usage (`git branch`, `git branch --show-current`, `git branch --list ...`,
+# `git branch -a`, `git branch -v`, etc.) is allowed.
+# Write usage is matched via: short flags -d/-D/-m/-M/-c/-C, long flags --delete/--move/--copy,
+# or a positional <new-name> (starts with a non-dash character).
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;|\||\()\s*git\s+branch\s+(-[dDmMcC]\b|--delete\b|--move\b|--copy\b|[^-[:space:]])'; then
+  echo "BLOCKED: git branch write operations (create/delete/rename/copy) are reserved for the orchestrator. Report this under Deviations if it blocks your task." >&2
   exit 2
 fi
 

--- a/.claude/hooks/pre_tool_use_bash_guard.sh
+++ b/.claude/hooks/pre_tool_use_bash_guard.sh
@@ -32,6 +32,14 @@ fi
 # `git branch -a`, `git branch -v`, etc.) is allowed.
 # Write usage is matched via: short flags -d/-D/-m/-M/-c/-C, long flags --delete/--move/--copy,
 # or a positional <new-name> (starts with a non-dash character).
+#
+# Known gaps (accepted out-of-scope per issue #303): branch creation/modification
+# forms whose first token is a non-matching flag slip through — e.g. `git branch
+# --track <name>`, `git branch --no-track <name>`, `git branch -t <name>`,
+# `git branch -u <upstream>`, `git branch -f <name> <start-point>`. These are
+# write ops but were not observed as pain points in the #295 pilot; a follow-up
+# issue should cover full `git branch` write coverage together with the
+# reset/checkout/switch read-vs-write distinction.
 if echo "$COMMAND" | grep -qE '(^|&&|\|\||;|\||\()\s*git\s+branch\s+(-[dDmMcC]\b|--delete\b|--move\b|--copy\b|[^-[:space:]])'; then
   echo "BLOCKED: git branch write operations (create/delete/rename/copy) are reserved for the orchestrator. Report this under Deviations if it blocks your task." >&2
   exit 2

--- a/.claude/hooks/pre_tool_use_denylist.sh
+++ b/.claude/hooks/pre_tool_use_denylist.sh
@@ -65,9 +65,6 @@ if [ "$AGENT_TYPE" = "react-developer" ]; then
     test/controllers/*|test/models/*)
       echo "BLOCKED: '$REL_PATH' belongs to the Rails domain. react-developer cannot edit this test path. Report this under Deviations." >&2
       exit 2 ;;
-    app/javascript/admin/App.tsx)
-      echo "BLOCKED: 'App.tsx' is owned by the orchestrator. Report the required route entry under Handoff Notes for orchestrator." >&2
-      exit 2 ;;
   esac
 fi
 


### PR DESCRIPTION
Fixes #303.

## Summary

- **Problem 1 — `pre_tool_use_denylist.sh`**: Removed the stale `app/javascript/admin/App.tsx` block from `react-developer` denylist, reconciling the hook with `DELEGATION.md` L138/L178 which declare that path as react-developer-owned. Ends the Handoff Notes round-trip observed in fork-join phase of #295.
- **Problem 2 — `pre_tool_use_bash_guard.sh`**: Removed `branch` from the blanket write-op regex and added a dedicated guard that blocks only write usage. Read-only `git branch` / `git branch --show-current` / `git branch --list` / `git branch -a|-v|-r` now pass; `git branch <new-name>` / `-d|-D|-m|-M|-c|-C` / `--delete|--move|--copy` remain blocked. Updated the header comment to match (L11).

**Option A** was chosen (defense in depth) per the issue's recommendation. Known accepted limitation: `git branch -f <name> <start-point>` (force-reset) passes the guard — documented as out-of-scope per issue #303.

## Test plan

Application code and tests are untouched; this is `.claude/`-only, so the Rails suite (I3) is skipped per Lightweight Flow. Verified the hooks with a 30-pattern shell dry-run:

- [x] **Problem 1 — denylist (6 cases, all expected)**
  - `react-developer` + `App.tsx` → exit 0 ✅
  - `react-developer` + `AdminLayout.tsx` → exit 0 ✅
  - `react-developer` + `app/models/user.rb` → exit 2 ✅ (Rails domain regression)
  - `react-developer` + `config/routes.rb` → exit 2 ✅ (shared-file regression)
  - `rails-developer` + `App.tsx` → exit 2 ✅ (React domain regression)
  - `rails-developer` + `app/controllers/**` → exit 0 ✅
- [x] **Problem 2 — bash guard (24 cases, all expected)**
  - **read-only pass (8)**: `git branch`, `--show-current`, `--list`, `-a`, `-v`, `-r`, `--all`, `--contains`
  - **write block (10)**: `git branch new-feature`, `-d`, `-D`, `-m`, `-M`, `-c`, `-C`, `--delete`, `--move`, `--copy`
  - **other write-op regressions (6)**: `commit`, `push`, `checkout`, `switch`, `add`, `stash` — still blocked
  - **false-positive guards**: `echo "git branch new"`, `echo "git commit example"`, `git status`, `git log`, `git diff`, `git rev-parse` → all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)