### PR TITLE
fix(auth): move Basic Auth to Rack middleware to gate pre-routing paths

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,11 +10,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
-  if ENV["BASIC_AUTH_USERNAME"].present? && ENV["BASIC_AUTH_PASSWORD"].present?
-    http_basic_authenticate_with name: ENV.fetch("BASIC_AUTH_USERNAME", nil),
-                                 password: ENV.fetch("BASIC_AUTH_PASSWORD", nil)
-  end
-
   private
 
     def in_time_zone_and_locale(&)

--- a/config/initializers/basic_auth.rb
+++ b/config/initializers/basic_auth.rb
@@ -28,8 +28,12 @@ class BasicAuthWithHealthcheckExemption
 end
 
 if ENV["BASIC_AUTH_USERNAME"].present? && ENV["BASIC_AUTH_PASSWORD"].present?
-  Rails.application.config.middleware.insert_after(
-    ActionDispatch::HostAuthorization,
+  # NOTE: anchor on Rack::Sendfile (unconditionally inserted by Rails 8's
+  # default_middleware_stack) rather than ActionDispatch::HostAuthorization,
+  # which is only inserted when config.hosts is non-empty. Production leaves
+  # config.hosts unset, so insert_after HostAuthorization would raise at boot.
+  Rails.application.config.middleware.insert_before(
+    Rack::Sendfile,
     BasicAuthWithHealthcheckExemption,
     ENV.fetch("BASIC_AUTH_USERNAME"),
     ENV.fetch("BASIC_AUTH_PASSWORD"),

--- a/config/initializers/basic_auth.rb
+++ b/config/initializers/basic_auth.rb
@@ -1,0 +1,37 @@
+# NOTE: Rack middleware for pilot-phase Basic Auth gating.
+# Placed here (rather than app/middleware/) for simplicity while this is the only
+# custom middleware. If additional middleware is added, consider relocating to
+# app/middleware/ with Zeitwerk autoload.
+# Only the /up health-check path is exempted; adding further exemptions requires
+# an explicit edit here, not a config change.
+
+require "rack/auth/basic"
+
+class BasicAuthWithHealthcheckExemption
+  HEALTHCHECK_PATH = "/up".freeze
+
+  def initialize(app, username, password)
+    @app = app
+    # NOTE: pass the downstream app (not self) to Rack::Auth::Basic to avoid
+    # recursion — Rack::Auth::Basic calls @app on successful auth.
+    @basic_auth = Rack::Auth::Basic.new(app, "Restricted") do |u, p|
+      ActiveSupport::SecurityUtils.secure_compare(u.to_s, username) &
+        ActiveSupport::SecurityUtils.secure_compare(p.to_s, password)
+    end
+  end
+
+  def call(env)
+    return @app.call(env) if env["PATH_INFO"] == HEALTHCHECK_PATH
+
+    @basic_auth.call(env)
+  end
+end
+
+if ENV["BASIC_AUTH_USERNAME"].present? && ENV["BASIC_AUTH_PASSWORD"].present?
+  Rails.application.config.middleware.insert_after(
+    ActionDispatch::HostAuthorization,
+    BasicAuthWithHealthcheckExemption,
+    ENV.fetch("BASIC_AUTH_USERNAME"),
+    ENV.fetch("BASIC_AUTH_PASSWORD"),
+  )
+end

--- a/lib/tasks/test_suites.rake
+++ b/lib/tasks/test_suites.rake
@@ -29,7 +29,7 @@ namespace :test do
     ])
   end
 
-  desc "Run auth domain tests (User, sessions, passwords, email, TOTP)"
+  desc "Run auth domain tests (User, sessions, passwords, email, TOTP, Basic Auth middleware)"
   task auth: :environment do
     Rails::TestUnit::Runner.run_from_rake("test", [
       "test/models/user_test.rb",
@@ -40,6 +40,7 @@ namespace :test do
       "test/controllers/emails_controller_test.rb",
       "test/controllers/users_controller_test.rb",
       "test/controllers/totp",
+      "test/middleware",
     ])
   end
 

--- a/test/middleware/basic_auth_with_healthcheck_exemption_test.rb
+++ b/test/middleware/basic_auth_with_healthcheck_exemption_test.rb
@@ -79,7 +79,7 @@ class BasicAuthWithHealthcheckExemptionTest < ActiveSupport::TestCase
   end
 
   test "GET /up?foo=bar without Authorization header passes through" do
