### PR TITLE
fix(e2e): resolve local Playwright failures end-to-end (#333)

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -10,6 +10,7 @@
   },
   "test": {
     "autoBuild": true,
-    "publicOutputDir": "vite-test"
+    "publicOutputDir": "vite-test",
+    "port": 3037
   }
 }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -106,31 +106,38 @@ Rails.logger.debug "Assigned permissions to roles"
 
 # Create admin users based on environment
 if Rails.env.local?
-  # Development environment - create default admin
+  # Development environment - create default admin.
+  # Chrome の weak password 警告を踏まないよう、test/test_helper.rb の
+  # TEST_PASSWORD と同じ値を使う。再実行時も既知の値へ戻すため明示 update する。
+  seed_password = "HoboTest!Str0ng#2024"
+
   admin_user = User.find_or_create_by!(email: "admin@example.com") do |user|
-    user.password = "password"
+    user.password = seed_password
     user.name = "Admin User"
   end
+  admin_user.update!(password: seed_password)
 
   # Assign admin role to the admin user
   admin_user.roles << admin_role unless admin_user.roles.include?(admin_role)
 
   # E2E テスト用のユーザーを作成
   viewer_user = User.find_or_create_by!(email: "viewer@example.com") do |user|
-    user.password = "password"
+    user.password = seed_password
     user.name = "Viewer User"
   end
+  viewer_user.update!(password: seed_password)
   viewer_user.roles << user_viewer_role unless viewer_user.roles.include?(user_viewer_role)
 
   llm_admin_user = User.find_or_create_by!(email: "llmadmin@example.com") do |user|
-    user.password = "password"
+    user.password = seed_password
     user.name = "LLM Admin User"
   end
+  llm_admin_user.update!(password: seed_password)
   llm_admin_user.roles << llm_admin_role unless llm_admin_user.roles.include?(llm_admin_role)
 
-  Rails.logger.debug "Created admin user: admin@example.com (password: password)"
-  Rails.logger.debug "Created viewer user: viewer@example.com (password: password)"
-  Rails.logger.debug "Created llm_admin user: llmadmin@example.com (password: password)"
+  Rails.logger.debug { "Created admin user: admin@example.com (password: #{seed_password})" }
+  Rails.logger.debug { "Created viewer user: viewer@example.com (password: #{seed_password})" }
+  Rails.logger.debug { "Created llm_admin user: llmadmin@example.com (password: #{seed_password})" }
 elsif Rails.env.production?
   # Production/Staging environment - create master user with environment variables
   master_email = ENV.fetch("MASTER_USER_EMAIL", nil)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:3100',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -51,10 +51,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'bin/rails server',
