### PR TITLE
feat(admin): warn on Sentry when dropdown per_page:100 cap truncates data

### DIFF
--- a/app/javascript/admin/__tests__/lib/sentry.test.ts
+++ b/app/javascript/admin/__tests__/lib/sentry.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock @sentry/react: keep real exports, spy on init + captureMessage
+vi.mock('@sentry/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sentry/react')>()
+  return {
+    ...actual,
+    init: vi.fn(),
+    captureMessage: vi.fn(),
+  }
+})
+
+// Helper to dynamically import a fresh module instance each test
+const loadSentry = () => import('@admin/lib/sentry')
+
+describe('initSentry', () => {
+  const originalHead = document.head.innerHTML
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    document.head.innerHTML = originalHead
+  })
+
+  afterEach(() => {
+    document.head.innerHTML = originalHead
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('does NOT call Sentry.init when MODE=test (Vitest default)', async () => {
+    // Vitest sets import.meta.env.MODE = 'test' by default
+    document.head.innerHTML = '<meta name="sentry-dsn" content="https://dsn@sentry.io/1">'
+    const { initSentry } = await loadSentry()
+    const Sentry = await import('@sentry/react')
+
+    initSentry()
+
+    expect(Sentry.init).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call Sentry.init when DSN is empty (non-production)', async () => {
+    vi.stubEnv('MODE', 'development')
+    document.head.innerHTML = '<meta name="sentry-dsn" content="">'
+    const { initSentry } = await loadSentry()
+    const Sentry = await import('@sentry/react')
+
+    initSentry()
+
+    expect(Sentry.init).not.toHaveBeenCalled()
+  })
+
+  it('emits console.warn in production when DSN is empty', async () => {
+    vi.stubEnv('MODE', 'production')
+    document.head.innerHTML = '<meta name="sentry-dsn" content="">'
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { initSentry } = await loadSentry()
+
+    initSentry()
+
+    expect(warn).toHaveBeenCalledWith('[sentry] DSN not set; truncation warnings will not be reported')
+  })
+
+  it('does NOT emit console.warn in development when DSN is empty', async () => {
+    vi.stubEnv('MODE', 'development')
+    document.head.innerHTML = '<meta name="sentry-dsn" content="">'
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { initSentry } = await loadSentry()
+
+    initSentry()
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('calls Sentry.init with dsn and environment when DSN is set (non-test mode)', async () => {
+    vi.stubEnv('MODE', 'production')
+    const dsn = 'https://key@sentry.io/123'
+    document.head.innerHTML = `<meta name="sentry-dsn" content="${dsn}">`
+    const { initSentry } = await loadSentry()
+    const Sentry = await import('@sentry/react')
+
+    initSentry()
+
+    expect(Sentry.init).toHaveBeenCalledWith({ dsn, environment: 'production' })
+  })
+})
+
+describe('reportTruncation', () => {
+  const originalHead = document.head.innerHTML
+  const dsn = 'https://key@sentry.io/123'
+
+  // Each test gets a fresh module with sentryEnabled = true (production DSN set)
+  const setupEnabled = async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubEnv('MODE', 'production')
+    document.head.innerHTML = `<meta name="sentry-dsn" content="${dsn}">`
+    const { initSentry, reportTruncation } = await loadSentry()
+    const Sentry = await import('@sentry/react')
+    initSentry()
+    return { reportTruncation, Sentry }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.head.innerHTML = originalHead
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('fires captureMessage with correct payload on truncation', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 150, per_page: 100 })
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith('Admin dropdown data truncated', {
+      level: 'warning',
+      tags: { resource: 'roles' },
+      contexts: { pagination: { fetched: 100, total_count: 150, per_page: 100 } },
+      fingerprint: ['admin-pagination-truncated', 'roles'],
+    })
+  })
+
+  it('is no-op when total_count === fetched (no truncation)', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 100, per_page: 100 })
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('is no-op when per_page !== 100', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    reportTruncation({ resource: 'roles', fetched: 20, total_count: 150, per_page: 20 })
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('is no-op when fetched < per_page (cap not reached)', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    reportTruncation({ resource: 'roles', fetched: 50, total_count: 150, per_page: 100 })
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates: 2nd call for same resource is no-op', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 150, per_page: 100 })
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 150, per_page: 100 })
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows different resources independently', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 150, per_page: 100 })
+    reportTruncation({ resource: 'permissions', fetched: 100, total_count: 200, per_page: 100 })
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('is no-op when sentryEnabled is false (no initSentry called)', async () => {
+    vi.resetModules()
+    // Do NOT call initSentry — leave sentryEnabled = false
+    const { reportTruncation } = await loadSentry()
+    const Sentry = await import('@sentry/react')
+
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 150, per_page: 100 })
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+  })
+
+  // Guard #2: non-finite values
+  const nonFiniteValues = [undefined, NaN, Infinity] as const
+
+  describe.each([
+    ['fetched', (v: number | undefined) => ({ resource: 'roles', fetched: v, total_count: 150, per_page: 100 as number | undefined })],
+    ['total_count', (v: number | undefined) => ({ resource: 'roles', fetched: 100, total_count: v, per_page: 100 as number | undefined })],
+    ['per_page', (v: number | undefined) => ({ resource: 'roles', fetched: 100, total_count: 150, per_page: v })],
+  ])('non-finite %s', (_field, makeParams) => {
+    it.each(nonFiniteValues)('is no-op when value is %s', async (val) => {
+      const { reportTruncation, Sentry } = await setupEnabled()
+
+      reportTruncation(makeParams(val) as Parameters<typeof reportTruncation>[0])
+
+      expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  // Ordering invariant: non-finite input must NOT consume dedup budget
+  it('ordering invariant: non-finite call does not consume dedup slot, valid call fires', async () => {
+    const { reportTruncation, Sentry } = await setupEnabled()
+
+    // First call: non-finite fetched — should be no-op (guard #2 fires before guard #6)
+    reportTruncation({ resource: 'roles', fetched: NaN, total_count: 150, per_page: 100 })
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+
+    // Second call: valid — dedup slot must still be free, so this should fire
+    reportTruncation({ resource: 'roles', fetched: 100, total_count: 150, per_page: 100 })
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -8,9 +8,8 @@ export interface PaginationMeta {
   total_pages: number
 }
 
-// TODO: Non-index pages fetch dropdown data with per_page: 100 hard cap.
-//       Add a Sentry warning when meta.total_count > fetched length so we
-//       notice before items are silently omitted from selection UIs.
+export const DROPDOWN_PER_PAGE = 100 as const
+
 export interface PaginationParams {
   page?: number
   per_page?: number

--- a/app/javascript/admin/lib/sentry.ts
+++ b/app/javascript/admin/lib/sentry.ts
@@ -1,0 +1,64 @@
+import * as Sentry from '@sentry/react'
+import { DROPDOWN_PER_PAGE } from './api'
+
+let sentryEnabled = false
+const reportedResources = new Set<string>()
+
+export const initSentry = (): void => {
+  // belt-and-suspenders: never run real Sentry init in Vitest / unit test mode
+  if (import.meta.env.MODE === 'test') return
+
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="sentry-dsn"]')
+  const dsn = meta?.content ?? ''
+
+  if (!dsn) {
+    if (import.meta.env.MODE === 'production') {
+      // eslint-disable-next-line no-console -- ops silent-failure signal
+      console.warn('[sentry] DSN not set; truncation warnings will not be reported')
+    }
+    return
+  }
+
+  Sentry.init({ dsn, environment: import.meta.env.MODE })
+  sentryEnabled = true
+}
+
+export interface ReportTruncationParams {
+  resource: string
+  fetched: number | undefined
+  total_count: number | undefined
+  per_page: number | undefined
+}
+
+export const reportTruncation = ({ resource, fetched, total_count, per_page }: ReportTruncationParams): void => {
+  // Guard #1: Sentry not initialised
+  if (!sentryEnabled) return
+
+  // Guard #2: any value is non-finite (NaN, Infinity, undefined, null) — must be before numeric comparisons
+  if (
+    !Number.isFinite(fetched) ||
+    !Number.isFinite(total_count) ||
+    !Number.isFinite(per_page)
+  ) return
+
+  // Guard #3: only track "full dropdown fetch" calls
+  if (per_page !== DROPDOWN_PER_PAGE) return
+
+  // Guard #4: fetched less than the cap — not a truncation signal
+  if ((fetched as number) < DROPDOWN_PER_PAGE) return
+
+  // Guard #5: no truncation — all records fit
+  if ((total_count as number) <= (fetched as number)) return
+
+  // Guard #6: already reported this resource in this session (dedup — must be last)
+  if (reportedResources.has(resource)) return
+
+  // All guards passed — report and mark as done
+  Sentry.captureMessage('Admin dropdown data truncated', {
+    level: 'warning',
+    tags: { resource },
+    contexts: { pagination: { fetched, total_count, per_page } },
+    fingerprint: ['admin-pagination-truncated', resource],
+  })
+  reportedResources.add(resource)
+}

--- a/app/javascript/admin/pages/DashboardPage.tsx
+++ b/app/javascript/admin/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { dashboardApi, llmProvidersApi, DashboardData, LlmProvider } from '../lib/api'
+import { dashboardApi, llmProvidersApi, DashboardData, LlmProvider, DROPDOWN_PER_PAGE } from '../lib/api'
+import { reportTruncation } from '../lib/sentry'
 import StatCard from '../components/StatCard'
 import Avatar from '../components/Avatar'
 import Badge from '../components/Badge'
@@ -12,11 +13,17 @@ export const DashboardPage = () => {
   useEffect(() => {
     Promise.all([
       dashboardApi.get(),
-      llmProvidersApi.list({ per_page: 100 }),
+      llmProvidersApi.list({ per_page: DROPDOWN_PER_PAGE }),
     ])
       .then(([dashData, provData]) => {
         setData(dashData)
         setProviders(provData.llm_providers)
+        reportTruncation({
+          resource: 'llm_providers',
+          fetched: provData.llm_providers.length,
+          total_count: provData.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load dashboard'))
   }, [])

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { adminAccountsApi, rolesApi, Role } from '../../lib/api'
+import { adminAccountsApi, rolesApi, Role, DROPDOWN_PER_PAGE } from '../../lib/api'
+import { reportTruncation } from '../../lib/sentry'
 
 export const AdminAccountNewPage = () => {
   const navigate = useNavigate()
@@ -14,8 +15,16 @@ export const AdminAccountNewPage = () => {
   const [loadingRoles, setLoadingRoles] = useState(true)
 
   useEffect(() => {
-    rolesApi.list({ per_page: 100 })
-      .then(response => setRoles(response.roles))
+    rolesApi.list({ per_page: DROPDOWN_PER_PAGE })
+      .then(response => {
+        setRoles(response.roles)
+        reportTruncation({
+          resource: 'roles',
+          fetched: response.roles.length,
+          total_count: response.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
+      })
       .catch(() => setError('Failed to load roles'))
       .finally(() => setLoadingRoles(false))
   }, [])

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { adminAccountsApi, rolesApi, type Role } from '../../lib/api'
+import { adminAccountsApi, rolesApi, type Role, DROPDOWN_PER_PAGE } from '../../lib/api'
+import { reportTruncation } from '../../lib/sentry'
 
 export const AdminAccountRolesEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -13,12 +14,18 @@ export const AdminAccountRolesEditPage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list({ per_page: 100 }),
+      rolesApi.list({ per_page: DROPDOWN_PER_PAGE }),
       adminAccountsApi.getRoles(Number(id)),
     ])
       .then(([rolesResponse, accountRoles]) => {
         setAllRoles(rolesResponse.roles)
         setSelectedRoleIds(accountRoles.map(r => r.id))
+        reportTruncation({
+          resource: 'roles',
+          fetched: rolesResponse.roles.length,
+          total_count: rolesResponse.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load roles'))
       .finally(() => setLoading(false))

--- a/app/javascript/admin/pages/roles/RolePermissionPage.tsx
+++ b/app/javascript/admin/pages/roles/RolePermissionPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { rolesApi, permissionsApi, type Permission } from '../../lib/api'
+import { rolesApi, permissionsApi, type Permission, DROPDOWN_PER_PAGE } from '../../lib/api'
+import { reportTruncation } from '../../lib/sentry'
 import { AdminPageHeader } from '../../components/AdminPageHeader'
 import { ErrorBanner } from '../../components/ErrorBanner'
 
@@ -17,11 +18,17 @@ export const RolePermissionPage = () => {
     const fetchData = async () => {
       try {
         const [allResponse, assigned] = await Promise.all([
-          permissionsApi.list({ per_page: 100 }),
+          permissionsApi.list({ per_page: DROPDOWN_PER_PAGE }),
           rolesApi.getPermissions(Number(id)),
         ])
         setAllPermissions(allResponse.permissions)
         setAssignedIds(new Set(assigned.map(p => p.id)))
+        reportTruncation({
+          resource: 'permissions',
+          fetched: allResponse.permissions.length,
+          total_count: allResponse.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load permissions')
       } finally {

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { LlmModel, LlmProvider, PromptSet, llmModelsApi, llmProvidersApi, promptSetsApi, suggestionConfigsApi } from '../../lib/api'
+import { LlmModel, LlmProvider, PromptSet, llmModelsApi, llmProvidersApi, promptSetsApi, suggestionConfigsApi, DROPDOWN_PER_PAGE } from '../../lib/api'
+import { reportTruncation } from '../../lib/sentry'
 
 interface EntryRow {
   key: number
@@ -25,13 +26,33 @@ export const SuggestionConfigNewPage = () => {
     const loadData = async () => {
       try {
         const [providersResponse, psResponse] = await Promise.all([
-          llmProvidersApi.list({ per_page: 100 }),
-          promptSetsApi.list({ per_page: 100 }),
+          llmProvidersApi.list({ per_page: DROPDOWN_PER_PAGE }),
+          promptSetsApi.list({ per_page: DROPDOWN_PER_PAGE }),
         ])
+        reportTruncation({
+          resource: 'llm_providers',
+          fetched: providersResponse.llm_providers.length,
+          total_count: providersResponse.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
+        reportTruncation({
+          resource: 'prompt_sets',
+          fetched: psResponse.prompt_sets.length,
+          total_count: psResponse.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
         const activeProviders = providersResponse.llm_providers.filter((p: LlmProvider) => p.active)
         const allModelResponses = await Promise.all(
-          activeProviders.map((p: LlmProvider) => llmModelsApi.list(p.id, { per_page: 100 }))
+          activeProviders.map((p: LlmProvider) => llmModelsApi.list(p.id, { per_page: DROPDOWN_PER_PAGE }))
         )
+        allModelResponses.forEach(modelsResponse => {
+          reportTruncation({
+            resource: 'llm_models',
+            fetched: modelsResponse.llm_models.length,
+            total_count: modelsResponse.meta?.total_count,
+            per_page: DROPDOWN_PER_PAGE,
+          })
+        })
         setModels(allModelResponses.flatMap(r => r.llm_models).filter((m: LlmModel) => m.active))
         setPromptSets(psResponse.prompt_sets.filter((p: PromptSet) => p.active))
       } catch (err) {

--- a/app/javascript/admin/pages/users/UserRolePage.tsx
+++ b/app/javascript/admin/pages/users/UserRolePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { usersApi, rolesApi, Role } from '../../lib/api'
+import { usersApi, rolesApi, Role, DROPDOWN_PER_PAGE } from '../../lib/api'
+import { reportTruncation } from '../../lib/sentry'
 
 export const UserRolePage = () => {
   const { id } = useParams<{ id: string }>()
@@ -13,12 +14,18 @@ export const UserRolePage = () => {
   useEffect(() => {
     if (!id) return
     Promise.all([
-      rolesApi.list({ per_page: 100 }),
+      rolesApi.list({ per_page: DROPDOWN_PER_PAGE }),
       usersApi.getRoles(Number(id)),
     ])
       .then(([rolesResponse, userRoles]) => {
         setAllRoles(rolesResponse.roles)
         setSelectedRoleIds(userRoles.map(r => r.id))
+        reportTruncation({
+          resource: 'roles',
+          fetched: rolesResponse.roles.length,
+          total_count: rolesResponse.meta?.total_count,
+          per_page: DROPDOWN_PER_PAGE,
+        })
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load roles'))
       .finally(() => setLoading(false))

--- a/app/javascript/admin/vite-env.d.ts
+++ b/app/javascript/admin/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/javascript/entrypoints/admin.tsx
+++ b/app/javascript/entrypoints/admin.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import '../admin/styles/admin.css'
 import App from '../admin/App'
+import { initSentry } from '../admin/lib/sentry'
+
+initSentry()
 
 const container = document.getElementById('admin-root')
 if (container) {

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="sentry-dsn" content="<%= ENV.fetch('SENTRY_DSN', '') %>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet">

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,6 +23,12 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
     policy.font_src    :self, "https://fonts.gstatic.com"
     policy.img_src     :self, :data
     policy.connect_src :self
+    # Sentry browser SDK ingest endpoints (region-specific subdomains).
+    # CSP wildcards match only one label, so list each region we support.
+    policy.connect_src(*policy.connect_src,
+                       "https://*.ingest.sentry.io",
+                       "https://*.ingest.us.sentry.io",
+                       "https://*.ingest.de.sentry.io")
     if Rails.env.development?
       policy.connect_src(*policy.connect_src,
                          "ws://#{ViteRuby.config.host_with_port}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@sentry/react": "^10.49.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1"
@@ -1604,6 +1605,97 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.49.0.tgz",
+      "integrity": "sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.49.0.tgz",
+      "integrity": "sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.49.0.tgz",
+      "integrity": "sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.49.0.tgz",
+      "integrity": "sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.49.0.tgz",
+      "integrity": "sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry-internal/feedback": "10.49.0",
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry-internal/replay-canvas": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.49.0.tgz",
+      "integrity": "sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "vitest": "^4.1.2"
   },
   "dependencies": {
+    "@sentry/react": "^10.49.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1"


### PR DESCRIPTION
## Summary
- Admin SPA の低カーディナリティドロップダウン (Roles / Permissions / LlmProviders / LlmModels / PromptSets) が `per_page=100` キャップに到達した時、Sentry に warning を送信。誤操作の原因となる silent truncation を検知できる。
- `@sentry/react@10.49.0` を Admin SPA に初導入（Rails 側 Sentry とは同一 `SENTRY_DSN` を共有）。
- Closes #292

## Implementation Notes
- `reportTruncation` は **page 側で明示呼び出し**。`api.ts` の `list()` 内ラップ案は `usePagination` の `PER_PAGE_OPTIONS = [25, 50, 100]` と衝突して誤検知を生むため rejected（I4 review fix）。
- 6 guard chain (`sentry.ts`): non-finite reject → `DROPDOWN_PER_PAGE` 判定 → 数値比較 → per-resource dedup（順序 invariant 厳守）。
- CSP `connect_src` に Sentry 3 region 列挙（`*.ingest.sentry.io` / `*.ingest.us.sentry.io` / `*.ingest.de.sentry.io`）。CSP wildcard は 1 label のみ match するため列挙方式。
- DSN はブラウザ公開トークンなので HTML meta タグ埋込は機密懸念なし。

## Delegation Notes
- I2: `react-developer` 1回委譲（Return Format violation あり、orchestrator が verify & fix — `vi.clearAllMocks` の mock leak / missing `vite/client` 型参照）。
- I4: `react-reviewer` + `architecture-reviewer` 並列 → CRITICAL 1 (CSP) + HIGH 1 (index pages 誤検知) 検出 → Option A で re-design → `architecture-reviewer` 単独 re-review で **no actionable findings**。

## Dismissed / Deferred Findings
- DSN の third-party JS 露出: DSN は公開ブラウザトークン（設計意図）。
- `@sentry/react` v10 default integrations: 検証済で replay/feedback は含まれない（`node_modules/@sentry/browser/build/npm/esm/prod/sdk.js` 確認）。
- `vite-env.d.ts` trailing blank line: project ESLint `no-multiple-empty-lines` と矛盾、単一 `\n` 終端で codebase 慣習準拠。

## Test plan
- [x] ` npx vitest run` — 62 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] `bin/rails test:admin` — 449 pass
- [x] `bin/rails test:all` — 910 pass / 0 failures
- [ ] デプロイ後、Render の Admin SPA で `SENTRY_DSN` 環境変数が設定されていることを確認（インフラ別作業）
- [ ] 本番で truncation 事象が発生した際、Sentry プロジェクトに `tags.resource` + `contexts.pagination` 付きの event が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)