### PR TITLE
fix: resolve TypeScript type errors and move tsc to pre-push hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,11 +44,6 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx)$'; then repo=$(git rev-parse --show-toplevel 2>/dev/null); if [ -z \"$repo\" ]; then exit 0; fi; relf=\"${f#$repo/}\"; result=$(npx tsc --noEmit 2>&1); rc=$?; filtered=$(printf '%s' \"$result\" | grep -F \"$relf\" || true); if [ -n \"$filtered\" ]; then jq -n --arg ctx \"TypeScript errors in $relf (tsc exit $rc):\\n$filtered\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; fi; fi; }",
-            "statusMessage": "Running tsc type check..."
-          },
-          {
-            "type": "command",
             "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx)$'; then result=$(npx eslint \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then jq -n --arg ctx \"ESLint errors in $f. Fix them: $result\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; fi; fi; }",
             "statusMessage": "Running eslint..."
           },

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,16 +1,31 @@
 #!/bin/sh
-# Pre-push hook to run rubocop before pushing
+# Pre-push hook to run rubocop + tsc before pushing
 
 echo "Running rubocop before push..."
 echo ""
 
-if bin/rubocop; then
-  echo ""
-  echo "✅ Rubocop passed! Proceeding with push."
-  exit 0
-else
+if ! bin/rubocop; then
   echo ""
   echo "❌ Rubocop failed. Please fix the issues before pushing."
   echo "To push anyway, use: git push --no-verify"
   exit 1
 fi
+echo ""
+echo "✅ Rubocop passed."
+echo ""
+
+echo "Running TypeScript typecheck before push..."
+echo ""
+
+if ! npm run typecheck --silent; then
+  echo ""
+  echo "❌ TypeScript typecheck failed. Please fix the issues before pushing."
+  echo "To push anyway, use: git push --no-verify"
+  exit 1
+fi
+echo ""
+echo "✅ TypeScript typecheck passed."
+echo ""
+
+echo "✅ All checks passed! Proceeding with push."
+exit 0

--- a/app/javascript/admin/__tests__/contexts/AuthContext.test.tsx
+++ b/app/javascript/admin/__tests__/contexts/AuthContext.test.tsx
@@ -27,6 +27,7 @@ const makeCapabilities = (overrides: Partial<Record<string, Partial<Record<strin
     Comment: { ...defaults, ...overrides.Comment },
     Admin: { ...defaults, ...overrides.Admin },
     LlmProvider: { ...defaults, ...overrides.LlmProvider },
+    EventLog: { ...defaults, ...overrides.EventLog },
   }
 }
 

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -235,7 +235,7 @@ export const adminAccountsApi = {
   update: (id: number, data: UpdateAdminAccountInput) =>
     api.patch<User>(`/admin_accounts/${id}`, { admin_account: data }),
   delete: (id: number) => api.delete<void>(`/admin_accounts/${id}`),
-  revoke: (id: number) => api.post<void>(`/admin_accounts/${id}/revocation`),
+  revoke: (id: number) => api.post<void>(`/admin_accounts/${id}/revocation`, {}),
   getRoles: (id: number) => api.get<Role[]>(`/admin_accounts/${id}/roles`),
   updateRoles: (id: number, roleIds: number[]) =>
     api.patch<Role[]>(`/admin_accounts/${id}/roles`, { role_ids: roleIds }),

--- a/app/javascript/admin/pages/events/EventsIndexPage.tsx
+++ b/app/javascript/admin/pages/events/EventsIndexPage.tsx
@@ -149,7 +149,8 @@ export const EventsIndexPage = () => {
   // stuck on an empty table with broken pagination even though earlier pages
   // have data. Uses `replace: true` to scrub the bad URL from history.
   useEffect(() => {
-    if (meta.total_pages > 0 && filters.page > meta.total_pages) {
+    const currentPage = filters.page ?? 1
+    if (meta.total_pages > 0 && currentPage > meta.total_pages) {
       setSearchParams(prev => {
         const next = new URLSearchParams(prev)
         if (meta.total_pages <= 1) next.delete('page')

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "npx playwright test",
     "test:e2e:coverage": "npx playwright test --project=chromium",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
       "@admin/*": ["app/javascript/admin/*"]
     }
   },
-  "include": ["app/javascript/admin/**/*", "vite.config.mts"]
+  "include": ["app/javascript/admin/**/*", "vite.config.mts"],
+  "exclude": ["app/javascript/admin/__tests__/**/*"]
 }


### PR DESCRIPTION
## Summary

- `npx tsc --noEmit` was failing with a mix of real type errors and structural noise; this PR fixes the real errors and restructures how TypeScript type checking runs.
- Three real errors were fixed in `api.ts`, `EventsIndexPage.tsx`, and `AuthContext.test.tsx`.
- The tsc hook moved from Claude Code PostToolUse to the existing `.githooks/pre-push`, mirroring how rubocop is already enforced on push.

## Details

### Real type errors (commit 1: `fix(admin)...`)

1. `app/javascript/admin/lib/api.ts:238` — `adminAccountsApi.revoke` called `api.post<void>(path)` without the required `body` argument. Fixed by passing `{}`.
2. `app/javascript/admin/pages/events/EventsIndexPage.tsx:152` — the out-of-range `page` clamp `useEffect` compared `filters.page > meta.total_pages`, but `EventLogListParams.page` is optional. Guarded with `const currentPage = filters.page ?? 1`.
3. `app/javascript/admin/__tests__/contexts/AuthContext.test.tsx:23` — `ResourceType` was extended to include `'EventLog'` in an earlier PR, but the `makeCapabilities` test helper wasn't updated. Added the missing `EventLog` entry.

### Type-check tooling & hook restructure (commit 2: `chore(typecheck)...`)

**Problem:** The root `tsconfig.json` included `app/javascript/admin/**/*` which swept in `__tests__/`, but the vitest/@testing-library type definitions only exist in `tsconfig.test.json` via `types: ["vitest/globals", "@testing-library/jest-dom"]`. Plain `tsc --noEmit` reported every vitest global (`vi`, `describe`, `it`, `expect`, …) as unresolved, swamping any real error.

The Claude PostToolUse tsc hook invoked the default `tsconfig.json` on every TS/TSX edit and filtered output by filename, which:
- was slow (full project scan per edit),
- couldn't see test files at all after the exclude below, and
- duplicated work that a pre-push gate already handles for Ruby via rubocop.

**Changes:**
- `tsconfig.json`: add `"exclude": ["app/javascript/admin/__tests__/**/*"]` so the default project no longer tries to type-check test files without vitest globals.
- `package.json`: add a `typecheck` script that runs **both** configs:
  ```
  "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
  ```
  A single `npm run typecheck` now covers the full project.
- `.githooks/pre-push`: run `npm run typecheck --silent` after rubocop. Failure blocks the push with the same `git push --no-verify` escape hatch rubocop already offers.
- `.claude/settings.json`: remove the PostToolUse tsc hook (the per-edit full-project scan). The eslint and rubocop per-file hooks remain untouched; type checking is now gated on push only.

## Trade-off

Type errors are no longer surfaced in real-time during Claude Code edits — they are caught at `git push`. This mirrors the existing rubocop behavior and reduces per-edit overhead. Run `npm run typecheck` manually if a mid-session check is needed.

## Test plan

- [x] `npm run typecheck` passes locally (both `tsconfig.json` and `tsconfig.test.json`)
- [x] `npx vitest run app/javascript/admin/__tests__/contexts/AuthContext.test.tsx` → 4/4 pass
- [x] `.githooks/pre-push` runs rubocop + typecheck end-to-end during `git push`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)