### PR TITLE
chore(claude-hooks): unify additionalContext newline pattern via jq concat

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,12 +39,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); if echo \"$f\" | rg -q '\\.rb$'; then result=$(bundle exec rubocop --no-color \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then safe_result=$(printf '%s' \"$result\" | tr -cd '\\11\\12\\15\\40-\\176'); snippet=$(printf '%s' \"$safe_result\" | sed -n '1,20p'); jq -n --arg ctx \"RuboCop issues in $f (exit $rc). Fix them:\\n$snippet\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; fi; fi; true",
+            "command": "f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); if echo \"$f\" | rg -q '\\.rb$'; then result=$(bundle exec rubocop --no-color \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then safe_result=$(printf '%s' \"$result\" | tr -cd '\\11\\12\\15\\40-\\176'); snippet=$(printf '%s' \"$safe_result\" | sed -n '1,20p'); jq -n --arg hdr \"RuboCop issues in $f (exit $rc). Fix them:\" --arg body \"$snippet\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":($hdr + \"\\n\" + $body)}}'; fi; fi; true",
             "statusMessage": "Running rubocop..."
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx)$'; then result=$(npx eslint \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then jq -n --arg ctx \"ESLint errors in $f. Fix them: $result\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; fi; fi; }",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx)$'; then result=$(npx eslint \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then jq -n --arg hdr \"ESLint errors in $f. Fix them:\" --arg body \"$result\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":($hdr + \"\\n\" + $body)}}'; fi; fi; }",
             "statusMessage": "Running eslint..."
           },
           {


### PR DESCRIPTION
## Summary

- bash double-quoted `\n` never interprets as a newline, so `jq --arg ctx "...:\n..."` was surfacing a literal backslash-n in the agent's `additionalContext` instead of a real line break
- Move newline construction inside jq where `"\n"` has defined semantics, using a shared `$hdr + "\n" + $body` concat pattern across both PostToolUse hooks
- Fixes the rubocop hook (actual bug) and realigns the eslint hook to the same pattern for intra-file consistency

## Scope note

The tsc PostToolUse hook originally listed in #307 was removed in 59c500f (moved to `.githooks/pre-push`), so this lands as a two-hook unification rather than three. No behavior change to filter logic (rubocop's `tr -cd` sanitization, eslint's direct stdout capture) — purely cosmetic output formatting.

## Test plan

- [x] JSON validity of `.claude/settings.json` (`jq -e .`)
- [x] Empirical probe: ran the exact rubocop `jq -n ...` command with a simulated multi-line snippet and confirmed `additionalContext` decodes to real line breaks (not literal `\n`)
- [x] Empirical probe: same for eslint hook payload
- [x] Pre-push hook chain (rubocop + tsc) passed locally before push
- [ ] Next rubocop/eslint-triggering edit in a fresh Claude Code session surfaces multi-line `additionalContext` to confirm end-to-end (requires session reload for the hook config to take effect)

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)