### PR TITLE
fix(tooling): codex CLI PROMPT and scope options are mutually exclusive

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -45,9 +45,9 @@ Read these before constructing the review request:
    codex CLI was not found on this machine. Review could not be performed.
    ```
 2. Determine the review scope from the orchestrator payload. Default is `--base main`.
-3. Read the Reference Docs listed above to incorporate project-specific conventions into your review request.
-4. Build a `<request>` string incorporating the Review Focus checklist and referencing the key project docs.
-5. Run `codex review "<request>" <scope-option>` from the project root.
+3. Read the Reference Docs listed above to understand project-specific conventions.
+4. Run `codex review <scope-option>` from the project root (e.g., `codex review --base main`). Note: `PROMPT` and scope options (`--base`, `--uncommitted`, `--commit`) are mutually exclusive in the codex CLI — do not pass a custom prompt when using a scope option.
+5. Evaluate the codex output through the lens of the Review Focus checklist and Reference Docs above. Prioritize and categorize findings accordingly.
 6. Structure the output into the Required Return Format below.
 
 ## Required Return Format

--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -45,13 +45,14 @@ If a must-read file does not exist, record it under Deviations and continue with
 6. **Run the domain test suite** named in the payload (e.g., `bin/rails test test/controllers/api/v1/admin/foos_controller_test.rb test/models/foo_test.rb`).
 7. **Review & fix (single pass).** After domain tests pass, perform a self-review using `codex review`:
    a. Run `which codex` to verify the CLI is available. If not found, skip this step and note "codex CLI not installed — review skipped" in Handoff Notes.
-   b. Run `codex review "<request>" --base main` where `<request>` incorporates:
+   b. Run `codex review --base main` to review all branch changes. Note: `PROMPT` and `--base` are mutually exclusive in the codex CLI — do not pass a custom prompt when using `--base`.
+   c. Evaluate the codex output through the lens of this project's Rails conventions:
       - RESTful routing (see `docs/conventions/ROUTING.md`)
       - ActiveRecord query patterns (see `docs/conventions/ACTIVE_RECORD_QUERIES.md`)
       - Fat model decomposition (see `docs/conventions/FAT_MODEL_DECOMPOSITION.md`)
       - Authorization (`require_capability!`, `current_user` scoping)
       - Test coverage (see `docs/conventions/TESTING.md`)
-   c. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
+   d. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes.
 8. **Return in the required format** (see below). Report the final command line and its last line of output verbatim.
 
 ## Scope discipline

--- a/.claude/agents/rails-reviewer.md
+++ b/.claude/agents/rails-reviewer.md
@@ -45,9 +45,9 @@ Read these before constructing the review request:
    codex CLI was not found on this machine. Review could not be performed.
    ```
 2. Determine the review scope from the orchestrator payload. Default is `--base main`.
-3. Read the Reference Docs listed above to incorporate project-specific conventions into your review request.
-4. Build a `<request>` string incorporating the Review Focus checklist and referencing the convention docs.
-5. Run `codex review "<request>" <scope-option>` from the project root.
+3. Read the Reference Docs listed above to understand project-specific conventions.
+4. Run `codex review <scope-option>` from the project root (e.g., `codex review --base main`). Note: `PROMPT` and scope options (`--base`, `--uncommitted`, `--commit`) are mutually exclusive in the codex CLI — do not pass a custom prompt when using a scope option.
+5. Evaluate the codex output through the lens of the Review Focus checklist and Reference Docs above. Prioritize and categorize findings accordingly.
 6. Structure the output into the Required Return Format below.
 
 ## Required Return Format

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -43,13 +43,14 @@ If a must-read file does not exist, record it under Deviations and continue with
 7. **Run the domain tests** named in the payload (React unit tests via the project's test runner, or system tests via `bin/rails test test/system/...`).
 8. **Review & fix (single pass).** After domain tests pass, perform a self-review using `codex review`:
    a. Run `which codex` to verify the CLI is available. If not found, skip this step and note "codex CLI not installed — review skipped" in Handoff Notes for orchestrator.
-   b. Run `codex review "<request>" --base main` where `<request>` incorporates:
+   b. Run `codex review --base main` to review all branch changes. Note: `PROMPT` and `--base` are mutually exclusive in the codex CLI — do not pass a custom prompt when using `--base`.
+   c. Evaluate the codex output through the lens of this project's React Admin conventions:
       - ADMIN_UI conventions (see `docs/conventions/ADMIN_UI.md`)
       - Design token usage (see `docs/design/admin/README.md`)
       - api.ts patterns (see `app/javascript/admin/lib/api.ts`)
       - Component structure and TypeScript correctness
       - No Hotwire/Turbo in admin
-   c. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
+   d. Fix actionable findings within your domain, then re-run the domain test suite to confirm nothing broke. Report what was fixed and what was deferred (with reason) in Handoff Notes for orchestrator.
 9. **Return in the required format** (see below).
 
 ## Scope discipline

--- a/.claude/agents/react-reviewer.md
+++ b/.claude/agents/react-reviewer.md
@@ -44,9 +44,9 @@ Read these before constructing the review request:
    codex CLI was not found on this machine. Review could not be performed.
    ```
 2. Determine the review scope from the orchestrator payload. Default is `--base main`.
-3. Read the Reference Docs listed above to incorporate project-specific conventions into your review request.
-4. Build a `<request>` string incorporating the Review Focus checklist and referencing the convention docs.
-5. Run `codex review "<request>" <scope-option>` from the project root.
+3. Read the Reference Docs listed above to understand project-specific conventions.
+4. Run `codex review <scope-option>` from the project root (e.g., `codex review --base main`). Note: `PROMPT` and scope options (`--base`, `--uncommitted`, `--commit`) are mutually exclusive in the codex CLI — do not pass a custom prompt when using a scope option.
+5. Evaluate the codex output through the lens of the Review Focus checklist and Reference Docs above. Prioritize and categorize findings accordingly.
 6. Structure the output into the Required Return Format below.
 
 ## Required Return Format


### PR DESCRIPTION
## Summary
- Fix `codex review` invocation in all 5 agent definitions: `PROMPT` and scope options (`--base`, `--uncommitted`, `--commit`) are mutually exclusive in the codex CLI
- Use scope option only (`codex review --base main`) and evaluate output through each agent's Review Focus lens instead of passing a custom prompt
- Discovered during #309 I4 review — initially dismissed as false positive based on `--help` output, but runtime verification confirmed the constraint

## Changed Files
- `.claude/agents/rails-developer.md` — Step 7b: remove PROMPT, use `--base main` only
- `.claude/agents/react-developer.md` — Step 8b: remove PROMPT, use `--base main` only
- `.claude/agents/rails-reviewer.md` — Procedure step 4-5: remove PROMPT, use scope option only
- `.claude/agents/react-reviewer.md` — Procedure step 4-5: remove PROMPT, use scope option only
- `.claude/agents/architecture-reviewer.md` — Procedure step 4-5: remove PROMPT, use scope option only

## Test plan
- [x] Verified `codex review "prompt" --base main` → `error: the argument '[PROMPT]' cannot be used with '--base <BRANCH>'`
- [x] Verified `codex review --base main` → works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)