### PR TITLE
docs(workflow): integrate UI design process into Standard Flow P3

### DIFF
--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -6,6 +6,7 @@ The following Claude Code resources live in the user-global config (`~/.claude/`
 
 - **`user-story-creation` skill** — Standard Flow P2
 - **`plan-reviewer` agent** — Standard Flow P3
+- **`ui-designer` agent** — Standard Flow P3 (UI Design Loop、UI 変更を伴う Issue のみ)
 
 The following resources **are bundled** with this repository and available automatically:
 
@@ -64,7 +65,10 @@ ALWAYS update `.progress/issue-XXXXX.md` during work. Update the progress file *
   - What you've done in this step.
   - ...
 - [ ] P2 — Create user stories
+  - [ ] UI changes: yes / no (decided with client) — recorded: ___
 - [ ] P3 — Create a plan
+  - [ ] UI Design Loop (if UI changes: yes) — Mockup gist URL: ___
+  - [ ] Plan Review Loop
 - [ ] P4 — Confirm the plan
 - [ ] P5 — Document the plan on the issue
 
@@ -77,16 +81,28 @@ ALWAYS update `.progress/issue-XXXXX.md` during work. Update the progress file *
 - [ ] I6 — Review Response
 ```
 
+If `UI changes: no`, mark the `UI Design Loop` sub-item as `- [x] UI Design Loop — N/A (UI changes: no)` so the progress file reads unambiguously on resume.
+
 #### Planning Phase
 
 P1. **Create a progress file** — Create an `issue-XXXXX.md` file in `.progress`. `XXXXX` is the issue number (5 digits with zero padding, e.g. `issue-00005.md` for issue #5). If the issue does not yet exist, create the GitHub Issue (`gh issue create`) first within this step to obtain the issue number, then create the progress file.
    - → **Done when**: the issue number is known, the progress file exists with the template filled in, and P1 is marked as completed.
-P2. **Create user stories** — Invoke the `user-story-creation` skill to clarify requirements and document them in the standard user story format (as the product owner). Reflect the resulting stories into the issue body.
-   - → **Done when**: user stories are recorded on the issue.
+P2. **Create user stories** — Invoke the `user-story-creation` skill to clarify requirements and document them in the standard user story format (as the product owner). Reflect the resulting stories into the issue body. As part of the same client-alignment round, agree on whether this Issue involves UI changes, and record the decision (`yes` / `no`) in the progress file's P2 sub-item.
+   - → **Done when**: user stories are recorded on the issue AND the progress file's `UI changes:` entry is filled with `yes` or `no` (empty is not allowed).
 P3. **Create a plan** — Review the requirements and design the implementation approach. Use plan mode. Consult the client for any undecided specifications.
+   - **UI Design Loop (mandatory if UI changes: yes)** — runs **before** the Plan Review Loop:
+     - **Invoke `ui-designer`**: start the agent with an instruction to read `docs/design/admin/README.md` and/or `docs/design/user/README.md` that matches the feature's surface. If the feature touches both surfaces, read both and state in the invocation which surface is primary.
+     - **Iterate until approval**: the agent produces an HTML mockup; present it to the client, re-invoke with any feedback, and repeat until the client approves.
+     - **Save & post**: save the approved HTML to a **secret** GitHub Gist (`gh gist create <file>.html --desc "issue-<N> mockup"` — secret by default; do NOT pass `--public`), post the gist URL as a comment on the issue, and record the URL in the progress file.
+     - **If the UI-change decision reverses**:
+       - **no → yes** (UI change surfaces after P2 closed or after initial mockup approval): re-enter the UI Design Loop before finalizing the plan.
+       - **yes → no** (it becomes clear during the loop that no UI change is actually needed): update the progress file P2 entry to `UI changes: no`, mark the P3 UI Design Loop sub-item as `- [x] UI Design Loop — N/A (UI changes: no)`, and proceed to the Plan Review Loop.
    - **Plan Review Loop (mandatory)**: Submit the plan to `plan-reviewer`. Address all actionable findings, then re-submit. Repeat until no actionable findings remain — every revision must be re-reviewed.
    - **Display element semantics**: Before designing badges, labels, icons, or status indicators, agree with the client on what they *semantically represent*. Implementation of display conditions follows from the semantic definition, not the other way around.
-   - → **Done when**: the plan exists in plan mode AND the most recent `plan-reviewer` run produced no actionable findings.
+   - → **Done when** (all apply):
+     - the plan exists in plan mode
+     - if `UI changes: yes` → UI Design Loop complete, mockup approved by the client, gist URL recorded in the progress file and posted on the issue
+     - the most recent `plan-reviewer` run produced no actionable findings
 P4. **Confirm the plan** — Confirm with the client if the plan can be proceeded. If the plan is accepted, exit plan mode.
    - → **Done when**: the client has explicitly approved the plan and plan mode is exited.
 P5. **Document the plan** — Document the plan in the issue as a comment. Include everything exactly as it is stated and approved in the plan file.


### PR DESCRIPTION
## Summary

- Standard Flow P3 に **UI Design Loop** を追加。`ui-designer` agent → HTMLモックアップ → client合意 → secret gist 保存 → Issueコメント URL 投稿までを、Plan Review Loop の**前**に実施するよう規定。
- P2 の Done 条件に「このIssueが UI 変更を伴うかを client と合意 (`yes`/`no`) し progress file に記録」を追加。
- Progress File Template を更新: P2/P3 サブ項目をチェックボックス化、`UI changes: no` 時の N/A マーク規約を明示。
- Prerequisites に `ui-designer` agent（user-global, 非 bundled）を追加。
- Lightweight Flow は対象外（一切変更なし）。

Resolves #330.

## Test plan

- [x] `git diff docs/process/WORKFLOW.md` で差分が plan と一致
- [x] Markdown 表示崩れなし（checkbox 階層、code fence、太字）
- [x] 既存 Planning/Implementation フロー記述と矛盾しないか確認（P4/P5 は未変更）
- [x] Lightweight Flow セクションが無改変であること
- [x] `rubocop` / TypeScript typecheck pre-push hook pass

## Out of Scope

- `ui-designer` agent 自体の改修
- Figma 連携 / `docs/design/` 自動更新
- モックアップバージョン管理方針（gist 履歴に委ねる）
- Lightweight Flow への適用

## Dogfood

- 本 PR 自身は workflow doc のみの編集のため `UI changes: no` 扱い。`.progress/issue-00330.md` に記録済み（gitignore対象）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)