### PR TITLE
feat(ask_ai): 提案後のレイアウト並び替え & 入力内容を先頭に表示

### DIFF
--- a/app/assets/stylesheets/tasks.css
+++ b/app/assets/stylesheets/tasks.css
@@ -362,7 +362,6 @@ a.show-task__due-date.show-task__editable {
   border-top: solid 1px var(--border);
 }
 .task-suggestion-summary__item dt {
-  font-weight: 600;
   color: var(--color-muted);
 }
 .task-suggestion-summary__item dd {

--- a/app/assets/stylesheets/tasks.css
+++ b/app/assets/stylesheets/tasks.css
@@ -337,11 +337,38 @@ a.show-task__due-date.show-task__editable {
 }
 
 .task-suggestions {
-  margin-top: var(--space-4);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-4);
+  border-bottom: solid 1px var(--border);
+}
+.task-suggestions-title,
+.task-suggestion-retry-title {
+  margin-top: var(--space-2);
+}
+.task-suggestion-summary {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--background-alt);
+  border: solid 1px var(--border);
+}
+.task-suggestion-summary__item {
+  display: grid;
+  grid-template-columns: minmax(5rem, 8rem) 1fr;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
+}
+.task-suggestion-summary__item + .task-suggestion-summary__item {
   border-top: solid 1px var(--border);
 }
-.task-suggestions-title {
-  margin-top: var(--space-2);
+.task-suggestion-summary__item dt {
+  font-weight: 600;
+  color: var(--color-muted);
+}
+.task-suggestion-summary__item dd {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .task-suggestion {
   display: flex;

--- a/app/views/tasks/_ask_ai.html.erb
+++ b/app/views/tasks/_ask_ai.html.erb
@@ -1,5 +1,11 @@
 <div id="form2" class="tab-panel <%= @show_suggestion ? "" : "hidden" %>" role="tabpanel" data-tabs-target="tabPanel">
   <div class="task-suggestion-form">
+    <%= turbo_frame_tag "task_suggestion" do %>
+      <% if @error_message %>
+        <%= render "shared/simple_error_message", message: @error_message %>
+      <% end %>
+    <% end %>
+
     <%= form_with model: @suggestion_session || SuggestionSession.new,
                   url: tasks_suggestions_path,
                   method: :post, # Always POST. Not PATCH.
@@ -39,12 +45,6 @@
                           "submit-target": "submit"
                         } %>
       </div>
-    <% end %>
-
-    <%= turbo_frame_tag "task_suggestion" do %>
-      <% if @error_message %>
-        <%= render "shared/simple_error_message", message: @error_message %>
-      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/tasks/_suggestions.html.erb
+++ b/app/views/tasks/_suggestions.html.erb
@@ -12,7 +12,7 @@
       <% if @suggestion_session.context.present? %>
         <div class="task-suggestion-summary__item">
           <dt><%= SuggestionSession.human_attribute_name(:context) %></dt>
-          <dd><%= simple_format(@suggestion_session.context) %></dd>
+          <dd><%= @suggestion_session.context %></dd>
         </div>
       <% end %>
       <% if @suggestion_session.start_date.present? %>

--- a/app/views/tasks/_suggestions.html.erb
+++ b/app/views/tasks/_suggestions.html.erb
@@ -4,6 +4,31 @@
        data-controller="suggestion-abandonment"
        data-suggestion-abandonment-url-value="<%= tasks_suggestion_abandonment_path(last_request.suggestion_session) %>"
        data-suggestion-abandonment-response-id-value="<%= last_request.response.id %>">
+    <dl class="task-suggestion-summary">
+      <div class="task-suggestion-summary__item">
+        <dt><%= SuggestionSession.human_attribute_name(:goal) %></dt>
+        <dd><%= @suggestion_session.goal %></dd>
+      </div>
+      <% if @suggestion_session.context.present? %>
+        <div class="task-suggestion-summary__item">
+          <dt><%= SuggestionSession.human_attribute_name(:context) %></dt>
+          <dd><%= simple_format(@suggestion_session.context) %></dd>
+        </div>
+      <% end %>
+      <% if @suggestion_session.start_date.present? %>
+        <div class="task-suggestion-summary__item">
+          <dt><%= SuggestionSession.human_attribute_name(:start_date) %></dt>
+          <dd><%= l(@suggestion_session.start_date) %></dd>
+        </div>
+      <% end %>
+      <% if @suggestion_session.due_date.present? %>
+        <div class="task-suggestion-summary__item">
+          <dt><%= SuggestionSession.human_attribute_name(:due_date) %></dt>
+          <dd><%= l(@suggestion_session.due_date) %></dd>
+        </div>
+      <% end %>
+    </dl>
+
     <h2 class="task-suggestions-title"><%= t("tasks.suggestions.title") %></h2>
     <%= form_with url: tasks_batches_path,
                   data: { turbo_frame: "_top",
@@ -38,4 +63,6 @@
       </div>
     <% end %>
   </div>
+
+  <h2 class="task-suggestion-retry-title"><%= t("tasks.suggestions.retry_title") %></h2>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
       task_name: "Task name"
       description: "Description"
       create_tasks: "Create tasks"
+      retry_title: "Suggest again"
     assignees:
       unassign: "Unassign"
       you: "You"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -292,6 +292,7 @@ ja:
       task_name: "タスク名"
       description: "説明"
       create_tasks: "タスクを作成"
+      retry_title: "もう一度提案してもらう"
     assignees:
       unassign: "割り当て解除"
       you: "自分"


### PR DESCRIPTION
## Summary
- 「AIに聞く」提案後、タスク候補一覧を先に、再提案用フォームを後に表示するようにレイアウトを並び替え
- 提案時に入力した内容（目標 / 背景 / 開始日 / 締切日）をタスク候補一覧の上に read-only で表示
- 再提案フォームの直上に「もう一度提案してもらう」見出しを付与（提案結果が出たときだけ出る）

## Test plan
- [ ] `/tasks/new` → 「AIに聞く」タブ初期表示でフォームのみが見える
- [ ] 目標等を入力して「提案する」→ 候補が先頭に、入力サマリがその上に、再提案フォームが「もう一度提案してもらう」見出し付きで下に表示されることを確認
- [ ] 再提案フォームから再送信して、同じレイアウトで新しい候補 + サマリが再描画されることを確認
- [ ] 提案設定が無効な場合 / LLM エラー時に従来通りフォーム上のエラーメッセージが出ることを確認
- [x] `bin/rails test:suggestion` 全件通過
- [x] `bin/rails test` 全件通過（886 runs, 0 failures, 0 errors, 2 skips）

🤖 Generated with [Claude Code](https://claude.com/claude-code)