### PR TITLE
chore(ci): add brakeman and bundler-audit to CI for Ruby-side security scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,41 @@
+name: Security
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  brakeman:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.8
+          bundler-cache: true
+
+      - name: Run brakeman
+        run: bundle exec brakeman --no-pager -q -w2
+
+  bundler-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.8
+          bundler-cache: true
+
+      - name: Run bundler-audit
+        run: bundle exec bundle-audit check --update

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,10 @@ group :development, :test do
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
+
+  # Security scanners — run in CI via .github/workflows/security.yml
+  gem "brakeman", require: false
+  gem "bundler-audit", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,12 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
+    brakeman (8.0.4)
+      racc
     builder (3.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -451,6 +456,8 @@ DEPENDENCIES
   activerecord-session_store
   bcrypt (~> 3.1.22)
   bootsnap
+  brakeman
+  bundler-audit
   capybara
   debug
   google-cloud-storage

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ Then open http://localhost:3000
 
 The admin panel is available at http://localhost:3000/admin
 
+### Security scanning (local)
+
+Before pushing, you can run the same security scanners the CI enforces:
+
+```bash
+bundle exec brakeman --no-pager -q -w2
+bundle exec bundle-audit check --update
+```
+
+Both commands exit non-zero if they find issues.
+
 ## Environment variables
 
 This application uses OpenAI API to generate todo list items. You need to set


### PR DESCRIPTION
## Summary

Closes #323.

Adds Ruby-side security scanning as a merge gate:
- **brakeman** — static Rails security analysis
- **bundler-audit** — gem CVE check against `ruby-advisory-db`

Both run as parallel jobs in a new `.github/workflows/security.yml` on `push` / `pull_request` against `main`, with minimal `permissions: contents: read`. Gems are added to `:development, :test` group with `require: false` (no production bundle impact). README documents the local equivalent commands.

## Red-path probes (verified locally, reverted)

| Scanner | Injection | Observed |
|---|---|---|
| brakeman | `eval(params[:x])` in `application_controller.rb` | Dangerous Eval detected, exit **3** |
| bundler-audit | `gem "nokogiri", "= 1.16.4"` pin | Multiple CVEs reported, exit **1** |

## Initial scan results (clean)

- `bundle exec brakeman --no-pager -q -w2` → 0 warnings, exit 0
- `bundle exec bundle-audit check --update` → No vulnerabilities, exit 0

No `config/brakeman.ignore` needed.

## Local Review Findings (architecture-reviewer)

No critical / high. The following were triaged and deferred per the approved plan:

- **[Medium] `bundle-audit check --update` is not hermetic (network dependency)** — known design trade-off per plan's Risks & Mitigations table (Scenario 2 requires CVE-freshness tracking). Retry-on-failure is the agreed mitigation. Not blocking I5.
- **[Low] README Ruby version drift (`3.4.4` → `3.4.8`)** — explicitly Out of Scope in plan (別 Issue 相当).
- **[Low] README local `--update` network caveat not documented** — deferred; low value for hobby-repo audience.

## Out of scope (repo maintainer action required after merge)

Branch protection must add `brakeman` and `bundler-audit` as required status checks on `main` — GitHub repo settings operation, not code, so not part of this PR.

## Test plan
- [x] `bin/rails test:all` (910 runs / 2186 assertions / 0 failures / 0 errors, exit 0)
- [x] brakeman local scan (clean)
- [x] bundler-audit local scan (clean)
- [x] brakeman red-path probe (detects injected eval; reverted)
- [x] bundler-audit red-path probe (detects pinned vulnerable nokogiri; reverted)
- [ ] CI: `brakeman` job green on GitHub Actions
- [ ] CI: `bundler-audit` job green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)