### PR TITLE
chore(docs): consolidate findings into reference notes and refresh guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Task Workflow
   - ALWAYS follow the workflow documented in `docs/process/WORKFLOW.md`. When you enter a new phase, make sure you are following the workflow.
+  - **Investigation → fix branch-fit check**: when an "investigate X" session starts producing Edits, check `git branch --show-current` before the **first** Edit. If the branch name contains `issue-\d+` or any scope marker, verify the change falls within that scope before writing. When a one-file fix grows into a two-file change, treat it as the scope-creep alarm bell — re-check fit before the second Edit lands. If the fix doesn't belong on the current branch, stop and offer: "this doesn't fit the current `issue-XXX` branch. Create a new branch from main, or bundle here?" — ask before proceeding.
 
 ## Architecture Overview
 
@@ -18,12 +19,14 @@ projects and can be assigned to project members.
 
 - All resource access scoped through `current_user` — no direct ID access
 - Proper validation at model level
+- **Pilot-stage app gating uses Rack-level Basic Auth, not controller-level**. The Rails pipeline is `Rack middleware → Routing → Controller`, so `http_basic_authenticate_with` on `ApplicationController` never fires against scanner traffic hitting non-existent paths (`/wp-admin`, `/.env`, `/*.php`) — those end in `RoutingError` and flood logs. Basic Auth must live at the Rack layer, anchored on `Rack::Sendfile` (unconditional in all envs; `ActionDispatch::HostAuthorization` is conditional on `config.hosts` being non-empty and is ABSENT in production by default). See `docs/reference/RACK_MIDDLEWARE_NOTES.md` for the full pattern and the Pilot-vs-Public (Basic Auth vs Rack::Attack) gating decision.
 
 ### Routing Guidelines
 
 - Follow RESTful principles strictly (see `docs/conventions/ROUTING.md`)
 - Create new controllers instead of custom actions
 - Maintain single responsibility per controller
+- **Rails命名quirk に注意**: singular resource → pluralized controller name など、`routes.rb` 編集時のgotcha があるので `docs/conventions/ROUTING.md` "Rails命名quirk" 節を参照。編集後は `bin/rails routes | grep <resource>` で controller 列を必ず確認。
 
 ### Admin Panel (React SPA)
 
@@ -56,6 +59,12 @@ The admin panel (`/admin`) is a React SPA. When modifying the Admin area, do NOT
 
 - **Run domain test suites**: During development, run the domain test suite that covers your changes (e.g., `bin/rails test:task`). See `docs/conventions/TESTING.md` for available suites and guidelines. Run the full suite (`bin/rails test`) only once before requesting review.
 - **Wait for test results**: Once you start a test run, wait for it to complete before doing anything else. Never re-run tests without confirming the previous run's results. The full suite takes 5+ minutes — use `run_in_background` and wait for the completion notification.
+- **Rails 8 `bin/rails test:*` には地雷が多い**: `test:*` は Rake をバイパスして Thor に直送される（同名 rake task は dead code）、`test:all` は single-process 実行、`bin/rails test test:system` は **exit 0 のまま system tests が走らないサイレント失敗**。test 関連の rake task・runner 設定・CI ワークフローに触る前に `docs/conventions/TESTING.md` "Rails 8 `bin/rails test:*` の dispatch 罠" 節を必読。
+
+### Linting discipline
+
+- **Pre-existing rubocop offences on touched files**: when a PostToolUse rubocop hook fails on lines you did not touch, do NOT silently auto-fix. (1) `git stash`, (2) `bundle exec rubocop <file>` to confirm pre-existing, (3) `git stash pop`, (4) present the user with options (fix in same commit / split / skip) before editing. `-A` autocorrect is OK for `Style/*` cops; NOT for `Lint/*`, `Metrics/*`, `Security/*` — those may indicate real bugs and need deliberate fixes.
+- **`eslint-disable-next-line <rule>` requires the rule to be configured**. If `eslint-plugin-react-hooks` is not installed, `// eslint-disable-next-line react-hooks/exhaustive-deps` itself becomes a new ESLint error, not a no-op. Before reaching for a disable comment, grep `.eslintrc*` / `eslint.config.*` / `package.json` to confirm the rule exists. Default to restructuring the code (derive a primitive dep key, `useCallback`, etc.) over suppressing.
 
 ## Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ projects and can be assigned to project members.
 - Follow RESTful principles strictly (see `docs/conventions/ROUTING.md`)
 - Create new controllers instead of custom actions
 - Maintain single responsibility per controller
-- **Rails命名quirk に注意**: singular resource → pluralized controller name など、`routes.rb` 編集時のgotcha があるので `docs/conventions/ROUTING.md` "Rails命名quirk" 節を参照。編集後は `bin/rails routes | grep <resource>` で controller 列を必ず確認。
+- **Rails naming quirks**: a singular `resource` infers a pluralized controller name (e.g. `resource :system_info` → `SystemInfosController`), plus other `routes.rb` gotchas — see `docs/conventions/ROUTING.md` "Rails命名quirk" section. After any `routes.rb` edit, run `bin/rails routes | grep <resource>` and confirm the controller column matches.
 
 ### Admin Panel (React SPA)
 
@@ -59,7 +59,7 @@ The admin panel (`/admin`) is a React SPA. When modifying the Admin area, do NOT
 
 - **Run domain test suites**: During development, run the domain test suite that covers your changes (e.g., `bin/rails test:task`). See `docs/conventions/TESTING.md` for available suites and guidelines. Run the full suite (`bin/rails test`) only once before requesting review.
 - **Wait for test results**: Once you start a test run, wait for it to complete before doing anything else. Never re-run tests without confirming the previous run's results. The full suite takes 5+ minutes — use `run_in_background` and wait for the completion notification.
-- **Rails 8 `bin/rails test:*` には地雷が多い**: `test:*` は Rake をバイパスして Thor に直送される（同名 rake task は dead code）、`test:all` は single-process 実行、`bin/rails test test:system` は **exit 0 のまま system tests が走らないサイレント失敗**。test 関連の rake task・runner 設定・CI ワークフローに触る前に `docs/conventions/TESTING.md` "Rails 8 `bin/rails test:*` の dispatch 罠" 節を必読。
+- **Rails 8 `bin/rails test:*` has multiple traps**: `test:*` bypasses Rake and dispatches through Thor (same-named rake tasks are dead code), `test:all` runs in a single process, and `bin/rails test test:system` is a **silent fail — exit 0 but system tests don't run**. Before touching test-related rake tasks, runner config, or CI workflows, read `docs/conventions/TESTING.md` "Rails 8 `bin/rails test:*` の dispatch 罠" section.
 
 ### Linting discipline
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is a sample todo list application to try Rails 8 & Hotwire.
 
 ## Requirements
 
