### PR TITLE
docs(delegation): fork-join I2 pilot retrospective fixes from #295

### DIFF
--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -30,7 +30,7 @@ Before touching any file, read these in order:
 5. `docs/design/admin/README.md` — the design system index; follow the linked topic docs when building new components.
 6. `app/javascript/admin/lib/api.ts` — the existing API client surface. Follow its conventions (fetch wrapper, error handling, type definitions).
 7. `app/javascript/admin/App.tsx` — read first to understand existing routes and guards. You **own** route registration for your feature and will edit this file as part of your work.
-8. `app/javascript/admin/components/layouts/AdminLayout.tsx` — read first to understand the nav item pattern. You own nav additions for your feature.
+8. `app/javascript/admin/components/AdminLayout.tsx` — read first to understand the nav item pattern. You own nav additions for your feature.
 
 If a must-read file does not exist, record it under Deviations and continue with the rest.
 
@@ -41,14 +41,14 @@ If a must-read file does not exist, record it under Deviations and continue with
 3. **Add types and API function to `app/javascript/admin/lib/api.ts`.** Extend the existing patterns (fetch wrapper, error handling, type definitions).
 4. **Build page / component.** Place new pages under `app/javascript/admin/pages/` and shared components under `app/javascript/admin/components/` per the existing directory structure. Use design tokens (`bg-sidebar`, `bg-accent`, `text-slate-800`, `font-syne`, `font-dm-mono`).
 5. **Write / extend React tests** following the existing `__tests__` patterns in the SPA.