-    env = rack_env("/up", query_string: "foo=bar")
+    env = rack_env("/up?foo=bar")
     status, _headers, body = @middleware.call(env)
 
     assert_equal 200, status
@@ -100,10 +100,8 @@ class BasicAuthWithHealthcheckExemptionTest < ActiveSupport::TestCase
 
   private
 
-    def rack_env(path, method: "GET", basic_auth: nil, query_string: "")
+    def rack_env(path, method: "GET", basic_auth: nil)
       env = Rack::MockRequest.env_for(path, method: method)
-      env["PATH_INFO"] = path
-      env["QUERY_STRING"] = query_string
       if basic_auth
         encoded = Base64.strict_encode64(basic_auth.join(":"))
         env["HTTP_AUTHORIZATION"] = "Basic #{encoded}"

--- a/test/middleware/basic_auth_with_healthcheck_exemption_test.rb
+++ b/test/middleware/basic_auth_with_healthcheck_exemption_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+require "base64"
+
+class BasicAuthWithHealthcheckExemptionTest < ActiveSupport::TestCase
+  USERNAME = "user".freeze
+  PASSWORD = "secret".freeze
+
+  setup do
+    downstream = ->(_env) { [200, { "Content-Type" => "text/plain" }, ["OK"]] }
+    @middleware = BasicAuthWithHealthcheckExemption.new(downstream, USERNAME, PASSWORD)
+  end
+
+  # Core paths
+
+  test "GET /up without Authorization header passes through" do
+    status, _headers, body = @middleware.call(rack_env("/up"))
+
+    assert_equal 200, status
+    assert_equal ["OK"], body
+  end
+
+  test "GET / without Authorization header returns 401 with WWW-Authenticate" do
+    status, headers, _body = @middleware.call(rack_env("/"))
+
+    assert_equal 401, status
+    # Rack 3 uses lowercase header names.
+    assert_equal %(Basic realm="Restricted"), headers["www-authenticate"]
+  end
+
+  test "GET / with correct credentials passes through" do
+    env = rack_env("/", basic_auth: [USERNAME, PASSWORD])
+    status, _headers, body = @middleware.call(env)
+
+    assert_equal 200, status
+    assert_equal ["OK"], body
+  end
+
+  test "GET / with correct username but wrong password returns 401" do
+    env = rack_env("/", basic_auth: [USERNAME, "wrong"])
+    status, _headers, _body = @middleware.call(env)
+
+    assert_equal 401, status
+  end
+
+  test "GET / with wrong username but correct password returns 401" do
+    env = rack_env("/", basic_auth: ["wrong", PASSWORD])
+    status, _headers, _body = @middleware.call(env)
+
+    assert_equal 401, status
+  end
+
+  test "GET /up with wrong credentials still passes through (exempt wins)" do
+    env = rack_env("/up", basic_auth: %w[wrong wrong])
+    status, _headers, body = @middleware.call(env)
+
+    assert_equal 200, status
+    assert_equal ["OK"], body
+  end
+
+  # Exempt semantics edge cases
+
+  test "HEAD /up without Authorization header passes through" do
+    env = rack_env("/up", method: "HEAD")
+    status, _headers, _body = @middleware.call(env)
+
+    assert_equal 200, status
+  end
+
+  test "GET /up/ (trailing slash) without Authorization header returns 401" do
+    status, _headers, _body = @middleware.call(rack_env("/up/"))
+
+    assert_equal 401, status
+  end
+
+  test "GET /UP (uppercase) without Authorization header returns 401" do
+    status, _headers, _body = @middleware.call(rack_env("/UP"))
+
+    assert_equal 401, status
+  end
+
+  test "GET /up?foo=bar without Authorization header passes through" do
+    env = rack_env("/up", query_string: "foo=bar")
+    status, _headers, body = @middleware.call(env)
+
+    assert_equal 200, status
+    assert_equal ["OK"], body
+  end
+
+  test "GET / with malformed Authorization header returns 4xx without raising" do
+    env = rack_env("/")
+    env["HTTP_AUTHORIZATION"] = "Basic zzzzz"
+
+    # Delegated to Rack::Auth::Basic. Its default behavior returns 400 Bad Request
+    # for malformed credentials. The test pins the contract: client error, no exception.
+    status, _headers, _body = @middleware.call(env)
+
+    assert_operator status, :>=, 400
+    assert_operator status, :<, 500
+  end
+
+  private
+
+    def rack_env(path, method: "GET", basic_auth: nil, query_string: "")
+      env = Rack::MockRequest.env_for(path, method: method)
+      env["PATH_INFO"] = path
+      env["QUERY_STRING"] = query_string
+      if basic_auth
+        encoded = Base64.strict_encode64(basic_auth.join(":"))
+        env["HTTP_AUTHORIZATION"] = "Basic #{encoded}"
+      end
+      env
+    end
+end