-- Ruby version: 3.4.4
-- Rails version: 8.0
+- Ruby version: 3.4.8
+- Rails version: 8.1
 - Database: SQLite
 - Node.js (with npm)
 
@@ -20,20 +20,26 @@ This is a sample todo list application to try Rails 8 & Hotwire.
 ### Install ruby 3.4.x
 
 I use [rbenv](https://github.com/rbenv/rbenv) to manage ruby versions. You can
-install ruby 3.4.4 with rbenv like this:
+install ruby 3.4.8 with rbenv like this:
 
 ```bash
-rbenv install 3.4.4
+rbenv install 3.4.8
 ```
 
 ### Install libvips for ActiveStorage
 
 See https://www.libvips.org/install.html.
 
-### Set up environment variables
+### (Optional) Set up OpenAI environment variables
 
-`OPENAI_ACCESS_TOKEN` and `OPENAI_ORGANIZATION_ID` are required. See
-[Environment variables](#environment-variables) for details.
+LLM provider configuration (API key, organization ID, etc.) is managed via the
+admin UI (`/admin/llm-providers`) and stored **encrypted in the database** —
+environment variables are not required to boot the app.
+
+If you want `bin/setup` to pre-populate an OpenAI `LlmProvider` row during
+seeding, set `OPENAI_ACCESS_TOKEN` and `OPENAI_ORGANIZATION_ID` before running
+`bin/setup`. Otherwise, skip this step and configure the provider later via the
+admin UI. See [Environment variables](#environment-variables) for details.
 
 ### Install JavaScript dependencies
 
@@ -55,7 +61,8 @@ bin/dev
 
 Then open http://localhost:3000
 
-The admin panel is available at http://localhost:3000/admin
+The admin panel is available at http://localhost:3000/admin. For first-time
+admin user creation and role setup, see [`docs/guides/ADMIN_SETUP.md`](docs/guides/ADMIN_SETUP.md).
 
 ### Security scanning (local)
 
@@ -70,11 +77,17 @@ Both commands exit non-zero if they find issues.
 
 ## Environment variables
 
-This application uses OpenAI API to generate todo list items. You need to set
-the following environment variables to use OpenAI API.
+LLM provider credentials (OpenAI, Anthropic, etc.) are managed via the admin UI
+(`/admin/llm-providers`) and stored encrypted in the database — not via
+environment variables at runtime.
 
-- OPENAI_ACCESS_TOKEN: OpenAI API access token
-- OPENAI_ORGANIZATION_ID: OpenAI organization ID
+The following variables are **optional** and only consulted by `bin/setup` /
+`db/seeds.rb` to pre-populate an OpenAI `LlmProvider` row during initial
+seeding. If unset, seeding uses placeholder values and you configure the
+provider later via the admin UI.
+
+- `OPENAI_ACCESS_TOKEN`: OpenAI API access token
+- `OPENAI_ORGANIZATION_ID`: OpenAI organization ID
 
 ## License
 

--- a/docs/conventions/ROUTING.md
+++ b/docs/conventions/ROUTING.md
@@ -139,6 +139,33 @@ namespace :tasks do
 end
 ```
 
+## Rails命名quirk — routing で踏みやすい地雷
+
+RESTful原則とは別に、Rails固有の命名規則で踏みやすい地雷がある。新規routes追加時は必ずチェック。
+
+### Singular resource はコントローラー名が複数化される
+
+`resource :system_info` (singular) の場合、Railsは `SystemInfosController` を推論する（`SystemInfoController` **ではない**）。
+
+```ruby
+# config/routes.rb
+resource :system_info
+# → SystemInfosController を期待される（複数形）
+
+# 単数形のコントローラー名を使いたい場合は明示的に指定
+resource :system_info, controller: "system_info"
+```
+
+### 検証手順
+
+`config/routes.rb` を編集したら必ず:
+
+```sh
+bin/rails routes | grep <resource>
+```
+
+を走らせて、**controller 列が実在するコントローラークラスと一致している** ことを確認する。この確認を怠ると `NameError: uninitialized constant` がランタイムまで出てこない。
+
 ## まとめ
 
 - RESTful設計を最優先とする

--- a/docs/conventions/TESTING.md
+++ b/docs/conventions/TESTING.md
@@ -22,7 +22,7 @@
 
 ### レビュー依頼前: フルスイートを1回実行
 
-レビュー依頼の前に `bin/rails test:all` を1回走らせて、ドメインをまたぐ予期せぬリグレッションを捕捉する。`test:all` は `bin/rails test`（system tests を除く全テスト）→ `bin/rails test:system`（ブラウザベースのシステムテスト）を順次、それぞれクリーンなサブプロセスで実行する。
+レビュー依頼の前に `bin/rails test:all` を1回走らせて、ドメインをまたぐ予期せぬリグレッションを捕捉する。`test:all` は Rails 8 の `Rails::Command::TestCommand#all` (Thor) が intercept するビルトインコマンドで、`test/**/*_test.rb` にマッチする全ファイル（unit + system）を **単一プロセス** で実行する（サブプロセス分割ではない）。
 
 - Standard Flow: `bin/rails test:all` を使う（system tests 含む）
 - Lightweight Flow: `bin/rails test` のみで可（typo/小変更は system tests 不要）
@@ -41,6 +41,38 @@
 **⚠ 必ず `Rails::TestUnit::Runner.run_from_rake` を使うこと**（`.run` ではない）。`.run` は `at_exit` 経由でインプロセス実行するため、rake の `:environment` でプリロードされた Rails 環境がセッション/リクエスト処理を壊し、**全コントローラテストが一律 403 Forbidden** を返す症状になる。`run_from_rake` は `rails test` をサブプロセスとして起動するのでクリーンな環境で実行される。
 
 症状の見分け方: テスト実行時間が異常に短い（例: 159テストが3.7秒 vs 正常時24秒）、かつ全コントローラテストが一律同一ステータス。
+
+## Rails 8 `bin/rails test:*` の dispatch 罠
+
+Rails 7+/8 では `bin/rails test:*` コマンドは **Rake をバイパスして `Rails::Command::TestCommand` (Thor) に直送される**。以下の地雷に注意。
+
+### `lib/tasks/*.rake` の同名 task は dead code
+
+`bin/rails test:all` は Thor の `TestCommand#all` が先に引き受けるため、`lib/tasks/test_suites.rake` で `task :all` を定義しても **rake task は一切発火しない**（過去に dead code として削除した事例あり: commit `6036e72`）。同名の `test:*` rake task を新規追加したくなったら、まず Thor 側に同名コマンドが存在しないか確認する。
+
+ドメイン別スイート（`test:task`, `test:project` 等）は Thor 側にビルトインが無いため rake task として正常に動く。
+
+### `bin/rails test:all` は single-process 実行
+
+複数の `test:*` を dispatch しているように見えても、**実体は単一プロセスで `test/**/*_test.rb` 全ファイルを走らせる**。検証は簡単で、出力中の `Run options: --seed` の出現回数を数えればよい（1回なら single-process 確定）。
+
+もし「unit → system を別サブプロセスで実行したい」要件があれば、`test:*` ではなく **別名の task**（例: `suite:full`）を定義して `sh "bin/rails test"` / `sh "bin/rails test:system"` を順次呼ぶ形にする必要がある。`test:*` 名前空間は Thor が intercept するため使えない。
+
+### `bin/rails test test:system` はサイレント失敗
+
+```sh
+bin/rails test test:system   # ❌ system tests は走らない
+```
+
+Rails はこの `test:system` を **file-path / pattern 引数** として解釈する（task chain ではない）。マッチするテストファイルがなくても通常のテストスイートが成功すれば exit 0 で帰ってくるため、CI や手動実行で **system tests が走っていないことに気付けない**。
+
+正しい呼び出し:
+
+```sh
+bin/rails test          # 非 system tests
+bin/rails test:system   # system tests
+bin/rails test:all      # 両方（単一プロセス、Thor ビルトイン）
+```
 
 ## Non-Transactional Tests と FK 制約
 

--- a/docs/reference/CI_SECURITY_SCAN_NOTES.md
+++ b/docs/reference/CI_SECURITY_SCAN_NOTES.md
@@ -1,0 +1,127 @@
+# CI security scan notes — design, probes, and branch protection
+
+Reference for `.github/workflows/security.yml` and related ruleset automation. Gathered from Issue #323 (brakeman + bundler-audit integration).
+
+## 1. Workflow design — strip test infrastructure
+
+Static-analysis tools that only read source or `Gemfile.lock` (brakeman, bundler-audit, RuboCop, `tsc --noEmit`, etc.) do **not** need the test infrastructure that `test.yml` pulls in — no DB setup, no Node install, no Redis, no asset precompile, no `SECRET_KEY_BASE`.
+
+### Rules
+
+- **Start from a blank workflow file**, not a copy of `test.yml`.
+- Minimum: `name`, `on: [push, pull_request]`, `permissions: contents: read`, one job per tool with `actions/checkout` + `ruby/setup-ruby` (with `bundler-cache: true`) + the scan command.
+- Do **not** carry over: Redis services, DB create/schema load, Node setup, `npm ci`, Vite build, `SECRET_KEY_BASE`.
+- Put scanners in their **own workflow** (`security.yml`), not appended to the test workflow. Clearer failure attribution in the Checks tab; each workflow can evolve independently.
+- **Parallel jobs** (one job per tool) > sequential steps — clearer failure attribution, and `bundler-cache` means cold-start cost is paid only on first run.
+- `permissions: contents: read` is the right default for static analysis. No write tokens, no PR comments, no artifact upload unless explicitly designing a report-posting feature.
+- Ruby scanners go into the `:development, :test` Gemfile group with `require: false` — they're CLI tools, not runtime deps. Matches the existing rubocop entry.
+- Trigger on `push` and `pull_request` to `main`. Scheduled scans (`schedule: { cron: ... }`) are a **design decision**, not a default — include explicitly in the plan or mark Out of Scope.
+
+## 2. Red-path probe is mandatory
+
+A workflow that "runs the scanner and passes on the happy path" proves only that the tool **runs**. The failure-detection path is a separate circuit that must be **observed** with a red-path probe before shipping. Matches the global "verify before claiming pipeline works" rule.
+
+### Recipe
+
+For each new failure-detecting check:
+
+1. Temporarily inject a minimal synthetic trigger for the failure condition.
+2. Run the tool locally.
+3. Confirm **non-zero exit** (don't assert a specific exit code — "non-zero" survives resolver surprises).
+4. **Revert before commit**. Never land the probe in the commit.
+5. Record the observation in the PR description as a one-liner:
+   > "Verified locally: brakeman exits non-zero on an injected `eval(params[:x])`. Reverted before commit."
+
+### Per-tool probe recipes
+
+#### Brakeman
+
+Inject `eval(params[:x])` into an unused controller action. RuboCop's `Security/Eval` cop in this repo will fire BEFORE brakeman sees the code (PostToolUse hook blocks the edit) — pre-draft the probe line with:
+
+```ruby
+eval(params[:x])  # rubocop:disable Security/Eval
+```
+
+Always revert **both** the probe line and the disable comment. Re-run brakeman to confirm exit 0 before committing.
+
+#### Bundler-audit
+
+Temporarily pin a gem to a known-CVE version, e.g. `gem "nokogiri", "= 1.16.4"`. Watch out:
+
+- **Bundler can downgrade transitive deps** to satisfy the constraint (nokogiri 1.16.4 pulls `rails-html-sanitizer` back from 1.7.0 to 1.6.0), and the reported advisories may name a **different** gem than the one you pinned.
+- Phrase the probe observation **CVE-agnostically**: "exit non-zero on a temporarily-pinned vulnerable gem version". Don't name a specific CVE in the PR description — the actual advisories fluctuate with `ruby-advisory-db`.
+- Prefer a **top-level gem with minimal reverse-dep surface** (leaf-ish libraries) over deep-graph gems like `nokogiri` / `activesupport`.
+- **Back up both `Gemfile` and `Gemfile.lock`** before the probe:
+
+```sh
+cp Gemfile /tmp/Gemfile.probe.bak && cp Gemfile.lock /tmp/Gemfile.lock.probe.bak
+```
+
+Restore from backup after probing — don't rely on `git restore` alone, which can miss fresh untracked lines.
+- Re-run `bundle exec bundle-audit check` after revert to confirm `No vulnerabilities found` / exit 0 before committing.
+
+### Linter hook interference rule (general)
+
+Repo linter hooks (rubocop, formatters, custom cops) may intercept the injected code before your target scanner sees it. Before probing:
+
+- Grep `.rubocop.yml` / linter configs for cops that cover the same vulnerability class (`Security/*`, `Lint/*`, custom).
+- If overlap exists, pre-draft the probe line with the necessary `# rubocop:disable <CopName>` (or equivalent).
+- Revert the probe **and** the disable comment together.
+
+## 3. Modifying branch protection via GitHub Rulesets
+
+2024+ repos often use the newer **Rulesets API** (`/repos/:owner/:repo/rulesets/:id`), not classic branch protection (`/repos/:owner/:repo/branches/:branch/protection`). Classic may return `404 Branch not protected` even when rulesets are active. Check **both**.
+
+### `PUT /rulesets/:id` is replace-semantics
+
+Sending only the new `required_status_checks` rule will wipe existing rules and bypass configuration. Correct pattern: **GET → merge → PUT**.
+
+```sh
+# 1. GET current state
+gh api repos/:owner/:repo/rulesets/:id > /tmp/ruleset.json
+
+# 2. Edit /tmp/ruleset.json — merge the new rule into rules[], preserve name,
+#    target, enforcement, conditions, bypass_actors, and all existing rule entries.
+
+# 3. PUT the full body
+gh api --method PUT repos/:owner/:repo/rulesets/:id --input /tmp/ruleset.json
+
+# 4. Verify
+gh api repos/:owner/:repo/rulesets/:id | jq '.updated_at, .rules'
+```
+
+### Example body for adding required status checks
+
+```json
+{
+  "name": "<existing name>",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ /* preserve existing array verbatim */ ],
+  "rules": [
+    /* preserve existing rule entries verbatim */,
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "<check-name>" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+- `strict_required_status_checks_policy: true` = "branch must be up-to-date with base before merge" (equivalent to classic `strict: true`).
+
+### Ordering hazard when enabling a new status-check gate
+
+The new check must exist on `main` before you gate on it — otherwise the gating PR itself blocks with "missing required check". Workflow:
+
+1. Merge the PR that **produces** the check first.
+2. Enable the required check on the ruleset.
+3. Flag this ordering in the PR description if someone else will perform the gate enablement.
+
+_Source findings: `static-analysis-ci-job-minimal-workflow-design`, `ci-red-path-probe-for-failure-detecting-automation`, `bundler-audit-probe-transitive-downgrade`, `red-path-probe-linter-hook-interference`, `github-rulesets-gh-api-put-pattern` (Apr 18, 2026, Issue #323)._

--- a/docs/reference/CSP_TRIX_DEBUGGING_NOTES.md
+++ b/docs/reference/CSP_TRIX_DEBUGGING_NOTES.md
@@ -40,3 +40,31 @@ Vite HMR uses `document.createElement('style')` at runtime to inject updates, by
 ## Principle
 
 Prefer the nonce fix over `'unsafe-inline'` in production — it's the whole reason Rails' nonce machinery exists. Dev-only CSP relaxations (`:unsafe_inline if Rails.env.development?`) are a double-edged sword: they make Vite/HMR work, but they normalize prod-only CSP blocks that never surface in local testing.
+
+## Rules for dev-only CSP relaxation
+
+- Any `if Rails.env.development?` branch in `config/initializers/content_security_policy.rb` is a candidate hiding spot for a prod-only bug. When investigating a prod-only UI bug, **diff that file first** and note every dev-only branch.
+- Add a comment next to each relaxation linking it to the dev tool that requires it (e.g. Vite client HMR) so future readers can tell legitimate relaxations from accidental cover-ups.
+- Quick prod-parity check: comment out the dev branches and launch locally, or run `RAILS_ENV=production` with assets precompiled. Consider a CI-level or staging environment with the real prod CSP so the gap closes before deploy.
+
+## Diagnosing "CSS change isn't reflecting"
+
+> **Note**: this project uses BOTH Sprockets 4 (for `app/assets/stylesheets/*` — SHA-256 / 64 hex fingerprints) AND Vite 3 (for entry points under `app/javascript/` — shorter content hashes). Identify which pipeline serves the file you're debugging before applying the steps below; the diagnostic approach is the same but the tooling (`bin/rails tmp:clear` / `bin/rails assets:clobber` vs. Vite dev server restart / `bin/vite clobber`) differs.
+
+Before blaming Sprockets cache or asset pipeline, resolve the two candidate causes:
+
+1. **Wrong environment** (far more common) — the browser is loading from a different server than the one you edited (staging/prod while you're editing dev, or vice versa).
+2. **Stale local server cache** (rare in dev; Sprockets recomputes fingerprints on file change).
+
+### The fingerprint is a content hash — use it as ground truth
+
+`application-<64 hex chars>.css` — same fingerprint = byte-identical content, guaranteed. Different fingerprint = content changed. One query resolves the ambiguity:
+
+1. Grab the exact fingerprinted filename from DevTools Network tab.
+2. `curl -s <exact-fingerprinted-url> | grep <your-new-rule>` — does the file the browser fetches actually contain your change?
+
+Ask the user **which URL they're viewing and which server they're connected to** before suspecting cache. "It's not reflecting" has two meanings and they look identical from the user side.
+
+- If fingerprint didn't change after a file edit → the server serving that response did not see the edit. Either the server is stale, or you're hitting a different server.
+- Only after confirming the right server is serving stale content should you reach for `bin/rails tmp:clear` or server restart.
+

--- a/docs/reference/EVENT_TRACKING_DESIGN_NOTES.md
+++ b/docs/reference/EVENT_TRACKING_DESIGN_NOTES.md
@@ -62,3 +62,5 @@ Events::Recorder.call(action: :destroyed, metadata: task_snapshot)
 `<input type="date">` は `YYYY-MM-DD` を返すため、`Time.zone.parse` すると当日の `00:00:00` になる。`to` フィルタで `..time` とすると当日のイベントが除外される。
 
 範囲末端には `.end_of_day` を付ける。詳細は `docs/conventions/USER_UI.md` 「`<input type="date">` の日付フィルタは end_of_day を付ける」を参照。
+
+> ⚠ 管理画面のイベントログで date-range フィルタを実装する場合、`.end_of_day` だけでは足りない。Admin API は `Time.use_zone` ラッパーが無く `Time.zone == UTC` で動くため、`Time.zone.parse("2026-04-11").end_of_day` は **UTC** の 23:59:59 になり JST ユーザーの期待 (JST 23:59:59) とズレる。詳細は `docs/reference/TIMEZONE_POLICY.md` を参照。修正は Issue [#286](https://github.com/tetran/Hotwire-ToDo/issues/286)（管理画面のタイムゾーンポリシー策定）で追跡中。

--- a/docs/reference/OBSERVABILITY_NOTES.md
+++ b/docs/reference/OBSERVABILITY_NOTES.md
@@ -1,0 +1,95 @@
+# Observability notes — Sentry triage & Render MCP logging
+
+## Sentry: `Rack::Multipart::BoundaryTooLongError` is defense firing, not an app bug
+
+Issues of the form `Rack::Multipart::BoundaryTooLongError: multipart boundary not found within limit` in Sentry are the **CVE-2025-61770 defense** (Rack 2.2.19 / 3.1.17 / 3.2.2, published 2025-10-07) working correctly — not application defects. The guard kills requests whose multipart preamble exceeds ~16 KiB without a valid boundary marker.
+
+### Why every POST trips it
+
+`Rack::MethodOverride#call` calls `req.POST` on every form-looking POST, which pulls in `Rack::Multipart.parse_multipart` and hits the new guard at `rack/multipart/parser.rb:350`. The multipart parser fires on endpoints that have nothing to do with file uploads — including `POST /`.
+
+### Scanner signature
+
+Distinct from legitimate upload errors:
+
+- Method/path: `POST /` or other non-form endpoints
+- Content-Type: advertises `multipart/form-data` but sends a malformed body
+- User-Agent: generic spoofed Chrome (real browsers never post malformed multipart)
+- Geo: residential-proxy exit nodes (misc. countries, small-town US)
+- Cadence: 1–3 requests minutes apart per probe, not a flood
+- **Users Impacted: 0** (critical indicator)
+- Culprit frame: `Rack::Multipart::Parser#handle_fast_forward`
+
+Motivation: scanner reconnaissance (Nuclei / Nikto / commercial scanners) probing for unpatched Rack versions or WAF parser differentials. Response behavior lets the scanner fingerprint patch level.
+
+### Triage heuristic
+
+| Condition | Action |
+|---|---|
+| Users Impacted = 0, culprit is `handle_fast_forward`, single-digit events/hour, path is not a real upload endpoint | **Archive/Ignore** in Sentry |
+| Users Impacted > 0 (real users hit it) OR rate > ~10/min (DoS signal) | **Investigate** (broken upload flow OR add an IP/path-based throttle rule to `config/initializers/rack_attack.rb`, or rate-limit upstream at CDN/Fail2ban) |
+| Noise outgrows one-off archiving | **Suppress via `before_send`** (see below) |
+
+### Suppression snippet (only when one-off archiving is insufficient)
+
+```ruby
+# config/initializers/sentry.rb
+config.before_send = lambda do |event, hint|
+  return nil if hint[:exception].is_a?(Rack::Multipart::BoundaryTooLongError)
+  event
+end
+```
+
+**Threshold rule**: do not pre-emptively suppress. The minimum-effort safe floor is to let individual issues get archived until the count justifies a global filter.
+
+### Related advisories in the same "defense-firing-as-exception" family
+
+- CVE-2025-61770 — preamble size (this one)
+- CVE-2025-61772 — per-part header block without CRLFCRLF
+- CVE-2026-34829 — no Content-Length streaming upload
+- CVE-2026-26961 — parser differential / WAF bypass (greedy boundary)
+- CVE-2022-30122 / CVE-2022-44572 — older multipart DoS
+
+Expect a burst of new Sentry issues for several days after every Rack upgrade — security patches that convert "crash server" into "raise exception" are a security win but a Sentry-noise loss.
+
+---
+
+## Render MCP `list_logs` quirks
+
+Several non-obvious behaviors when using the Render MCP tools to investigate prod logs. Surfaced during 5-day scanner-traffic investigation.
+
+### 1. Not every service emits `request` logs
+
+The Hobo Todo service (`srv-cmohgnocmk4c738sa610`) only emits `app` and `build` log types — **no `request` stream**. Filters like `type=["request"]` or `statusCode=["404"]` silently return `null`/empty even when the requests did happen, because no request-type log was emitted.
+
+### 2. `statusCode` wildcards do not work
+
+`statusCode=["4*", "5*"]` → empty. Enumerate explicitly: `["400", "401", "403", "404", "500", "502", "503"]`.
+
+### 3. Regex with special characters in `text` / `path` silently fails
+
+Patterns like `(?i)(wp-|\.php|...)` return empty even when matching lines exist. **Use plain substring** (`"RoutingError"`, `"Completed 5"`). For OR logic, run multiple queries.
+
+### 4. `statusCode` label may not exist on non-request streams
+
+`list_log_label_values(label="statusCode")` returning `null` is the canary that there are no request logs at all.
+
+### Investigation recipe
+
+```
+1. list_log_label_values(label="type", resource=[serviceId])
+   → what log types exist?
+2. list_log_label_values(label="statusCode", resource=[serviceId])
+   → are request logs available at all? null = no.
+```
+
+If `type` is only `["app", "build"]`, skip statusCode/method/path filters entirely.
+
+- For Rails apps, `text=["RoutingError"]` on `type=["app"]` is the most reliable way to surface scanner traffic regardless of log level.
+- For real HTTP-level metrics when request logs are absent, use `get_metrics(metricTypes=["http_request_count"], aggregateHttpRequestCountsBy="statusCode")` — this works via the platform metrics, not logs.
+
+### Interpretation rule
+
+**"Empty result from `list_logs` is ambiguous"** — it can mean "no matches" or "filter syntax not supported". When empty + unsure, simplify the filter (drop regex, drop wildcards, drop optional labels) and retry.
+
+_Source findings: `rack-boundarytoolongerror-scanner-signature`, `render-mcp-log-query-quirks` (Apr 18, 2026)._

--- a/docs/reference/RACK_MIDDLEWARE_NOTES.md
+++ b/docs/reference/RACK_MIDDLEWARE_NOTES.md
@@ -78,9 +78,9 @@ config.middleware.insert_before Rack::Sendfile, BasicAuthWrapper
 class BasicAuthWrapper
   def initialize(app)
     @app = app
+    # Pass `app` (the downstream) to Rack::Auth::Basic, NOT self — otherwise recursion
+    # (Rack::Auth::Basic calls its wrapped app on successful auth).
     @auth = Rack::Auth::Basic.new(app, "Restricted") do |u, p|
-      # Pass the downstream @app to Rack::Auth::Basic, NOT self — otherwise recursion.
-      #
       # Single `&` (bitwise AND), NOT `&&`. `&&` short-circuits when the username check
       # fails, skipping the password compare and leaking a timing side channel that lets
       # an attacker distinguish "valid username + wrong password" from "wrong username".

--- a/docs/reference/RACK_MIDDLEWARE_NOTES.md
+++ b/docs/reference/RACK_MIDDLEWARE_NOTES.md
@@ -1,0 +1,112 @@
+# Rack middleware notes — Basic Auth placement & insertion anchors
+
+Reference for Rails 8 custom middleware insertion, especially the pilot-stage Basic Auth gating pattern (Issue #321, PR #322).
+
+## Controller-level auth is the wrong layer
+
+The Rails request pipeline is:
+
+```
+Rack middleware → Routing → Controller
+```
+
+`ApplicationController#http_basic_authenticate_with` is a `before_action` filter — it only fires **after** a route is matched and a controller is instantiated. Scanner traffic to non-existent paths (`/wp-admin`, `/.env`, `/*.php`, `/xmlrpc.php`) never reaches a controller; it ends in `ActionController::RoutingError` and floods logs. Basic Auth at the controller layer cannot gate these.
+
+For pilot-stage / closed-beta deployments, install Basic Auth as **Rack middleware** instead.
+
+## Pilot vs Public — when to use Rack Basic Auth vs Rack::Attack
+
+Two distinct decisions that are often conflated:
+
+### 1. Whole-app gating (Basic Auth vs. open + Rack::Attack filtering)
+
+The gating choice depends on the app's public surface:
+
+- **Pilot / closed beta** (only allowlisted testers should reach the app): Rack-level Basic Auth. 100% coverage, zero maintenance. Every request — including scanner traffic to non-existent paths — is gated at the middleware layer before routing.
+- **Public app** (must remain open to anonymous traffic, but need to filter abusive subsets): drop Basic Auth, rely on Rack::Attack for selective throttling / blocking based on IP, path, fingerprint, etc.
+
+These two are **swap-in / swap-out at the pilot→public transition**, not additive for whole-app gating. Running both as the app-level allow/deny layer buys no defense-in-depth worth the coupling cost — the semantic purposes (binary allow/deny vs. selective filtering) don't compose meaningfully.
+
+### 2. Endpoint-specific throttling (orthogonal — keep regardless of gating choice)
+
+Rack::Attack for **endpoint-scoped brute-force protection** (e.g. admin login throttling at `POST /api/v1/admin/session`) is a different role. It coexists happily with either whole-app gating choice and should not be removed during the pilot→public transition. See `config/initializers/rack_attack.rb` for the current admin-login throttling rules (5 req / 60s per IP, per email). This role is *additive* — Basic Auth gates the whole app; Rack::Attack still throttles admin login attempts within the gated surface.
+
+## Rails 8 middleware insertion anchors
+
+`default_middleware_stack.rb` in `railties` decides which middleware is inserted based on env config. Insertion anchors must be **unconditional** or the app will fail to boot in environments where the anchor is absent.
+
+| Middleware | Condition | Safe anchor? |
+|---|---|---|
+| `Rack::Sendfile` | Unconditional | ✅ Yes — preferred default |
+| `ActionDispatch::Executor` | Unconditional | ✅ Yes |
+| `Rack::Runtime` | Unconditional | ✅ Yes |
+| `ActionDispatch::HostAuthorization` | Only when `config.hosts` is non-empty. **Absent in production by default** (the `config.hosts = [...]` block in a generated `production.rb` is commented out). Present in dev (localhost + `ALLOWED_HOSTS_IN_DEVELOPMENT`). | ❌ No — causes `"No such middleware to insert after: ActionDispatch::HostAuthorization"` on prod boot |
+| `ActionDispatch::Static` | Conditional on `ENV["RAILS_SERVE_STATIC_FILES"]` / `config.public_file_server.enabled` | ❌ No |
+| `ActionDispatch::SSL` | Only when `config.force_ssl = true` | ❌ No |
+| `Rack::Cache`, `Rack::Lock`, `ServerTiming`, `AssumeSSL` | Environment-conditional | ❌ No |
+
+### Prefer `insert_before Rack::Sendfile`
+
+For custom middleware in `config/application.rb`:
+
+```ruby
+config.middleware.insert_before Rack::Sendfile, BasicAuthWrapper
+```
+
+Only deviate if you have a specific layering reason (e.g. "must run after SSL termination" → `insert_after ActionDispatch::SSL` only if `force_ssl = true` is guaranteed, else anchor on `Sendfile`).
+
+### Verifying insertion anchor safety
+
+- `bin/rails middleware` in **dev** gives **false confidence** about production because dev's `config.hosts` is populated.
+- `RAILS_ENV=test bin/rails middleware` simulates the prod middleware stack (empty `config.hosts`) cheaply.
+- Diff the two outputs. Any entry that appears in dev but not test is conditional — never use as an anchor.
+- Reproducing the prod boot failure: run with `RAILS_ENV=production` + dummy `SECRET_KEY_BASE`. The insertion error surfaces in `run_initializers` before credentials decryption; stack trace names `ActionDispatch::MiddlewareStack#assert_index`.
+
+## Basic Auth wrapper pattern (with `/up` exemption)
+
+`Rack::Auth::Basic` alone cannot exempt paths, but Render's unauthenticated `/up` health check needs to bypass auth. Pattern: thin wrapper middleware that short-circuits `/up` and delegates everything else to `Rack::Auth::Basic`.
+
+```ruby
+# config/application.rb
+require "rack/auth/basic"   # NOT auto-required by "rails/all"
+
+config.middleware.insert_before Rack::Sendfile, BasicAuthWrapper
+```
+
+```ruby
+# app/middleware/basic_auth_wrapper.rb
+class BasicAuthWrapper
+  def initialize(app)
+    @app = app
+    @auth = Rack::Auth::Basic.new(app, "Restricted") do |u, p|
+      # Pass the downstream @app to Rack::Auth::Basic, NOT self — otherwise recursion.
+      #
+      # Single `&` (bitwise AND), NOT `&&`. `&&` short-circuits when the username check
+      # fails, skipping the password compare and leaking a timing side channel that lets
+      # an attacker distinguish "valid username + wrong password" from "wrong username".
+      # `&` forces both compares regardless of the first result.
+      ActiveSupport::SecurityUtils.secure_compare(u.to_s, ENV["BASIC_AUTH_USERNAME"].to_s) &
+        ActiveSupport::SecurityUtils.secure_compare(p.to_s, ENV["BASIC_AUTH_PASSWORD"].to_s)
+    end
+  end
+
+  def call(env)
+    return @app.call(env) if env["PATH_INFO"] == "/up"
+    @auth.call(env)
+  end
+end
+```
+
+### Edge cases to test explicitly
+
+- `/up?foo=bar` → `PATH_INFO == "/up"`, query string excluded, exemption still applies.
+- `/UP` and `/up/` do **not** match — they get gated. Usually what you want (locks exemption tight); name test cases for it so future refactors don't loosen it.
+- HEAD/GET parity for `/up`.
+- Malformed `Authorization` header should reject cleanly (Rack::Auth::Basic handles this).
+- `config.silence_healthcheck_path = "/up"` only affects **logging** — it does NOT skip middleware. Your wrapper still needs its own `/up` check.
+
+## Rollback considerations
+
+Same-PR removal of controller auth + addition of middleware auth creates a **coupled rollback**. Unsetting the env vars at runtime leaves the app with *zero* auth, not the previous state. Document in the PR description: rollback is `git revert`, NOT env-var toggling.
+
+_Source findings: `rails8-basic-auth-rack-middleware-pattern`, `rails8-middleware-anchor-env-conditionality`, `rails-basic-auth-controller-vs-middleware` (Apr 18, 2026, Issue #321/#322)._

--- a/docs/reference/SYSTEM_TEST_GOTCHAS.md
+++ b/docs/reference/SYSTEM_TEST_GOTCHAS.md
@@ -1,0 +1,63 @@
+# System test gotchas — Capybara / Stimulus / `<dialog>`
+
+Collected gotchas that bit during keyboard-shortcut and dialog work (Issue #14 and related). Check this file before writing a system test that dispatches DOM events or interacts with native `<dialog>` elements.
+
+## 1. Capybara `execute_script` — do NOT wrap the body in an IIFE
+
+`page.execute_script(script, *args)` and `page.evaluate_script(script, *args)` run the script as the body of an anonymous function and expose `*args` via the standard JS `arguments` array. Wrapping the body in an IIFE `(function() { ... })()` **shadows** the outer `arguments` with the IIFE's own empty arg list — `arguments[0]` becomes `undefined` **silently**, no error. Hours-deep debugging for "the event fires but `e.key === undefined`".
+
+### Rules
+
+- Write script text at the **top level**. The driver already wraps it in a function.
+- If you need an IIFE (e.g. for a local `return` inside `evaluate_script`), explicitly pass outer args in: `(function(k) { ... }(arguments[0]))`.
+- **Safest pattern** for small values: skip the args array and embed values via Ruby-side `to_json` interpolation:
+
+```ruby
+key_json = "/".to_json
+page.execute_script("window.dispatchEvent(new KeyboardEvent('keydown', { key: #{key_json}, bubbles: true }))")
+```
+
+- Debugging "nothing happens in my JS test"? First check: `page.evaluate_script("arguments[0]", "expected")` — does the value survive into the script?
+
+## 2. Testing Stimulus `keydown@window` actions
+
+`send_keys` on a Capybara session does NOT reliably trigger Stimulus `keydown@window` actions — the key event gets fired at the active element but doesn't bubble to `window` in a way that matches the action binding. **Dispatch synthetic `KeyboardEvent`s directly on the target**:
+
+```ruby
+page.execute_script(<<~JS)
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }))
+JS
+```
+
+Combined with the IIFE rule above, use Ruby-side `to_json` interpolation when the key value is dynamic.
+
+## 3. Native `<dialog>` — `cancel` vs `close` event asymmetry
+
+Two close events with different semantics:
+
+| Trigger | Events | Cancelable? |
+|---|---|---|
+| User presses Escape | `cancel` → `close` | `cancel` yes (`event.preventDefault()` aborts); `close` no |
+| JS calls `dialog.close()` | `close` only | `close` is not cancelable |
+
+**Implication for global Escape handlers that call `dialog.close()`**: any `cancel`-based cleanup logic (e.g. "unsaved changes? really close?") is silently bypassed.
+
+### Rules
+
+- Before building a global Escape handler, grep for `cancel` listeners on dialogs:
+  ```
+  addEventListener\s*\(\s*['"]cancel
+  cancel->                  # Stimulus data-action (element)
+  cancel@window->           # Stimulus data-action (window)
+  ```
+- If none exist → `dialog.close()` is safe. Add a code comment stating "no `cancel` listeners in the codebase as of <date/PR>".
+- If listeners exist → dispatch a synthetic cancel first:
+  ```js
+  const cancelEvent = new Event('cancel', { cancelable: true })
+  if (topDialog.dispatchEvent(cancelEvent)) {   // not prevented
+    topDialog.close()
+  }
+  ```
+- When adding a new `<dialog>` with cleanup logic, **prefer the `close` event** unless you actually need cancelable behavior. Close fires on both Escape and `.close()`.
+
+_Source findings: `capybara-execute-script-iife-arguments-quirk`, `testing-stimulus-keyboard-shortcuts-via-dispatchevent`, `html-dialog-cancel-vs-close-event-semantics` (all Apr 11, 2026, Issue #14)._

--- a/docs/reference/TIMEZONE_POLICY.md
+++ b/docs/reference/TIMEZONE_POLICY.md
@@ -1,0 +1,65 @@
+# Timezone policy — user-facing vs Admin API gap
+
+## Background
+
+Hobo's user-facing Rails stack wraps requests in `Time.use_zone(current_user.time_zone)` via an `around_action` in `ApplicationController`:
+
+```ruby
+around_action :in_time_zone_and_locale, if: :logged_in?
+```
+
+Each `User` has a `time_zone` column (NOT NULL, default `"UTC"`). `config.time_zone` is NOT set in `config/application.rb`, so Rails defaults the process-wide zone to UTC.
+
+## The gap
+
+The **Admin JSON API** (`Api::V1::Admin::*`) inherits from a different base controller and has **no equivalent wrapping**. Admin requests run with `Time.zone == UTC` regardless of the admin user's local zone.
+
+Any datetime parsing on the admin path silently misinterprets local-date inputs as UTC:
+
+- `Time.zone.parse("2026-04-11")` → UTC midnight, not JST midnight
+- `Date.current`, `end_of_day`, range filters — all UTC-framed
+
+### Symptom
+
+JST user submits `to=2026-04-11` on a date-range filter expecting JST midnight cutoff. Backend compares against UTC `2026-04-11 23:59:59`, which is JST `2026-04-12 08:59:59` — events from the next morning leak into the range.
+
+Symmetric bug on `from=`: misses events from "this morning local" because they're still yesterday UTC.
+
+## Why fixture tests miss this
+
+Fixtures typically store UTC datetimes and test expectations match in the same UTC frame. Real-user reports (or a deliberate test with a non-UTC user) are needed to surface it.
+
+## Policy decision paths
+
+No single right answer — pick based on operating reality:
+
+| Option | Implication |
+|---|---|
+| Global `config.time_zone = 'Asia/Tokyo'` | Fine if admins + users are all one region. Process-wide. |
+| Admin-base `around_action` with per-admin `time_zone` | Parallel to user-side. Requires `time_zone` column on admin user. |
+| Admin-base `around_action` hardcoded to JST | Simpler than per-admin zone, fine for single-country ops. |
+
+## Rules when touching admin datetime code
+
+- **First**, check `config/application.rb` for `config.time_zone` and the admin base controller for any `Time.use_zone` wrapper. Know who is (or isn't) pushing the zone.
+- A naked date string `"2026-04-11"` is parsed in whatever `Time.zone` is active. That zone must match the user's input frame.
+- Don't defer the policy decision to "we'll figure it out when it breaks" — a new admin datetime feature is the right forcing function for picking a path.
+- When reporting a zone bug, surface both `from` and `to` symmetric sides — users usually only notice one.
+
+## Known offending patterns
+
+- Event log date-range filters in the admin SPA (feature shipped in `#273`-era work; the underlying timezone gap is tracked in Issue [#286](https://github.com/tetran/Hotwire-ToDo/issues/286) — "管理画面の日付フィルタがタイムゾーンを考慮していない / 管理画面のタイムゾーンポリシー要策定"). The Policy decision paths above will be resolved there.
+
+## Related documents
+
+The full timezone problem surface is split across three docs by layer:
+
+| Doc | Layer | Concern |
+|---|---|---|
+| `docs/reference/TIMEZONE_POLICY.md` (this doc) | **Zone context** | Admin API lacks the user-side `Time.use_zone` wrapper — `Time.zone == UTC` on every admin request |
+| `docs/conventions/USER_UI.md` §「`<input type="date">` の日付フィルタは end_of_day を付ける」 | **Day boundary** | Date-only inputs default to midnight; inclusive-end ranges need `.end_of_day` |
+| `docs/reference/EVENT_TRACKING_DESIGN_NOTES.md` §5 | **Day boundary (admin context)** | Same end_of_day pattern in the admin event log filter |
+
+The two classes of bug (zone context vs. day boundary) can co-occur — an admin event log filter can be wrong in BOTH dimensions at once, so fixing one without the other still leaves a silent off-by-`(zone_offset)` or off-by-`23:59:59.999` error.
+
+_Source findings: `rails-admin-timezone-gap-pattern` (Apr 12, 2026)._


### PR DESCRIPTION
## Summary

Docs-only consolidation. Folds recent debugging/investigation findings (from #14, #282-era, #321/#322, #323, and #286 context) into topic-scoped files under `docs/reference/`, and refreshes CLAUDE.md, README.md, and convention docs so they reflect current repo reality.

No runtime impact. No code, migration, or test changes.

### New reference notes (`docs/reference/`)

| File | Source | Purpose |
|---|---|---|
| `CI_SECURITY_SCAN_NOTES.md` | #323 | Workflow design, red-path probes, Rulesets API merge pattern |
| `RACK_MIDDLEWARE_NOTES.md` | #321/#322 | Basic Auth placement, `Rack::Sendfile` anchor, Pilot-vs-Public decision |
| `SYSTEM_TEST_GOTCHAS.md` | #14 | Capybara IIFE/arguments quirk, Stimulus keyboard dispatch, `<dialog>` cancel vs close |
| `TIMEZONE_POLICY.md` | #286 context | Admin API timezone gap + policy paths |
| `OBSERVABILITY_NOTES.md` | Scanner-traffic investigation | Sentry triage for Rack multipart CVEs (CVE-2025-61770 等6件、NVDで検証済み), Render MCP log-query quirks |

### CLAUDE.md — new rules + pointer discipline

- Branch-fit check for investigation→fix sessions
- Pilot-stage Rack-level Basic Auth + `Rack::Sendfile` anchor (summary; detail in `RACK_MIDDLEWARE_NOTES.md`)
- Rails 8 \`bin/rails test:*\` pitfalls pointer to `TESTING.md`
- Linting discipline (pre-existing rubocop offences, `eslint-disable-next-line` rule-configured check)

Detail content moved to convention/reference docs so CLAUDE.md stays concise.

### Convention docs

- **`ROUTING.md`** — new "Rails 命名 quirk" section: singular \`resource\` infers **pluralized** controller name (\`resource :system_info\` → \`SystemInfosController\`). Verification step via \`bin/rails routes | grep\`.
- **`TESTING.md`** — fix stale claim that \`test:all\` runs as separate subprocesses (since #6036e72 it's Thor-intercepted single-process). Add "Rails 8 \`bin/rails test:*\` の dispatch 罠" section covering:
  - Thor intercepts \`test:*\` (same-named rake tasks are dead code)
  - \`test:all\` is single-process
  - \`bin/rails test test:system\` is a **silent fail** (parses as pattern, exit 0)

### README.md

- Ruby 3.4.4 → **3.4.8**, Rails 8.0 → **8.1** (versions were stale vs. \`.ruby-version\` / \`Gemfile\`)
- OpenAI env vars reclassified as **optional seeding conveniences** — primary LLM provider config is managed via \`/admin/llm-providers\` (encrypted in DB)
- Added link to \`docs/guides/ADMIN_SETUP.md\` for first-admin setup

### Cross-refs

- \`EVENT_TRACKING_DESIGN_NOTES.md\` §5 — added warning that \`.end_of_day\` alone is insufficient on admin API (\`Time.zone == UTC\`); points to \`TIMEZONE_POLICY.md\` and flags Issue #286 as the tracker
- \`CSP_TRIX_DEBUGGING_NOTES.md\` — dual-pipeline (Sprockets 4 + Vite 3) note on "CSS change isn't reflecting" section, with correct clobber commands per pipeline

## Test plan

- [x] Docs-only change — no test suite required
- [x] Ruby version claim verified against \`.ruby-version\` (3.4.8) and \`Gemfile\` (\`~> 8.1.0\`)
- [x] Rack-middleware claims verified against \`config/application.rb\`, \`app/middleware/basic_auth_wrapper.rb\`
- [x] \`test:all\` single-process claim verified against commit \`6036e72\` (removed the defunct rake task)
- [x] CVE references (CVE-2025-61770, -61772, CVE-2026-34829, -26961, CVE-2022-30122, -44572) verified via NVD
- [x] Issue #273 (admin event log filter) and #286 (timezone policy tracker) verified via \`gh issue view\`
- [x] Rack::Attack role description matches \`config/initializers/rack_attack.rb\` (admin-login throttling)
- [x] \`pre-push\` hook ran: rubocop 0 offences, TypeScript typecheck passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)