-6. **Register the route and nav item.** Add the route to `app/javascript/admin/App.tsx` (path, element, guards) and the nav entry to `app/javascript/admin/components/layouts/AdminLayout.tsx`, following the existing patterns. For fork-join, the orchestrator has already created a stub route + temporary controller in `config/routes.rb`; your job is the frontend wiring.
+6. **Register the route and nav item.** Add the route to `app/javascript/admin/App.tsx` (path, element, guards) and the nav entry to `app/javascript/admin/components/AdminLayout.tsx`, following the existing patterns. For fork-join, the orchestrator has already created a stub route + temporary controller in `config/routes.rb`; your job is the frontend wiring.
 7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`).
 8. **Review & fix (single pass).** After domain tests pass, run `/hobo-codex-review-react` against the diff once. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
 9. **Return in the required format** (see below).
 
 ## Scope discipline
 
-- **Domain boundaries, not file allowlists.** Your domain is the entire `app/javascript/admin/**` tree — pages, components (including `components/layouts/AdminLayout.tsx`), contexts, `lib/api.ts`, `App.tsx`, and `**/__tests__/**`. You may create, modify, or delete files anywhere inside your domain as the implementation requires.
+- **Domain boundaries, not file allowlists.** Your domain is the entire `app/javascript/admin/**` tree — pages, components (including `components/AdminLayout.tsx`), contexts, `lib/api.ts`, `App.tsx`, and `**/__tests__/**`. You may create, modify, or delete files anywhere inside your domain as the implementation requires.
 - **The `Scope` section in the payload is a hint, not a hard constraint.** It lists the files the orchestrator expects you to touch. If you need a new component, hook, or type file that wasn't listed, add it — that is not a Deviation. Record meaningful additions in `Changed Files` and, if they materially change the approach, note the reasoning in `Handoff Notes for orchestrator`.
 - **You MUST NOT edit anything in the `Denylist`.** Reading Denylist files (e.g., Rails controllers to understand the API contract) is expected and encouraged; only writes are forbidden. If you genuinely need to edit a Denylist file, stop and report it under Deviations.
 - Run only the domain test suite specified in the payload.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,7 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx)$'; then npx tsc --noEmit; else true; fi; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx)$'; then repo=$(git rev-parse --show-toplevel 2>/dev/null); if [ -z \"$repo\" ]; then exit 0; fi; relf=\"${f#$repo/}\"; result=$(npx tsc --noEmit 2>&1); rc=$?; filtered=$(printf '%s' \"$result\" | grep -F \"$relf\" || true); if [ -n \"$filtered\" ]; then jq -n --arg ctx \"TypeScript errors in $relf (tsc exit $rc):\\n$filtered\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; fi; fi; }",
             "statusMessage": "Running tsc type check..."
           },
           {

--- a/.claude/skills/hobo-codex-review-rails/SKILL.md
+++ b/.claude/skills/hobo-codex-review-rails/SKILL.md
@@ -27,7 +27,7 @@ codex review "<request>"
 - ActiveRecord queries: correct use of `present?`/`exists?`/`count`/`size`/`length`, eager loading, N+1 avoidance (see `docs/conventions/ACTIVE_RECORD_QUERIES.md`)
 - Fat model decomposition: concerns, service objects, proper separation of domain logic from controllers (see `docs/conventions/FAT_MODEL_DECOMPOSITION.md`)
 - Authorization: `require_capability!` on all admin endpoints, `current_user`-scoped resource access, no direct ID access, no privilege escalation
-- Admin API test coverage: 4-pattern (401 unauthenticated / 403 regular user / 403 insufficient capability / 200 proper capability)
+- Admin API test coverage: 4-pattern (401 unauthenticated / 401 regular user (non-admin session) / 403 admin with insufficient capability / 200 admin with proper capability)
 - Model-level validations, not controller-level
 - Strong parameters, no mass assignment vulnerabilities
 

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -1,6 +1,6 @@
 # I2 Delegation to Domain Subagents
 
-This document defines how the orchestrator (the main Claude conversation driving a task through `docs/process/WORKFLOW.md`) may delegate **Implementation Phase Step I2 (Implement)** to domain-specific subagents.
+This document defines how the orchestrator may delegate **Implementation Phase Step I2 (Implement)** to domain-specific subagents.
 
 Two subagents are bundled with this repository:
 
@@ -91,8 +91,6 @@ bin/rails test <path>            # for rails-developer
 - Tables, bullet lists, and deep-dive content live **inside** `Summary` or `Handoff Notes`.
 - `Handoff Notes` is dual-purpose: sequential API contract for the next agent **and/or** follow-up observations for the orchestrator (maintenance risks, suspected issues, flagged files). Use `not applicable` only when neither applies.
 
-The Required Return Format section is copied verbatim from the agent definition so subagents return machine-parseable results.
-
 ### Payload Quality Rules
 
 A payload is an **instruction** to the agent, not the orchestrator's thinking log. Clean, verified payloads are the single biggest lever on delegation quality.
@@ -101,6 +99,7 @@ A payload is an **instruction** to the agent, not the orchestrator's thinking lo
 - **No reasoning residue.** Phrases like "wait, actually..." or "let me reconsider..." belong to your working memory, never to the payload. If you catch yourself writing them, rewrite the payload to state the final conclusion only.
 - **Pre-existing errors go into `Done When`.** If there are known-broken type errors, flaky tests, or warnings in the area the agent will touch, list them under `Done When` as "the following pre-existing errors may be ignored" so the agent does not spend turns chasing them.
 - **Copy, don't paraphrase.** When quoting the Plan Excerpt or an API contract, copy verbatim from the approved plan. Paraphrasing introduces drift between what the user approved and what the agent implements.
+- **Intentional duplication across fork-join payloads is a feature, not a bug.** When duplicating API contract / authorization tables / field semantics to both rails-developer and react-developer payloads, annotate the duplicated block with `# Duplicated in both fork-join payloads for type-contract integrity (see DELEGATION.md Fork-join §5)`. This turns silent token cost into an audited decision and prevents future payload authors from "DRY-ing" the duplication away.
 
 ## Invocation Patterns
 
@@ -133,13 +132,12 @@ Use when the Plan Excerpt covers both Rails and React within the same feature, b
 
 1. **Pre-Fork — stub route + temporary controller.** The orchestrator adds a stub route to `config/routes.rb` and creates a temporary controller returning a fixed JSON response matching the planned contract. This is the only shared-file edit the orchestrator performs before dispatch; do **not** touch `App.tsx` or `AdminLayout.tsx` here — those belong to react-developer.
 2. **Verify routing.** Run `bin/rails routes | grep <resource>` to confirm the stub is wired up correctly. Fix typos now, not after dispatch.
-3. **Dispatch** two Agent calls in a **single message** so they run concurrently:
+3. **Hook compatibility check (pre-dispatch).** Before dispatching, grep `.claude/hooks/pre_tool_use_denylist.sh` (and related hooks) against the shared files the subagents are expected to touch (typically `App.tsx`, `AdminLayout.tsx`, `config/routes.rb`, `.progress/**`). If a hook denies a file that the plan assigns to a subagent, resolve the drift before dispatch — either by updating the hook, adjusting ownership, or handing the edit back to the orchestrator explicitly.
+4. **Dispatch** two Agent calls in a **single message** so they run concurrently:
    - `rails-developer` overwrites the temporary controller with the real implementation and adds tests.
-   - `react-developer` owns `app/javascript/admin/App.tsx` (route registration), `app/javascript/admin/components/layouts/AdminLayout.tsx` (nav item), the page, and the `api.ts` additions.
-4. **Wait for both agents to return (join).**
-5. **Post-Join Verification** — run the Completion Verification checklist explicitly for **each** agent (see `Completion Verification` section below). If type mismatches surface between the Rails response and the TypeScript types (e.g., field name divergence), treat as a sequential dependency and redispatch react-developer with the Rails agent's actual output as context.
-
-**Example**: Issue #204 was a candidate for this pattern — the API contract for all eight Admin endpoints was fully specified in the plan, so react-developer could have worked in parallel with rails-developer.
+   - `react-developer` owns `app/javascript/admin/App.tsx` (route registration), `app/javascript/admin/components/AdminLayout.tsx` (nav item), the page, and the `api.ts` additions.
+5. **Wait for both agents to return (join).**
+6. **Post-Join Verification** — run the Completion Verification checklist explicitly for **each** agent (see `Completion Verification` section below). If type mismatches surface between the Rails response and the TypeScript types (e.g., field name divergence), treat as a sequential dependency and redispatch react-developer with the Rails agent's actual output as context.
 
 ### Parallel (independent domains)
 
@@ -153,8 +151,6 @@ Use when a single domain agent's expected Scope exceeds ~10 files. Split the wor
 - Common infrastructure (concerns, migrations, shared modules) is created by the orchestrator before dispatching **if** both instances would otherwise need to create it concurrently. Otherwise each instance adds what it needs within its own domain.
 - Each instance's Scope does not overlap with the other (file-level mutual exclusion of expected work).
 - Each instance's Denylist includes the files the other instance is expected to own plus all shared files, so concurrent writes cannot collide.
-
-**Example**: Issue #204's Rails side could have been split into two rails-developer instances — one for Users/AdminAccounts/Roles/Permissions and another for LlmProviders/LlmModels/PromptSets/SuggestionConfigs.
 
 ### Single-domain
 
@@ -175,7 +171,7 @@ This table defines each agent's **domain**. An agent may freely edit any file in
 | `CLAUDE.md`, `docs/**` | orchestrator |
 | `.claude/**` (agents / skills / settings) | orchestrator |
 | `app/controllers/**`, `app/models/**`, `app/services/**`, `app/jobs/**`, `db/migrate/**`, `test/controllers/**`, `test/models/**`, `test/services/**`, `test/jobs/**`, `test/system/**` (non-React) | rails-developer (orchestrator may stub a temporary controller under `app/controllers/api/v1/admin/**` at Pre-Fork for fork-join — rails-developer then overwrites it with the real implementation) |
-| `app/javascript/admin/**` — including `App.tsx` (route registration), `components/layouts/AdminLayout.tsx` (nav item), `pages/**`, `components/**`, `contexts/**`, `lib/api.ts`, `**/__tests__/**` | react-developer |
+| `app/javascript/admin/**` — including `App.tsx` (route registration), `components/AdminLayout.tsx` (nav item), `pages/**`, `components/**`, `contexts/**`, `lib/api.ts`, `**/__tests__/**` | react-developer |
 
 When a task requires editing an orchestrator-owned file, the orchestrator performs the edit itself before or after the delegation, never inside the subagent payload. For fork-join, the orchestrator's Pre-Fork edit is limited to the `config/routes.rb` stub + a temporary controller (see Fork-join Procedure Step 1).
 
@@ -231,3 +227,12 @@ If any item is **fail**, apply the relevant Fallback Procedure case before proce
 - **Stay direct for complex refactors.** Cross-file refactors where the orchestrator needs to hold the whole mental model are poor fits for delegation.
 - **Update the agent definitions** (`.claude/agents/*.md`) when payload expectations evolve. Keep this document and the agents in sync.
 - **If you hit repeated fallbacks** in a given task class, that's a signal to either expand the agent prompt or mark that class as "direct-only".
+
+### Pilot Reporting Rules
+
+- **Pilot reporting must distinguish observed paths from untouched paths.** When retrospecting a fork-join pilot, separate "paths that ran and produced evidence" from "paths the happy path did not exercise (negative evidence)". Fallback branches (e.g., post-join type-mismatch redispatch) that were **not** triggered in the pilot must be labeled as **untested** — do not claim the contract is validated if only the happy path ran.
+- **Smoke test selection is an explicit choice, not a default.** When Plan Phase calls for a manual smoke test after fork-join merge, the orchestrator must consciously choose between: (a) **automated** via `webapp-testing` (playwright) skill, (b) **manual** by asking the user, or (c) **skip** when the change is low-risk and covered by tests. Record the choice + reasoning in `.progress/issue-*.md` I2. Default preference is (a) when the feature has a visible UI path; fall back to (b) only when scope mismatch or cost makes automation impractical.
+
+### I4 Parallel Review (Rails + React)
+
+When a PR's diff covers **both Rails backend and React Admin SPA** files, the orchestrator should run `/hobo-codex-review-rails`, `/hobo-codex-review-react`, and `/hobo-codex-review-architecture` **in parallel** (three Skill/Agent calls in a single message) instead of a single generic `/codex-review`. This extends the parallelism acquired at I2 fork-join into I4 and improves review coverage for cross-cutting changes. Single-domain PRs still use the matching single skill.


### PR DESCRIPTION
## Summary
- Close out the fork-join I2 delegation pilot (#295 / PR #302) retrospective: fix 2 doc drifts surfaced during the pilot, inject 5 workflow improvement rules into DELEGATION.md (反省点 1-5), and filter the noisy tsc PostToolUse hook so it only surfaces errors from the edited file (反省点 6).
- Bundle-per-PR approved by owner during Planning Phase — all 6 retrospective items land together as boss instructed.
- Tier 1 inert-passage simplification applied in-PR (4 deletions, -7 net lines) per boss direction during I4, preserving all protective-redundancy rules at mistake-temptation points per CLAUDE.md LLM-facing-docs meta rule.

## Changes
- **`.claude/skills/hobo-codex-review-rails/SKILL.md`**: Admin API 4-pattern corrected to `401 / 401 / 403 / 200` (was `401 / 403 / 403 / 200`). Aligns with `.claude/agents/rails-developer.md:40-43` and `app/controllers/api/v1/admin/application_controller.rb`.
- **`.claude/agents/react-developer.md`**: 3 stale references updated from `components/layouts/AdminLayout.tsx` → `components/AdminLayout.tsx` (must-read list, Procedure step 6, domain boundaries).
- **`docs/process/DELEGATION.md`**:
  - 2 drift fixes for AdminLayout path (Shared File Ownership + Fork-join Procedure)
  - Fork-join Procedure: new Step 3 "Hook compatibility check (pre-dispatch)" — renumbered former Steps 3/4/5 to 4/5/6 (cross-refs to Step 1 unchanged, verified)
  - Payload Quality Rules: new bullet on intentional cross-payload duplication
  - New H3 `Pilot Reporting Rules` under Rollout Notes (observed-vs-untouched paths, smoke test selection discipline — 反省点 3 + 5)
  - New H3 `I4 Parallel Review (Rails + React)` under Rollout Notes (反省点 4)
  - Tier 1 inert-passage trims: reader-orientation parenthetical, meta comment on Return Format section, 2 stale Issue #204 examples
- **`.claude/settings.json`**: PostToolUse tsc hook filtered — scopes tsc output to the edited file via `grep -F "$relf"` and emits through `jq additionalContext` (matching the rubocop/eslint pattern). Massively reduces noise: 50+ repo-wide errors → errors scoped to the edited file.

## Test plan
- [x] Docs/config-only change → Rails full test suite intentionally skipped (WORKFLOW.md L110-111)
- [x] 12 post-edit sanity greps (all passed): 4-pattern, AdminLayout drift, 5 reflection key phrases, Fork-join step renumbering, settings.json JSON validity
- [x] Cross-reference integrity: `Fork-join.*Step [0-9]` still points to Step 1 in both L175/L182 (plan-reviewer Proposal 3 pin confirmed)
- [x] Empirical smoke test for the new tsc hook (Case A/B/C, dummy edit + revert, 0 residual changes):
  - Case A (clean file, SystemInfoPage.tsx): tsc hook **silent** as expected
  - Case B (error file, lib/api.ts): own error surfaces, unrelated errors from EventsIndexPage + 4 test files **blocked** by filter
  - Case C (test file, Badge.test.tsx): **empirical correction** — plan predicted silence but `tsconfig.json` includes `app/javascript/admin/**/*`, so main tsc DOES pick up tests. Filter still works correctly, scoping to the edited test file's own errors. Net effect vs old hook is still massive noise reduction.
- [x] `/codex-review --uncommitted` passed all 4 focus areas (shell correctness, Step renumber, path drift completeness, 4-pattern vs controller)

## Delegation Notes
- I2 delegation: **not used** — docs/config-only task, orchestrator direct implementation per plan classification
- Pilot Reporting Rules reflection 3 (observed vs untouched) is itself applied to this PR: Case C's divergence from plan's silent expectation is explicitly labeled as empirically corrected, not papered over
- Codex Handoff Notes triage: vitest-globals missing types in `__tests__/components/AdminLayout.test.tsx` noted as pre-existing out-of-scope debt — not bundled into this PR per CLAUDE.md scope discipline
- Tier 2 simplification candidates (Rollout Notes compression, Progress File Responsibility consolidation, 反省点 3 tightening) **declined** as scope creep, deferred to potential follow-up issue

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)