### PR TITLE
feat(admin): unify back navigation into AdminBackLink/AdminCancelButton

### DIFF
--- a/app/javascript/admin/__tests__/components/AdminBackLink.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminBackLink.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AdminBackLink } from '@admin/components/AdminBackLink'
+
+const renderComponent = (to: string, label: string) =>
+  render(
+    <MemoryRouter>
+      <AdminBackLink to={to} label={label} />
+    </MemoryRouter>
+  )
+
+describe('AdminBackLink', () => {
+  it('renders the label text', () => {
+    renderComponent('/admin/users', 'Users')
+    expect(screen.getByText('Users')).toBeInTheDocument()
+  })
+
+  it('renders as a link with the correct href', () => {
+    renderComponent('/admin/users', 'Users')
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/admin/users')
+  })
+
+  it('has accessible role of link', () => {
+    renderComponent('/admin/admin-accounts', 'Admin Accounts')
+    expect(screen.getByRole('link', { name: /Admin Accounts/i })).toBeInTheDocument()
+  })
+
+  it('renders the back arrow with aria-hidden', () => {
+    const { container } = renderComponent('/admin/users', 'Users')
+    const arrow = container.querySelector('[aria-hidden="true"]')
+    expect(arrow).toBeInTheDocument()
+    expect(arrow?.textContent).toBe('←')
+  })
+
+  it('includes hover color class for indigo', () => {
+    renderComponent('/admin/users', 'Users')
+    const link = screen.getByRole('link')
+    expect(link.className).toContain('hover:text-[#6366f1]')
+  })
+
+  it('exposes "Back to {label}" as the accessible name via aria-label', () => {
+    renderComponent('/admin/users', 'Users')
+    expect(screen.getByRole('link', { name: 'Back to Users' })).toBeInTheDocument()
+  })
+})

--- a/app/javascript/admin/__tests__/components/AdminBackLink.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminBackLink.test.tsx
@@ -21,9 +21,9 @@ describe('AdminBackLink', () => {
     expect(link).toHaveAttribute('href', '/admin/users')
   })
 
