### PR TITLE
refactor(admin): extract Roles/Permissions shared helpers and components

### DIFF
--- a/app/controllers/api/v1/admin/application_controller.rb
+++ b/app/controllers/api/v1/admin/application_controller.rb
@@ -44,6 +44,10 @@ module Api
           def require_manage_access
             render json: { error: "Forbidden" }, status: :forbidden unless current_admin.admin?
           end
+
+          def protect_system_role
+            render json: { error: "Forbidden" }, status: :forbidden if @role&.system_role?
+          end
       end
     end
   end

--- a/app/controllers/api/v1/admin/role_permissions_controller.rb
+++ b/app/controllers/api/v1/admin/role_permissions_controller.rb
@@ -27,16 +27,8 @@ module Api
             params.permit(permission_ids: [])[:permission_ids] || []
           end
 
-          def protect_system_role
-            render json: { error: "Forbidden" }, status: :forbidden if @role&.system_role?
-          end
-
           def protect_permission_escalation
-            new_ids = permission_ids_param.compact_blank.map(&:to_i)
-            return if new_ids.empty?
-
-            admin_ids = current_admin.roles.joins(:permissions).pluck("permissions.id").uniq
-            return if (new_ids - admin_ids).empty?
+            return if current_admin.can_grant_permissions?(permission_ids_param)
 
             render json: { error: "Forbidden" }, status: :forbidden
           end

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -54,10 +54,6 @@ module Api
           def role_params
             params.expect(role: %i[name description])
           end
-
-          def protect_system_role
-            render json: { error: "Forbidden" }, status: :forbidden if @role&.system_role?
-          end
       end
     end
   end

--- a/app/javascript/admin/components/AdminPageHeader.tsx
+++ b/app/javascript/admin/components/AdminPageHeader.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+interface AdminPageHeaderProps {
+  eyebrow: string
+  title: string
+  action?: ReactNode
+}
+
+export const AdminPageHeader = ({ eyebrow, title, action }: AdminPageHeaderProps) => (
+  <div className="flex items-end justify-between">
+    <div>
+      <p
+        className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
+        style={{ fontFamily: 'DM Mono, monospace' }}
+      >
+        {eyebrow}
+      </p>
+      <h1
+        className="text-2xl font-bold text-slate-800"
+        style={{ fontFamily: 'Syne, sans-serif' }}
+      >
+        {title}
+      </h1>
+    </div>
+    {action}
+  </div>
+)

--- a/app/javascript/admin/components/ErrorBanner.tsx
+++ b/app/javascript/admin/components/ErrorBanner.tsx
@@ -1,0 +1,12 @@
+interface ErrorBannerProps {
+  message: string | null
+}
+
+export const ErrorBanner = ({ message }: ErrorBannerProps) => {
+  if (!message) return null
+  return (
+    <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+      {message}
+    </div>
+  )
+}

--- a/app/javascript/admin/pages/permissions/PermissionDetailPage.tsx
+++ b/app/javascript/admin/pages/permissions/PermissionDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { permissionsApi, type Permission } from '../../lib/api'
+import { AdminPageHeader } from '../../components/AdminPageHeader'
 
 export const PermissionDetailPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -26,14 +27,7 @@ export const PermissionDetailPage = () => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