### PR DESCRIPTION
Closes #321

## Summary
- ApplicationController の `http_basic_authenticate_with` を Rack ミドルウェア `BasicAuthWithHealthcheckExemption` に移設。ルーティング到達前にゲート可能になり、`/wp-admin`・`/.env`・`*.php` 等への未ルート攻撃も 401 で遮断する (従来は `ActionController::RoutingError` がログを圧迫していた)。
- Render ヘルスチェック (`GET /up`) のみ exempt (完全一致、case-sensitive、末尾スラッシュ不可)。`/up?foo=bar` のようなクエリ付きは通過。
- credentials 比較は `ActiveSupport::SecurityUtils.secure_compare` を single `&` で結合して timing-safe / non-short-circuit に。
- 有効化条件は従来どおり: `BASIC_AUTH_USERNAME` と `BASIC_AUTH_PASSWORD` が両方 present のときのみミドルウェアを挿入 (両方未設定なら挿入されず通常動作)。

## Technical Notes
- **挿入アンカー**: `insert_before Rack::Sendfile`。初版は `insert_after ActionDispatch::HostAuthorization` を想定していたが、`ActionDispatch::HostAuthorization` は `config.hosts` 非空のときのみスタックに入るため、`config.hosts` 未設定の production では `"No such middleware to insert after: ActionDispatch::HostAuthorization"` で boot が落ちることを実機再現して判明 (I4 local review 指摘)。`Rack::Sendfile` は Rails 8 の `default_middleware_stack.rb` で無条件に `use` されるため全環境で安定。
- **配置**: `config/initializers/basic_auth.rb` にクラス定義と条件付き挿入を同居。当面カスタムミドルウェアがこの 1 つだけなので。将来増えたら `app/middleware/` への移設を検討。
- **Rollback 注意**: この PR は controller 側の Basic Auth 削除を同時に行うため、env var unset による forward-fix は完全無認証状態を招く。ロールバックは **PR revert** が正しい手順。

## Test plan
- [x] `bin/rails test test/middleware/basic_auth_with_healthcheck_exemption_test.rb` → 11 tests green (core 6 ケース + exempt edge cases 5 ケース: HEAD, 末尾スラッシュ, 大文字, クエリ, malformed header)
- [x] `bin/rails test:auth` → 59 tests green (既存 48 + 新規 11)
- [x] `bin/rails test:all` → 910 tests, 0 failures, 0 errors, 2 skips (pre-existing)
- [x] `BASIC_AUTH_USERNAME=u BASIC_AUTH_PASSWORD=p bin/rails middleware` で dev 環境挿入順序確認: `HostAuthorization → BasicAuth → Sendfile → Static`
- [x] `RAILS_ENV=test BASIC_AUTH_USERNAME=u BASIC_AUTH_PASSWORD=p bin/rails middleware` (hosts 空 = prod 相当) で `BasicAuth → Sendfile → Static` 挿入成功を確認 (boot error 再発なし)
- [ ] **Prod 検証 (merge + deploy 後)**: Render でヘルスチェック green 維持 / スキャナー由来 `RoutingError` が止まる / env var を両方 unset した状態で通常動作に戻ることを確認

## Review Findings
- **CRITICAL** (I4 rails-reviewer + architecture-reviewer 両検出 → 修正済): HostAuthorization anchor による prod boot crash → Rack::Sendfile anchor に変更
- **MEDIUM** (同上 → 修正済): `test/middleware` が `test:auth` スイート未登録 → 追加
- **LOW** (re-review で検出 → cleanup 済): `rack_env` helper の redundant 代入削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)