-  it('has accessible role of link', () => {
+  it('exposes the accessible name "Back to {label}" via aria-label', () => {
     renderComponent('/admin/admin-accounts', 'Admin Accounts')
-    expect(screen.getByRole('link', { name: /Admin Accounts/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to Admin Accounts' })).toBeInTheDocument()
   })
 
   it('renders the back arrow with aria-hidden', () => {
@@ -37,10 +37,5 @@ describe('AdminBackLink', () => {
     renderComponent('/admin/users', 'Users')
     const link = screen.getByRole('link')
     expect(link.className).toContain('hover:text-[#6366f1]')
-  })
-
-  it('exposes "Back to {label}" as the accessible name via aria-label', () => {
-    renderComponent('/admin/users', 'Users')
-    expect(screen.getByRole('link', { name: 'Back to Users' })).toBeInTheDocument()
   })
 })

--- a/app/javascript/admin/__tests__/components/AdminCancelButton.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminCancelButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AdminCancelButton } from '@admin/components/AdminCancelButton'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const renderComponent = (to: string) =>
+  render(
+    <MemoryRouter>
+      <AdminCancelButton to={to} />
+    </MemoryRouter>
+  )
+
+describe('AdminCancelButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the fixed label "Cancel"', () => {
+    renderComponent('/admin/users')
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  it('has accessible role of button', () => {
+    renderComponent('/admin/users')
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  it('has type="button" attribute to prevent form submit', () => {
+    renderComponent('/admin/users')
+    const button = screen.getByRole('button', { name: 'Cancel' })
+    expect(button).toHaveAttribute('type', 'button')
+  })
+
+  it('calls navigate(to) when clicked', () => {
+    renderComponent('/admin/roles')
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mockNavigate).toHaveBeenCalledWith('/admin/roles')
+  })
+})

--- a/app/javascript/admin/components/AdminBackLink.tsx
+++ b/app/javascript/admin/components/AdminBackLink.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom'
+
+interface AdminBackLinkProps {
+  to: string
+  label: string
+}
+
+export const AdminBackLink = ({ to, label }: AdminBackLinkProps) => (
+  <Link
+    to={to}
+    aria-label={`Back to ${label}`}
+    className="group inline-flex items-center gap-1 text-xs font-medium text-slate-500 transition-colors hover:text-[#6366f1]"
+  >
+    <span className="inline-block transition-transform group-hover:-translate-x-0.5" aria-hidden="true">←</span>
+    {label}
+  </Link>
+)

--- a/app/javascript/admin/components/AdminCancelButton.tsx
+++ b/app/javascript/admin/components/AdminCancelButton.tsx
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom'
+
+interface AdminCancelButtonProps {
+  to: string
+}
+
+export const AdminCancelButton = ({ to }: AdminCancelButtonProps) => {
+  const navigate = useNavigate()
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(to)}
+      className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+    >
+      Cancel
+    </button>
+  )
+}

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountDetailPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountDetailPage.tsx
@@ -4,6 +4,7 @@ import { adminAccountsApi, type AdminAccountDetail, type ResourceType, type Acti
 import { useAuth } from '../../contexts/AuthContext'
 import Avatar from '../../components/Avatar'
 import Badge from '../../components/Badge'
+import { AdminBackLink } from '../../components/AdminBackLink'
 
 const RESOURCE_TYPES: ResourceType[] = ['User', 'Project', 'Task', 'Comment', 'Admin', 'LlmProvider']
 const ACTIONS: Action[] = ['read', 'write', 'delete', 'manage']
@@ -40,6 +41,7 @@ export const AdminAccountDetailPage = () => {
 
   return (
     <div className="space-y-6">
+      <AdminBackLink to="/admin/admin-accounts" label="Admin Accounts" />
       {/* Page header */}
       <div className="flex items-end justify-between">
         <div>
@@ -139,14 +141,6 @@ export const AdminAccountDetailPage = () => {
         </>
       )}
 
-      <div>
-        <Link
-          to="/admin/admin-accounts"
-          className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-        >
-          Back to list
-        </Link>
-      </div>
     </div>
   )
 }

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountEditPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { adminAccountsApi } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const AdminAccountEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -67,10 +68,7 @@ export const AdminAccountEditPage = () => {
             </div>
           </div>
           <div className="mt-6 flex items-center justify-end gap-2">
-            <button type="button" onClick={() => navigate('/admin/admin-accounts')}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
-              Cancel
-            </button>
+            <AdminCancelButton to="/admin/admin-accounts" />
             <button type="submit"
               className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
               Update

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountNewPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { adminAccountsApi, rolesApi, Role, DROPDOWN_PER_PAGE } from '../../lib/api'
 import { reportTruncation } from '../../lib/sentry'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const AdminAccountNewPage = () => {
   const navigate = useNavigate()
@@ -125,10 +126,7 @@ export const AdminAccountNewPage = () => {
             </div>
           </div>
           <div className="mt-6 flex items-center justify-end gap-2">
-            <Link to="/admin/admin-accounts"
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
-              Cancel
-            </Link>
+            <AdminCancelButton to="/admin/admin-accounts" />
             <button type="submit"
               className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
               Create

--- a/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
+++ b/app/javascript/admin/pages/admin-accounts/AdminAccountRolesEditPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { adminAccountsApi, rolesApi, type Role, DROPDOWN_PER_PAGE } from '../../lib/api'
 import { reportTruncation } from '../../lib/sentry'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const AdminAccountRolesEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -94,10 +95,7 @@ export const AdminAccountRolesEditPage = () => {
             ))}
           </ul>
           <div className="mt-6 flex items-center justify-end gap-2">
-            <button type="button" onClick={() => navigate(`/admin/admin-accounts/${id}`)}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
-              Cancel
-            </button>
+            <AdminCancelButton to={`/admin/admin-accounts/${id}`} />
             <button type="submit"
               className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
               Save

--- a/app/javascript/admin/pages/llm-providers/LlmModelEditPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmModelEditPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { llmModelsApi, LlmModel, UpdateLlmModelInput } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const LlmModelEditPage = () => {
   const { id, modelId } = useParams<{ id: string; modelId: string }>()
@@ -125,12 +126,7 @@ export const LlmModelEditPage = () => {
           </div>
 
           <div className="mt-6 flex items-center justify-end gap-2">
-            <Link
-              to={`/admin/llm-providers/${providerId}/models`}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-            >
-              Cancel
-            </Link>
+            <AdminCancelButton to={`/admin/llm-providers/${providerId}/models`} />
             <button
               type="submit"
               disabled={submitting}

--- a/app/javascript/admin/pages/llm-providers/LlmModelNewPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmModelNewPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { llmModelsApi, llmProvidersApi, CreateLlmModelInput, AvailableModel } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const LlmModelNewPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -142,12 +143,7 @@ export const LlmModelNewPage = () => {
           </div>
 
           <div className="mt-6 flex items-center justify-end gap-2">
-            <Link
-              to={`/admin/llm-providers/${providerId}/models`}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-            >
-              Cancel
-            </Link>
+            <AdminCancelButton to={`/admin/llm-providers/${providerId}/models`} />
             <button
               type="submit"
               disabled={submitting || loadingModels || !!modelsError}

--- a/app/javascript/admin/pages/llm-providers/LlmModelsIndexPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmModelsIndexPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { llmModelsApi, LlmModel, type PaginationMeta } from '../../lib/api'
+import { AdminBackLink } from '../../components/AdminBackLink'
 import Badge from '../../components/Badge'
 import Pagination from '../../components/Pagination'
 import { usePagination, useClampPage } from '../../hooks/usePagination'
@@ -54,6 +55,7 @@ export const LlmModelsIndexPage = () => {
 
   return (
     <div className="space-y-6">
+      <AdminBackLink to={`/admin/llm-providers/${providerId}`} label="Provider" />
       {/* Page header */}
       <div className="flex items-end justify-between">
         <div>
@@ -66,12 +68,6 @@ export const LlmModelsIndexPage = () => {
             className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]"
           >
             New Model
-          </Link>
-          <Link
-            to={`/admin/llm-providers/${providerId}`}
-            className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-          >
-            Back
           </Link>
         </div>
       </div>

--- a/app/javascript/admin/pages/llm-providers/LlmProviderDetailPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmProviderDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { llmProvidersApi, LlmProvider } from '../../lib/api'
 import Badge from '../../components/Badge'
+import { AdminBackLink } from '../../components/AdminBackLink'
 
 export const LlmProviderDetailPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -27,6 +28,7 @@ export const LlmProviderDetailPage = () => {
 
   return (
     <div className="space-y-6">
+      <AdminBackLink to="/admin/llm-providers" label="LLM Providers" />
       {/* Page header */}
       <div className="flex items-end justify-between">
         <div>
@@ -45,12 +47,6 @@ export const LlmProviderDetailPage = () => {
             className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
           >
             Manage Models
-          </Link>
-          <Link
-            to="/admin/llm-providers"
-            className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-          >
-            Back to list
           </Link>
         </div>
       </div>

--- a/app/javascript/admin/pages/llm-providers/LlmProviderEditPage.tsx
+++ b/app/javascript/admin/pages/llm-providers/LlmProviderEditPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { llmProvidersApi, LlmProvider, UpdateLlmProviderInput } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const LlmProviderEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -124,12 +125,7 @@ export const LlmProviderEditPage = () => {
           </div>
 
           <div className="mt-6 flex items-center justify-end gap-2">
-            <Link
-              to="/admin/llm-providers"
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-            >
-              Cancel
-            </Link>
+            <AdminCancelButton to="/admin/llm-providers" />
             <button
               type="submit"
               disabled={submitting}

--- a/app/javascript/admin/pages/permissions/PermissionDetailPage.tsx
+++ b/app/javascript/admin/pages/permissions/PermissionDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { permissionsApi, type Permission } from '../../lib/api'
 import { AdminPageHeader } from '../../components/AdminPageHeader'
+import { AdminBackLink } from '../../components/AdminBackLink'
 
 export const PermissionDetailPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -27,6 +28,7 @@ export const PermissionDetailPage = () => {
 
   return (
     <div className="space-y-6">
+      <AdminBackLink to="/admin/permissions" label="Permissions" />
       <AdminPageHeader eyebrow="MANAGEMENT" title="Permission Detail" />
       {error && <p className="text-rose-500">{error}</p>}
       {permission && (
@@ -82,12 +84,6 @@ export const PermissionDetailPage = () => {
           </div>
         </>
       )}
-      <div>
-        <Link
-          to="/admin/permissions"
-          className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-        >Back to list</Link>
-      </div>
     </div>
   )
 }

--- a/app/javascript/admin/pages/prompt-sets/PromptSetEditPage.tsx
+++ b/app/javascript/admin/pages/prompt-sets/PromptSetEditPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { PromptInput, PromptSet, promptSetsApi } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 const VARIABLES = ['goal', 'context', 'due_date', 'start_date']
 
@@ -224,12 +225,7 @@ export const PromptSetEditPage = () => {
 
         {/* Actions */}
         <div className="flex justify-end gap-3">
-          <Link
-            to="/admin/prompt-sets"
-            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50"
-          >
-            Cancel
-          </Link>
+          <AdminCancelButton to="/admin/prompt-sets" />
           <button
             type="submit"
             disabled={submitting}

--- a/app/javascript/admin/pages/prompt-sets/PromptSetNewPage.tsx
+++ b/app/javascript/admin/pages/prompt-sets/PromptSetNewPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { PromptInput, promptSetsApi } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 const VARIABLES = ['goal', 'context', 'due_date', 'start_date']
 
@@ -169,12 +170,7 @@ export const PromptSetNewPage = () => {
 
         {/* Actions */}
         <div className="flex justify-end gap-3">
-          <Link
-            to="/admin/prompt-sets"
-            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50"
-          >
-            Cancel
-          </Link>
+          <AdminCancelButton to="/admin/prompt-sets" />
           <button
             type="submit"
             disabled={submitting}

--- a/app/javascript/admin/pages/roles/RoleEditPage.tsx
+++ b/app/javascript/admin/pages/roles/RoleEditPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { rolesApi } from '../../lib/api'
 import { AdminPageHeader } from '../../components/AdminPageHeader'
 import { ErrorBanner } from '../../components/ErrorBanner'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const RoleEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -75,13 +76,7 @@ export const RoleEditPage = () => {
             </div>
           </div>
           <div className="mt-6 flex items-center justify-end gap-3">
-            <button
-              type="button"
-              onClick={() => navigate('/admin/roles')}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-            >
-              Cancel
-            </button>
+            <AdminCancelButton to="/admin/roles" />
             <button
               type="submit"
               disabled={submitting}

--- a/app/javascript/admin/pages/roles/RoleNewPage.tsx
+++ b/app/javascript/admin/pages/roles/RoleNewPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { rolesApi } from '../../lib/api'
 import { AdminPageHeader } from '../../components/AdminPageHeader'
 import { ErrorBanner } from '../../components/ErrorBanner'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const RoleNewPage = () => {
   const navigate = useNavigate()
@@ -56,13 +57,7 @@ export const RoleNewPage = () => {
             </div>
           </div>
           <div className="mt-6 flex items-center justify-end gap-3">
-            <button
-              type="button"
-              onClick={() => navigate('/admin/roles')}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-            >
-              Cancel
-            </button>
+            <AdminCancelButton to="/admin/roles" />
             <button
               type="submit"
               disabled={submitting}

--- a/app/javascript/admin/pages/roles/RolePermissionPage.tsx
+++ b/app/javascript/admin/pages/roles/RolePermissionPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { rolesApi, permissionsApi, type Permission, DROPDOWN_PER_PAGE } from '../../lib/api'
 import { reportTruncation } from '../../lib/sentry'
 import { AdminPageHeader } from '../../components/AdminPageHeader'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 import { ErrorBanner } from '../../components/ErrorBanner'
 
 export const RolePermissionPage = () => {
@@ -110,7 +111,8 @@ export const RolePermissionPage = () => {
           ))}
         </div>
 
-        <div className="mt-6 flex items-center justify-end">
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <AdminCancelButton to="/admin/roles" />
           <button
             type="submit"
             disabled={submitting}

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigDetailPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { SuggestionConfig, suggestionConfigsApi } from '../../lib/api'
 import Badge from '../../components/Badge'
+import { AdminBackLink } from '../../components/AdminBackLink'
 
 export const SuggestionConfigDetailPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -21,6 +22,7 @@ export const SuggestionConfigDetailPage = () => {
 
   return (
     <div className="space-y-6">
+      <AdminBackLink to="/admin/suggestion-configs" label="Suggestion Configs" />
       {/* Header */}
       <div className="flex items-end justify-between">
         <div>
@@ -31,12 +33,6 @@ export const SuggestionConfigDetailPage = () => {
             Config #{config.id}
           </h1>
         </div>
-        <Link
-          to="/admin/suggestion-configs"
-          className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50"
-        >
-          Back to list
-        </Link>
       </div>
 
       {/* Info */}

--- a/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
+++ b/app/javascript/admin/pages/suggestion-configs/SuggestionConfigNewPage.tsx
@@ -1,7 +1,8 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { LlmModel, LlmProvider, PromptSet, llmModelsApi, llmProvidersApi, promptSetsApi, suggestionConfigsApi, DROPDOWN_PER_PAGE } from '../../lib/api'
 import { reportTruncation } from '../../lib/sentry'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 interface EntryRow {
   key: number
@@ -198,12 +199,7 @@ export const SuggestionConfigNewPage = () => {
         </div>
 
         <div className="flex justify-end gap-3">
-          <Link
-            to="/admin/suggestion-configs"
-            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50"
-          >
-            Cancel
-          </Link>
+          <AdminCancelButton to="/admin/suggestion-configs" />
           <button
             type="submit"
             disabled={submitting || weightsTotal !== 100}

--- a/app/javascript/admin/pages/users/UserEditPage.tsx
+++ b/app/javascript/admin/pages/users/UserEditPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { usersApi } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const UserEditPage = () => {
   const { id } = useParams<{ id: string }>()
@@ -67,10 +68,7 @@ export const UserEditPage = () => {
             </div>
           </div>
           <div className="mt-6 flex items-center justify-end gap-2">
-            <button type="button" onClick={() => navigate('/admin/users')}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
-              Cancel
-            </button>
+            <AdminCancelButton to="/admin/users" />
             <button type="submit"
               className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
               Update

--- a/app/javascript/admin/pages/users/UserNewPage.tsx
+++ b/app/javascript/admin/pages/users/UserNewPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { usersApi } from '../../lib/api'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const UserNewPage = () => {
   const navigate = useNavigate()
@@ -68,10 +69,7 @@ export const UserNewPage = () => {
             </div>
           </div>
           <div className="mt-6 flex items-center justify-end gap-2">
-            <Link to="/admin/users"
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
-              Cancel
-            </Link>
+            <AdminCancelButton to="/admin/users" />
             <button type="submit"
               className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
               Create

--- a/app/javascript/admin/pages/users/UserRolePage.tsx
+++ b/app/javascript/admin/pages/users/UserRolePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { usersApi, rolesApi, Role, DROPDOWN_PER_PAGE } from '../../lib/api'
 import { reportTruncation } from '../../lib/sentry'
+import { AdminCancelButton } from '../../components/AdminCancelButton'
 
 export const UserRolePage = () => {
   const { id } = useParams<{ id: string }>()
@@ -91,10 +92,7 @@ export const UserRolePage = () => {
             ))}
           </ul>
           <div className="mt-6 flex items-center justify-end gap-2">
-            <button type="button" onClick={() => navigate('/admin/users')}
-              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50">
-              Back
-            </button>
+            <AdminCancelButton to="/admin/users" />
             <button type="submit"
               className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
               Save

--- a/docs/conventions/ADMIN_UI.md
+++ b/docs/conventions/ADMIN_UI.md
@@ -165,6 +165,40 @@ className="bg-[#0f1117]"      // ハードコード
   bg-{color}-500/15 text-{color}-400 ring-1 ring-{color}-500/30">
 ```
 
+### 4.5 戻るナビゲーション
+
+admin画面の「前画面に戻る」UIは意味論で2種に分離。
+
+| ページ種別 | 使うコンポーネント | 配置 | 例 |
+|---|---|---|---|
+| Detail / 閲覧 | `<AdminBackLink>` | ページヘッダー左上（`space-y-6` の先頭子要素） | AdminAccountDetail |
+| ネスト Index（親が Detail） | `<AdminBackLink>` | ページヘッダー左上（同上）、label は親リソース単数形 | LlmModels（親: LlmProvider Detail） |
+| Edit / New / 設定フォーム | `<AdminCancelButton>` | フォームフッター、Saveボタンの左隣 | UserEdit, RolePermission |
+| Top-level Index / Dashboard 等 | （無し） | — | 親が存在しないページ |
+
+**AdminBackLink**：`<Link>` ベース。props: `to`（親ルート）, `label`（親リソース名）。例：`<AdminBackLink to="/admin/users" label="Users" />`。ネスト Index の場合は親 Detail を指し、label は親リソース単数形（例：`<AdminBackLink to="/admin/llm-providers/:id" label="Provider" />`）。アクセシビリティのため `aria-label="Back to {label}"` を内部で自動付与。
+
+**AdminCancelButton**：`<button type="button">` + `useNavigate` ベース。props: `to`。固定ラベル "Cancel"。`<Link>` を使わないのは、Cmd/Ctrl-click で別タブに「親リストを開く」挙動が Cancel の意味論（編集破棄して同コンテキスト離脱）と矛盾するため。
+
+#### Semantic Invariants
+
+| 項目 | AdminBackLink | AdminCancelButton |
+|---|---|---|
+| HTML | `<a>` (react-router `<Link>`) | `<button type="button">` |
+| role | `link` | `button` |
+| Cmd/Ctrl-click | 新タブで開く（意図通り） | 無効（意図通り） |
+| keyboard | Tab + Enter | Tab + Enter/Space |
+| form submit risk | N/A | `type="button"` で防止 |
+
+**Do**：
+- Detail ページはヘッダー領域の上に `AdminBackLink` を1つだけ配置
+- Edit/New フォームは `AdminCancelButton` をフォームフッターでプライマリアクションの左隣に配置
+
+**Don't**：
+- Cancel を `<Link>` に置き換えない
+- Back と Cancel を同じページで併用しない
+- Index / Dashboard / Login 等に戻るUIを追加しない
+
 ---
 
 ## 5. レイアウト

--- a/docs/design/admin/components/button.md
+++ b/docs/design/admin/components/button.md
@@ -32,3 +32,5 @@ text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300
 text-xs text-[#6366f1] hover:underline
 ```
 
+※ 戻る系UI（`AdminBackLink` / `AdminCancelButton`）は [`docs/conventions/ADMIN_UI.md` §4.5](../../../conventions/ADMIN_UI.md#45-戻るナビゲーション) を参照。
+

--- a/tests/admin/llm_providers.spec.ts
+++ b/tests/admin/llm_providers.spec.ts
@@ -35,7 +35,7 @@ test.describe('Admin LLM プロバイダー管理', () => {
     // 詳細情報が表示されること
     await expect(page.getByText('API Key')).toBeVisible()
     await expect(page.getByRole('rowheader', { name: 'Active' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Back to list' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Back to LLM Providers' })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Edit' })).toBeVisible()
   })
 })


### PR DESCRIPTION
Closes #329

## Summary
- Replace 18 admin pages' ad-hoc back UIs (3 labels / 3 positions / 2 component types) with two semantically-divided shared components: `AdminBackLink` (Detail / nested-Index) and `AdminCancelButton` (Edit/New/forms).
- Add missing back affordance on `RolePermissionPage` (Cancel button) and `LlmModelsIndexPage` (Back link).
- Document the convention in `docs/conventions/ADMIN_UI.md` §4.5 with a Decision table, Semantic Invariants, and Do/Don't.

## Why two components?
- `AdminBackLink` uses `<Link>` — Cmd/Ctrl-click opening the parent list in a new tab is desirable for Back.
- `AdminCancelButton` uses `<button type="button"> + useNavigate` — Cancel means "discard edits and stay in context", so opening the parent in a new tab is semantically wrong; `type="button"` also prevents accidental form submission.

## Scope (26 files)
- **New (4)**: 2 components + 2 vitest specs
- **Modified pages (20)**: 4 Detail + 14 Edit/New + RolePermission (rescue) + LlmModelsIndexPage (rescue)
- **Docs (2)**: `ADMIN_UI.md` §4.5 added (incl. nested-Index row); `button.md` cross-ref

## Test plan
- [x] `npm test` — 72 passed (9 files), includes new `AdminBackLink` / `AdminCancelButton` specs
- [x] `npm run typecheck` — clean
- [x] `bin/rails test:all` — 910 runs / 0 failures (no Rails impact, run for completeness)
- [ ] Manual smoke: AdminAccountDetail / UserEdit / RolePermission / LlmModelsIndex on local `bin/dev`

## I4 (Local Review) summary
Initial parallel review (`react-reviewer` + `architecture-reviewer`) raised CRITICAL 1 / MED 2 / LOW 3.
- **Fixed**: C1 (LlmModelNewPage leftover `<Link>` after import swap → typecheck failure), L2 (AdminBackLink missing `aria-label`), M2 (LlmModelsIndexPage statement-of-work miss → expanded scope to satisfy "unify" goal).
- **Deferred** (existing inconsistencies, separate issues recommended): M1 (`gap-2` vs `gap-3` in Roles pages), L1 (`#6366f1` hardcoded — `text-accent` Tailwind utility not yet defined), L3 (`Save` vs `Save Permissions` wording).
- Re-review by `architecture-reviewer` produced no substantive findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)