-             style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>Permission Detail</h1>
-        </div>
-      </div>
+      <AdminPageHeader eyebrow="MANAGEMENT" title="Permission Detail" />
       {error && <p className="text-rose-500">{error}</p>}
       {permission && (
         <>

--- a/app/javascript/admin/pages/permissions/PermissionsIndexPage.tsx
+++ b/app/javascript/admin/pages/permissions/PermissionsIndexPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { permissionsApi, type Permission, type PaginationMeta } from '../../lib/api'
 import Pagination from '../../components/Pagination'
 import { usePagination, useClampPage } from '../../hooks/usePagination'
+import { AdminPageHeader } from '../../components/AdminPageHeader'
 
 export const PermissionsIndexPage = () => {
   const [permissions, setPermissions] = useState<Permission[]>([])
@@ -38,14 +39,7 @@ export const PermissionsIndexPage = () => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
-             style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>Permissions</h1>
-        </div>
-      </div>
+      <AdminPageHeader eyebrow="MANAGEMENT" title="Permissions" />
       {error && <p className="text-rose-500">{error}</p>}
       <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>

--- a/app/javascript/admin/pages/roles/RoleEditPage.tsx
+++ b/app/javascript/admin/pages/roles/RoleEditPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { rolesApi } from '../../lib/api'
+import { AdminPageHeader } from '../../components/AdminPageHeader'
+import { ErrorBanner } from '../../components/ErrorBanner'
 
 export const RoleEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -44,20 +46,9 @@ export const RoleEditPage = () => {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
-             style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>Edit Role</h1>
-        </div>
-      </div>
+      <AdminPageHeader eyebrow="MANAGEMENT" title="Edit Role" />
 
-      {error && (
-        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
-          {error}
-        </div>
-      )}
+      <ErrorBanner message={error || null} />
 
       {/* Form card */}
       <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/app/javascript/admin/pages/roles/RoleNewPage.tsx
+++ b/app/javascript/admin/pages/roles/RoleNewPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { rolesApi } from '../../lib/api'
+import { AdminPageHeader } from '../../components/AdminPageHeader'
+import { ErrorBanner } from '../../components/ErrorBanner'
 
 export const RoleNewPage = () => {
   const navigate = useNavigate()
@@ -25,20 +27,9 @@ export const RoleNewPage = () => {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
-             style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>New Role</h1>
-        </div>
-      </div>
+      <AdminPageHeader eyebrow="MANAGEMENT" title="New Role" />
 
-      {error && (
-        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
-          {error}
-        </div>
-      )}
+      <ErrorBanner message={error || null} />
 
       {/* Form card */}
       <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/app/javascript/admin/pages/roles/RolePermissionPage.tsx
+++ b/app/javascript/admin/pages/roles/RolePermissionPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { rolesApi, permissionsApi, type Permission } from '../../lib/api'
+import { AdminPageHeader } from '../../components/AdminPageHeader'
+import { ErrorBanner } from '../../components/ErrorBanner'
 
 export const RolePermissionPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -66,20 +68,9 @@ export const RolePermissionPage = () => {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
-             style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>Role Permissions</h1>
-        </div>
-      </div>
+      <AdminPageHeader eyebrow="MANAGEMENT" title="Role Permissions" />
 
-      {error && (
-        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
-          {error}
-        </div>
-      )}
+      <ErrorBanner message={error || null} />
 
       <form onSubmit={handleSubmit}>
         {/* Permission groups */}

--- a/app/javascript/admin/pages/roles/RolesIndexPage.tsx
+++ b/app/javascript/admin/pages/roles/RolesIndexPage.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from 'react-router-dom'
 import { rolesApi, type Role, type PaginationMeta } from '../../lib/api'
 import Pagination from '../../components/Pagination'
 import { usePagination, useClampPage } from '../../hooks/usePagination'
+import { AdminPageHeader } from '../../components/AdminPageHeader'
+import { ErrorBanner } from '../../components/ErrorBanner'
 
 export const RolesIndexPage = () => {
   const navigate = useNavigate()
@@ -50,26 +52,20 @@ export const RolesIndexPage = () => {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
-             style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>Roles</h1>
-        </div>
-        <button
-          onClick={() => navigate('/admin/roles/new')}
-          className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]"
-        >
-          New Role
-        </button>
-      </div>
+      <AdminPageHeader
+        eyebrow="MANAGEMENT"
+        title="Roles"
+        action={
+          <button
+            onClick={() => navigate('/admin/roles/new')}
+            className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]"
+          >
+            New Role
+          </button>
+        }
+      />
 
-      {error && (
-        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
-          {error}
-        </div>
-      )}
+      <ErrorBanner message={error || null} />
 
       {/* Table */}
       <div className="rounded-xl border border-slate-200 bg-white shadow-sm">

--- a/app/models/admin_policy.rb
+++ b/app/models/admin_policy.rb
@@ -27,4 +27,13 @@ class AdminPolicy
   def can_manage?(resource_type)
     has_permission?(resource_type, "manage")
   end
+
+  def owned_permission_ids
+    @user.roles.joins(:permissions).distinct.pluck("permissions.id")
+  end
+
+  def can_grant_permissions?(permission_ids)
+    ids = Array(permission_ids).compact_blank.map(&:to_i)
+    (ids - owned_permission_ids).empty?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,7 +77,8 @@ class User < ApplicationRecord
   end
 
   delegate :admin?, :has_permission?, :can_read?, :can_write?,
-           :can_delete?, :can_manage?, to: :policy
+           :can_delete?, :can_manage?, :can_grant_permissions?,
+           :owned_permission_ids, to: :policy
 
   def force_destroy
     comments.destroy_all

--- a/test/models/admin_policy_test.rb
+++ b/test/models/admin_policy_test.rb
@@ -104,4 +104,57 @@ class AdminPolicyTest < ActiveSupport::TestCase
 
     assert_not @policy.can_manage?("User")
   end
+
+  # owned_permission_ids / can_grant_permissions? pinned contract tests
+
+  test "owned_permission_ids returns distinct ids for a user with multiple roles sharing a permission" do
+    shared_perm = Permission.find_by(resource_type: "User", action: "read")
+    role_a = Role.create!(name: "test_role_a")
+    role_b = Role.create!(name: "test_role_b")
+    role_a.permissions << shared_perm
+    role_b.permissions << shared_perm
+    @user.roles << role_a
+    @user.roles << role_b
+
+    ids = @policy.owned_permission_ids
+    assert_equal ids.uniq, ids
+    assert_includes ids, shared_perm.id
+  end
+
+  test "can_grant_permissions? returns true when all ids are owned, Integer input" do
+    perm_read  = Permission.find_by(resource_type: "User", action: "read")
+    perm_write = Permission.find_by(resource_type: "User", action: "write")
+    role = Role.create!(name: "test_role_int")
+    role.permissions << perm_read
+    role.permissions << perm_write
+    @user.roles << role
+
+    assert @policy.can_grant_permissions?([perm_read.id, perm_write.id])
+  end
+
+  test "can_grant_permissions? returns true when all ids are owned, String input" do
+    perm_read  = Permission.find_by(resource_type: "User", action: "read")
+    perm_write = Permission.find_by(resource_type: "User", action: "write")
+    role = Role.create!(name: "test_role_str")
+    role.permissions << perm_read
+    role.permissions << perm_write
+    @user.roles << role
+
+    assert @policy.can_grant_permissions?([perm_read.id.to_s, perm_write.id.to_s])
+  end
+
+  test "can_grant_permissions? returns false when any id is not owned, String input" do
+    perm_read = Permission.find_by(resource_type: "User", action: "read")
+    role = Role.create!(name: "test_role_neg")
+    role.permissions << perm_read
+    @user.roles << role
+
+    assert_not @policy.can_grant_permissions?([perm_read.id.to_s, "99999"])
+  end
+
+  test "can_grant_permissions? returns true on empty input (nil, [], and [''])" do
+    assert @policy.can_grant_permissions?(nil)
+    assert @policy.can_grant_permissions?([])
+    assert @policy.can_grant_permissions?([""])
+  end
 end


### PR DESCRIPTION
## Summary

- Lifts duplicated `protect_system_role` helper into `Api::V1::Admin::ApplicationController`; `RolesController` and `RolePermissionsController` drop their shadowed copies.
- Extracts `owned_permission_ids` / `can_grant_permissions?` into `AdminPolicy` (delegated via `User`), matching the Policy Object pattern documented in `docs/conventions/FAT_MODEL_DECOMPOSITION.md`. `RolePermissionsController#protect_permission_escalation` collapses from an 8-line inline calculation to a 2-line policy delegation.
- Introduces shared `AdminPageHeader` + `ErrorBanner` React components and applies them to roles pages (4 files, both) + permissions pages (2 files, header only — `<p>` error style preserved per AC).
- Adds 5 new `AdminPolicyTest` cases locking the pinned `can_grant_permissions?` normalization contract (Integer / String / negative-path String / empty input across `nil` / `[]` / `[""]`).

**Behavior unchanged** across all touched routes. 14 files changed, 139 insertions / 88 deletions.

Closes #297

## Test plan

- [x] Domain tests green at I2 per agent (`roles_controller_test.rb`: 33/0/0, `role_permissions_controller_test.rb` + `admin_policy_test.rb`: 32/0/0, `tsc --noEmit` in refactor scope: 0 errors)
- [x] Full suite green: `bin/rails test:all` → `899 runs, 2169 assertions, 0 failures, 0 errors, 2 skips` (2 skips pre-existing, unrelated)
- [x] Vite build probe green: `bin/vite build --clear --mode=test` → `✓ built in 651ms`
- [x] Parallel I4 local review: `/hobo-codex-review-rails` + `/hobo-codex-review-react` + `/hobo-codex-review-architecture` — 0 blockers

---

## Pilot Observations — fork-join same-type parallel dispatch

**Pattern**: 4-way fork (2× rails-developer + 2× react-developer), preceded by 2× Pre-Fork agents (1 rails + 1 react in parallel) = **6 agent dispatches total**
**Pre-Fork**: Rails delegated (3 file edits + 2 probes as domain tests) + React delegated (2 new files) — 1 message, both agents dispatched in parallel.

### Completion Verification (per agent, 4 items each)

All 6 agents × 4 items = **24/24 PASS**. Details:

- **Pre-Fork-Rails** — ✅ Denylist clean (3 files in scope) / ✅ Plan items satisfied (1a, 1b, 1c verbatim + pinned contract) / ✅ Domain tests green (Probe A: `true`, Probe B: `57 runs, 101 assertions, 0 failures`) / ✅ Return Format 5 sections
- **Pre-Fork-R** — ✅ Denylist clean (2 new files) / ✅ Plan items satisfied (verbatim class strings) / ✅ Domain tests green (`npx tsc --noEmit`: only allowlisted 3 pre-existing errors) / ✅ Return Format 5 sections
- **Rails-A** (Roles) — ✅ Denylist clean (`roles_controller.rb` only) / ✅ Plan items (local `protect_system_role` removed, `before_action` preserved) / ✅ Domain tests (`33 runs, 53 assertions, 0 failures`) / ✅ Return Format
- **Rails-B** (RolePermissions + Policy tests) — ✅ Denylist clean (`role_permissions_controller.rb` + append-only `admin_policy_test.rb`) / ✅ Plan items (2-line delegation + 5 new pinned-contract tests) / ✅ Domain tests (`32 runs, 45 assertions, 0 failures`) / ✅ Return Format
- **React-C** (Roles pages) — ✅ Denylist clean (4 files in scope) / ✅ Plan items (all 4 pages use both new components) / ✅ Domain tests (direct tsc re-run: 0 errors in refactor scope) / ✅ Return Format. **Minor deviation**: `error` state typed `string` → `message={error || null}` cast used (behavior equivalent, preserves existing state — accepted).
- **React-D** (Permissions pages) — ✅ Denylist clean (2 files + `ErrorBanner` not imported per AC) / ✅ Plan items (header only, inline `<p>` preserved) / ✅ Domain tests (direct tsc re-run clean) / ✅ Return Format

### New pilot observations (not in original template)

**1. Parallel agent race on shared tsc state.** React-D's domain-test run hit a transient TS6133 error on `RoleNewPage.tsx` ("`ErrorBanner` declared but never read") because React-C was still mid-write when React-D's tsc fired. The final state was clean — orchestrator direct tsc re-run confirmed 0 errors. **Lesson**: parallel agents can observe sibling mid-write state through shared tool invocations (type-checkers, linters, build probes). Post-Join verification must re-run checks directly rather than trusting each agent's in-flight report.

**2. Pre-Fork-R `@admin/*` alias false assumption → I3 Vite build crash.** Pre-Fork-R's Handoff Note recommended `import { X } from '@admin/components/X'` based on `tsconfig.json`'s `paths` entry. `tsc --noEmit` (the agent's domain test) passed. But `vite.config.mts` has **no `resolve.alias`** — Vite/Rollup can't resolve `@admin/*`. The mismatch wasn't caught until I3 (`bin/rails test:all`), which produced **155 identical errors** from `ActionView::Template::Error: Vite Ruby can't find entrypoints/application.js`. Existing production pages use relative imports (`'../../components/Badge'`); `@admin/*` is used only in `__tests__/` (vitest, separate config). **Fix**: orchestrator direct rewrite of 6 page files' imports to relative paths, verified by `bin/vite build --clear --mode=test` (`✓ built in 651ms`). **Lesson**: `tsc --noEmit` is not a sufficient domain test for SPA import changes in a Vite-backed Rails app — Pre-Fork payloads touching imports should specify `tsc --noEmit` **and** `bin/vite build --mode=test` as the domain-test pair.

### Fallback paths

- Domain-test failure fallback (I2 level): **UNTESTED — happy path only**
- Denylist violation fallback: **UNTESTED — happy path only**
- Type-mismatch redispatch fallback: **UNTESTED — happy path only**
- Return Format violation fallback: **UNTESTED — happy path only**
- maxTurns exhaustion fallback: **UNTESTED — happy path only**
- **I3 payload-design failure fallback (new category — NOT in original template): TRIGGERED**. The Vite alias mismatch surfaced at I3, not I2. Because the root cause was orchestrator-side payload design (wrong domain test chosen) rather than an agent bug, direct orchestrator fix was the right call — re-delegation would have added overhead for a 6-line mechanical rewrite. This reinforces the DELEGATION.md §Fallback rule that the orchestrator takes over when the fix is trivial relative to the re-dispatch cost.

### Observations (template fills)

- **Parallel wall-clock vs estimated serial**: Pre-Fork dispatch wall-clock ~3 min for both agents (max of 167s Rails + 124s React). Fork dispatch wall-clock ~4 min (max of 192s Rails-A + 155s Rails-B + 189s React-C + 58s React-D). **Total I2 wall-clock ~7 min** vs estimated serial sum of ~15 min → **~2× speedup**. The long tail was Rails-A (192s) and React-C (189s) — future parallelism gains are capped by the slowest agent, not the sum.
- **Did 3 parallel I4 reviews produce differentiated findings vs single `/codex-review`?** Yes. **rails + architecture reviews both returned zero findings** (security + policy pattern verified); **react review returned 3 Medium + 4 Low findings**, 1 of which was a false positive vs plan (rejected with plan evidence), 1 YAGNI (rejected), 1 pre-existing observation, and 4 follow-up candidates tracked in #308. A single generic `/codex-review` would almost certainly have missed the React-specific convention cross-check against `docs/conventions/ADMIN_UI.md`. **Parallel 3-way I4 review is a keeper pattern for cross-cutting Admin PRs.**
- **Surprises about Pre-Fork size or shared-file coordination?** Two surprises: (a) Pre-Fork-R's `@admin/*` alias recommendation was accepted without runtime probe, causing the I3 failure above — **a `vite build` probe should be added to Pre-Fork-R's domain tests for any future SPA import refactor**; (b) the first `/hobo-codex-review-react` invocation returned empty (skill's task-detection logic didn't pick up the uncommitted diff without explicit args), requiring a second invocation with explicit file list — **skill-side bug to fix in a follow-up**.
- **Codex CLI v0.120.0 quirk observed in all 3 review skills**: `codex review --uncommitted` is mutually exclusive with `[PROMPT]` argument. All 3 skill agents hit this and independently fell back to workarounds (auto-scope detection, stdin pipe). **Skill cards should be updated** to document the correct invocation form — tracked as follow-up.

### Model/policy note

`AdminPolicy` extended with `owned_permission_ids` / `can_grant_permissions?` — pattern unchanged (still a Policy Object, still the same delegation surface in `User`). `docs/conventions/FAT_MODEL_DECOMPOSITION.md` Fat Model table still accurate; **no doc update needed**.

### React review findings disposition

| # | Finding | Severity | Disposition |
|---|---|---|---|
| M1 | Permissions pages still use inline `<p className=\"text-rose-500\">` instead of `ErrorBanner` | Medium | **Reject (false positive)** — plan explicitly out-of-scope, preserving `<p>` style is an AC, reviewer lacked plan context |
| M2 | `AdminPageHeader` lacks `subtitle?: string` prop | Medium | **Reject (YAGNI)** — 0 consumers in current scope need a subtitle; speculative future requirement |
| M3 | Hardcoded `#6366f1` in input focus rings / checkboxes | Medium | **No action** — reviewer explicitly labeled as pre-existing, not introduced by this PR |
| L4 | 14+18 other admin pages still duplicate `ErrorBanner` / `AdminPageHeader` patterns | Low | **Deferred to #308** (already filed at P5) |
| L5 | `ErrorBanner` prop shape `message: string \| null` forces `error \|\| null` at call sites | Low | **Deferred to #308** — minor API cleanup |
| L6 | Loading state uses unstyled `<p>Loading...</p>` | Low | **Deferred** — pre-existing, separate follow-up |
| L7 | Consider extracting `CardHeader` for inline card headings | Low | **Deferred to #308** |

### Follow-up Issue

- #308 — **Apply AdminPageHeader / ErrorBanner to remaining Admin SPA pages (follow-up to #297)** — tracks migration of 14 remaining `rose-500/30` banner sites + 18 remaining `MANAGEMENT` eyebrow sites, plus the Low-severity follow-ups (ErrorBanner prop cleanup, CardHeader extraction, loading state standardization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)