-    url: 'http://localhost:3000',
+    command: 'bin/rails server -p 3100',
+    url: 'http://localhost:3100',
     env: { RAILS_ENV: 'test' },
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * Read environment variables from file.
@@ -53,7 +53,8 @@ export default defineConfig({
   webServer: {
     command: 'bin/rails server',
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    env: { RAILS_ENV: 'test' },
+    reuseExistingServer: false,
     timeout: 120000,
   },
-});
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ import { defineConfig, devices } from '@playwright/test'
  */
 export default defineConfig({
   testDir: './tests',
+  globalSetup: './tests/global-setup.ts',
   globalTeardown: './tests/global-teardown.ts',
   /* Test timeout */
   timeout: 30000,

--- a/tests/admin/admin-accounts.spec.ts
+++ b/tests/admin/admin-accounts.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
 
 test.describe('Admin アカウント管理', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
   })
@@ -31,8 +32,8 @@ test.describe('Admin アカウント管理', () => {
     await page.locator('input[type="text"]').fill(newName)
 
     const passwordInputs = page.locator('input[type="password"]')
-    await passwordInputs.nth(0).fill('password123')
-    await passwordInputs.nth(1).fill('password123')
+    await passwordInputs.nth(0).fill(TEST_PASSWORD)
+    await passwordInputs.nth(1).fill(TEST_PASSWORD)
 
     // Select a role with admin access (user_viewer has Admin:read)
     await page.getByText('user_viewer').click()
@@ -56,8 +57,8 @@ test.describe('Admin アカウント管理', () => {
     await page.locator('input[type="text"]').fill(revokeName)
 
     const passwordInputs = page.locator('input[type="password"]')
-    await passwordInputs.nth(0).fill('password123')
-    await passwordInputs.nth(1).fill('password123')
+    await passwordInputs.nth(0).fill(TEST_PASSWORD)
+    await passwordInputs.nth(1).fill(TEST_PASSWORD)
 
     await page.getByText('user_viewer').click()
     await page.getByRole('button', { name: 'Create' }).click()

--- a/tests/admin/auth.spec.ts
+++ b/tests/admin/auth.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
 
 test.describe('Admin 認証フロー', () => {
   test('ログインページが表示されること', async ({ page }) => {
@@ -14,7 +15,7 @@ test.describe('Admin 認証フロー', () => {
     await page.goto('/admin/login')
 
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
 
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
@@ -36,7 +37,7 @@ test.describe('Admin 認証フロー', () => {
     // ログイン
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
     await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({ timeout: 10000 })
@@ -52,7 +53,7 @@ test.describe('ナビゲーション capabilities フィルタリング', () => 
   test('user_viewer は Users ナビが表示され LLM Providers ナビが非表示', async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('viewer@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
 
@@ -63,7 +64,7 @@ test.describe('ナビゲーション capabilities フィルタリング', () => 
   test('llm_admin_user は LLM Providers ナビが表示され Users ナビが非表示', async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('llmadmin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
 
@@ -74,7 +75,7 @@ test.describe('ナビゲーション capabilities フィルタリング', () => 
   test('user_viewer が /admin/llm-providers に直接アクセスすると Dashboard にリダイレクト', async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('viewer@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
 
@@ -85,7 +86,7 @@ test.describe('ナビゲーション capabilities フィルタリング', () => 
   test('llm_admin_user が /admin/roles/new に直接アクセスすると Dashboard にリダイレクト', async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('llmadmin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
 

--- a/tests/admin/dashboard.spec.ts
+++ b/tests/admin/dashboard.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
 
 test.describe('Admin ダッシュボード', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
   })

--- a/tests/admin/llm_providers.spec.ts
+++ b/tests/admin/llm_providers.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
 
 test.describe('Admin LLM プロバイダー管理', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
   })

--- a/tests/admin/roles.spec.ts
+++ b/tests/admin/roles.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
 
 test.describe('Admin ロール管理', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
   })

--- a/tests/admin/users.spec.ts
+++ b/tests/admin/users.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
 
 test.describe('Admin ユーザー管理', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/admin/login')
     await page.locator('input[type="email"]').fill('admin@example.com')
-    await page.locator('input[type="password"]').fill('password')
+    await page.locator('input[type="password"]').fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
   })
@@ -31,8 +32,8 @@ test.describe('Admin ユーザー管理', () => {
     await page.locator('input[type="text"]').fill(newName)
 
     const passwordInputs = page.locator('input[type="password"]')
-    await passwordInputs.nth(0).fill('password123')
-    await passwordInputs.nth(1).fill('password123')
+    await passwordInputs.nth(0).fill(TEST_PASSWORD)
+    await passwordInputs.nth(1).fill(TEST_PASSWORD)
 
     await page.getByRole('button', { name: 'Create' }).click()
 
@@ -75,8 +76,8 @@ test.describe('Admin ユーザー管理', () => {
     await page.locator('input[type="text"]').fill(deleteName)
 
     const passwordInputs = page.locator('input[type="password"]')
-    await passwordInputs.nth(0).fill('password123')
-    await passwordInputs.nth(1).fill('password123')
+    await passwordInputs.nth(0).fill(TEST_PASSWORD)
+    await passwordInputs.nth(1).fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Create' }).click()
     await expect(page).toHaveURL('/admin/users', { timeout: 10000 })
     await expect(page.getByText(deleteEmail)).toBeVisible({ timeout: 10000 })

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -1,0 +1,4 @@
+// Shared credentials for E2E tests.
+// Must match test/test_helper.rb TEST_PASSWORD and db/seeds.rb seed_password.
+// Chrome の weak password 警告を回避するため、英数記号を含む強いパスワードを使用する。
+export const TEST_PASSWORD = 'HoboTest!Str0ng#2024'

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'node:child_process'
+
+async function globalSetup() {
+  execSync('bin/rails db:prepare db:seed', {
+    stdio: 'inherit',
+    env: { ...process.env, RAILS_ENV: 'test' },
+  })
+}
+
+export default globalSetup


### PR DESCRIPTION
## Summary
Fixes #333

Issue #333 の調査中、真の「ローカル E2E が壊れる原因」が単一ではなく **4層** に渡っていたことが判明したため、当初の `RAILS_ENV=test` 追加に留まらず **E2E 実行に関わる問題を全て解決** する方針に拡張。

## Root causes fixed (4 layers)

1. **Rails env drift** — `webServer` が RAILS_ENV 未指定で `development.sqlite3` を使用 → `test.sqlite3` に強制
2. **Port 衝突** — dev server (port 3000) と共存不可 → E2E は **port 3100** 専用に分離
3. **Vite dev server 誤検知** — vite_ruby が dev の Vite dev server (port 3036) を test env 用にも使ってしまう → test env に専用 port **3037** を割当
4. **Seed の非 idempotency** — seeds.rb は「The code here should be idempotent」と自称するが `find_or_create_by!` block は既存ユーザーの password を更新せず、state drift で login が常に壊れる → 明示 `update!` で契約通りに idempotent 化

## Changes

### config
- `playwright.config.ts`: `env: { RAILS_ENV: 'test' }`、webServer port 3100、`globalSetup` 登録
- `config/vite.json`: test env に `"port": 3037` 追加

### auto-healing seed
- `tests/global-setup.ts` 新規: E2E 前に `bin/rails db:prepare db:seed RAILS_ENV=test` を自動実行
- `db/seeds.rb`: admin/viewer/llm_admin を `find_or_create_by!` 後に明示 `update!` で password を再設定、**Chrome の weak password 警告を避けるため** `test/test_helper.rb` の `TEST_PASSWORD` と同じ `"HoboTest!Str0ng#2024"` に統一

### Playwright tests
- `tests/fixtures/auth.ts` 新規: `TEST_PASSWORD` 定数を export (Ruby 側 `TEST_PASSWORD` と値揃え)
- `tests/admin/*.spec.ts`: 6 ファイルで `.fill('password')` / `.fill('password123')` を `.fill(TEST_PASSWORD)` に置換 (`'wrongpassword'` の意図的失敗ケースは温存)
- (bonus) 既存の extra-semicolon ESLint offence 2 件を autofix

## ⚠️ Breaking change: dev の admin login 資格

`db/seeds.rb` 経由で作成される dev 環境の admin/viewer/llm_admin パスワードも `"password"` → `"HoboTest!Str0ng#2024"` に変わる。dev 環境で手動 login する開発者は再 seed 後に新 password を使用のこと。

## Verification (ローカル実行)

dev server (port 3000 + vite 3036) を立てたまま、以下を全て確認済：

- [x] `npx playwright test` → **23/23 pass** (12s)、dev server と共存可能
- [x] `bin/rails test test/system/` → **24 runs / 0 failures**、Chrome weak password 警告による system test 失敗なし
- [x] `npm test` (Vitest) → **78/78 pass**
- [x] password を意図的に drift させても globalSetup が自動修復して login 通過
- [x] port 3000 に dev server 立てた状態でも E2E が衝突なく走る

🤖 Generated with [Claude Code](https://claude.com/claude-code)