### PR TITLE
docs(reference): consolidate Playwright/Vite/Rails testing pitfalls

### DIFF
--- a/docs/reference/PLAYWRIGHT_PITFALLS.md
+++ b/docs/reference/PLAYWRIGHT_PITFALLS.md
@@ -1,0 +1,53 @@
+# Playwright pitfalls — headless Chrome / webServer env / strict mode
+
+Collected pitfalls from Issues #328/#333 Playwright work. Check before writing a new E2E spec, editing `playwright.config.ts`, or debugging "passes in CI but fails locally" failures.
+
+## 1. Chrome's "weak password" warning blocks headless form submit
+
+Headless Chrome runs the built-in password manager. A `<input type="password">` submit with a weak password (`"password"`, `"password123"`, anything failing Chrome's complexity heuristic) triggers a warning popup that blocks the test flow. The failure surfaces as a timeout on the submit interaction or a missing element — **not** as a clean assertion failure.
+
+### Rules
+
+- Use a single strong `TEST_PASSWORD` across every layer that touches auth fixtures: `test/test_helper.rb` (`TEST_PASSWORD = "HoboTest!Str0ng#2024"`), `test/fixtures/users.yml` (bcrypt of the same string), `db/seeds.rb` when `Rails.env.local?`, and any hardcoded password in `tests/**.spec.ts`. Miss a layer → regression.
+- Minimum complexity: 12+ chars, mixed case, digits, at least one symbol. `HoboTest!Str0ng#2024` is the known-good value in this repo.
+- Symptom-first check: if a form-submit step times out with no visible error, look at the Playwright screenshot/video for a Chrome password-manager overlay **before** chasing selectors, CSS, or backend logs.
+
+## 2. `webServer.env` only applies when Playwright spawns the server
+
+`playwright.config.ts`'s `webServer: { command, env, reuseExistingServer }` has a subtle interaction: `env: { RAILS_ENV: 'test' }` is passed only when Playwright **launches** the command. When `reuseExistingServer: true` (common, often gated on `!process.env.CI`) and a dev server is already listening on the target port, Playwright skips launch and silently ignores the `env` block. The server runs under the dev env; the tests think they're talking to test env. DB selection diverges; every 200 looks healthy.
+
+### Rules
+
+- **Give Playwright its own port distinct from the dev server** (dev 3000, E2E 3100 in this repo). Any existing server on the E2E port is almost certainly a stale E2E server, not a live dev process — `reuseExistingServer: true` stays safe.
+- If you insist on a shared port, set `reuseExistingServer: false` unconditionally. Plan for the conflict with concurrent dev work.
+- When debugging "CI passes, local fails on same commit", diff the env the web server **actually saw** against the config — not what the config declares.
+
+## 3. `getByRole('link', { name: 'X' })` silently breaks on strict mode when a UI change introduces duplicates
+
+Playwright strict mode (the default) fails assertions that match more than one element with `locator resolved to N elements`. Consolidations ("Detail page + Models table → single Workspace page") routinely introduce duplicate accessible names: one page-level `Edit` link plus N per-row `Edit` links. The failure is invisible at plan time — it only surfaces when the spec runs against the built UI.
+
+### Rules
+
+- When a UI change consolidates elements onto a single page, grep the E2E specs for role+name selectors that matched exactly one element before but could match N afterwards. Catch at plan time.
+- Prefer **scoped locators** (`sectionLocator.getByRole('link', { name: 'Edit' })`) over adding `data-testid`. Scoping keeps accessibility semantics intact.
+- Reach for `data-testid` when the scope has no natural accessible landmark (a bare `<div>` card). Name it semantically — `data-testid="workspace-provider-edit"` explains intent; `data-testid="edit-link-1"` does not.
+- In plans for consolidation PRs, list the E2E spec paths + the exact assertions that will need re-targeting. Plan-reviewer can verify the before/after without running the suite.
+
+## 4. Playwright locally uses dev DB; CI uses test DB — drift silently breaks local E2E
+
+`playwright.config.ts` declares `webServer: { command: 'bin/rails server', ... }` without an env override. Locally this starts a development-env Rails server backed by `storage/development.sqlite3`. CI sets `env.RAILS_ENV: test` at the workflow level, so CI always runs against a fresh `db:schema:load` + `db:seed` on `storage/test.sqlite3`. Local dev DB drifts over time (manual password edits, fixture tweaks, test runner side effects) and silently breaks E2E login while CI stays green.
+
+Common amplifier: `find_or_create_by!` in `db/seeds.rb` is create-only (see `RAILS_TESTING_PITFALLS.md` §2). Re-running seed against a drifted dev DB does **not** reset fields on existing rows, so "just reseed" looks like it worked without actually fixing the drift.
+
+### Rules
+
+- Debug order for "CI passes, local fails on same commit":
+  1. `gh run list --limit 5 --workflow="E2E Test"` — confirm CI is actually green on this SHA.
+  2. Diff CI env against local env: `RAILS_ENV`, DB path, `Rack::Attack` throttles, seeds.
+  3. Verify auth directly before blaming middleware: `bin/rails runner 'puts User.authenticate_by(email:, password:)'`.
+- Before modifying env / config to "reproduce CI locally", fix the dev-DB drift first (`User#update!(password: TEST_PASSWORD)`). The drift is usually the real issue; env mismatch is a secondary cause.
+- Log hypotheses you ruled out in the progress file or PR comment so reviewers see the investigation path, not just the conclusion.
+
+## 5. `vite_ruby` cross-env dev-server contamination
+
+Related pitfall covered in `VITE_TESTING_PITFALLS.md` §2 — when test-env `config/vite.json` omits `port`, vite_ruby falls back to the dev default (3036) and a running dev Vite dev server hijacks test-env asset URLs. React SPA boots to an empty `<div id="admin-root"></div>` in test env while the backend responds 200. Separate port per env is the fix.

--- a/docs/reference/RAILS_TESTING_PITFALLS.md
+++ b/docs/reference/RAILS_TESTING_PITFALLS.md
@@ -1,0 +1,56 @@
+# Rails testing pitfalls — seeds / i18n / CodeQL
+
+Collected pitfalls from Issue #333 Rails-seed + test-suite work. Check before editing `db/seeds.rb`, debugging a "translation missing" against a key that grep shows on disk, or dismissing a CodeQL alert flagged on seed passwords.
+
+## 1. CodeQL `rb/clear-text-storage-sensitive-data` on seed passwords — standard false positive
+
+CodeQL flags seed lines like `admin_user.update!(password: seed_password)` with the "stores sensitive data as clear text" advisory when the password flows through a named local variable. **Inline literals** (`user.password = "password"`) sometimes skip the alert; refactoring to a DRY named variable tips the dataflow tracker. The security posture is identical — `has_secure_password` still stores bcrypt in the DB — but the ruleset is more sensitive to variable-based flows.
+
+### Rules
+
+- When introducing a named constant or local variable for a test/dev password (even for pure DRY reasons), expect fresh CodeQL alerts even if the literal existed before. Budget a dismissal pass in the same PR.
+- Dismiss reason: **`"used in tests"`** — the block is scoped to `if Rails.env.local?` and production uses `ENV.fetch("MASTER_USER_PASSWORD")` (separate branch). `"false positive"` is misleading (the dataflow is real). `"won't fix"` implies unacceptable risk.
+- In the dismissal comment, document the env-scope guarantee, the production alternative, and the actual DB encoding (bcrypt). Future maintainers revisiting the dismissal need that context without re-reading the code.
+- Alerts are line-anchored. Adding a comment above a flagged line creates new alert numbers and closes old ones — do not be surprised by the churn after a reformat.
+- `gh api` dismissal has a 280-char comment limit and requires one of the enum `reason` values — see `gh api repos/:owner/:repo/code-scanning/alerts/:number -X PATCH -f state=dismissed -f dismissed_reason="used in tests" -f dismissed_comment="..."`.
+
+## 2. `find_or_create_by!` block is the single most common non-idempotent seed
+
+`db/seeds.rb` in this repo opens with "The code here should be idempotent so that it can be executed at any point in every environment." Every user creation then used:
+
+```ruby
+User.find_or_create_by!(email: "admin@example.com") do |user|
+  user.password = "password"
+  user.name = "Admin User"
+end
+```
+
+The block **only runs on create**. If the user already exists with a drifted password (manual edit, test side effect, failed previous run), re-running `db:seed` does nothing — the password stays drifted. The file's own documented contract is violated silently. Downstream effect: E2E login breaks in local dev (see `PLAYWRIGHT_PITFALLS.md` §4) while CI stays green because CI seeds a fresh DB every run.
+
+### Rules
+
+- For any field that must be in a **known state** (not just any-value), follow `find_or_create_by!` with an explicit `.update!` pass:
+
+  ```ruby
+  admin = User.find_or_create_by!(email: "admin@example.com") do |user|
+    user.password = SEED_PASSWORD
+    user.name = "Admin User"
+  end
+  admin.update!(password: SEED_PASSWORD, name: "Admin User")
+  ```
+
+- Alternative idiom for readers who don't know the block-on-create trap: `find_or_initialize_by` + explicit setters + `save!`. Makes the "every run sets these" intent obvious.
+- When a `seeds.rb` claims idempotency, verify by re-running against a **drifted** DB, not a clean one. A clean-DB seed run proves creation works; it tells you nothing about idempotency.
+- When debugging login failures in seeded envs, check `User.authenticate_by(email:, password:)` against the DB **before** assuming the auth layer (Rack::Attack throttle, session store, middleware) is broken.
+
+## 3. Rails i18n YAML is cached at test-process boot
+
+`bin/rails test` loads `config/locales/*.yml` once at process startup. `config.cache_classes = true` in test env means there is no reload trigger for locale files either. Keys added **during** a long-running test run are invisible until the process restarts — `t("new.key")` dies with `Translation missing: new.key` while `grep -n` shows the key clearly on disk.
+
+The failure mode is identical to "key truly missing" — easy to waste time hunting for syntax errors or namespace mistakes when the real cause is timing.
+
+### Rules
+
+- Add i18n keys **before** starting a long-running test run. If a key is added during a background run, accept that the current run is contaminated and plan for a fresh-process rerun.
+- When a test reports `Translation missing:` but `grep -n` shows the key on disk, first hypothesis: "was this YAML edited after the test process booted?" Check the file mtime against the test-start timestamp before editing anything else.
+- A fresh `bin/rails test:<domain>` rerun is the cheapest confirmation. Pass → timing artifact. Fail → real bug.

--- a/docs/reference/SYSTEM_TEST_GOTCHAS.md
+++ b/docs/reference/SYSTEM_TEST_GOTCHAS.md
@@ -60,4 +60,23 @@ Two close events with different semantics:
   ```
 - When adding a new `<dialog>` with cleanup logic, **prefer the `close` event** unless you actually need cancelable behavior. Close fires on both Escape and `.close()`.
 
-_Source findings: `capybara-execute-script-iife-arguments-quirk`, `testing-stimulus-keyboard-shortcuts-via-dispatchevent`, `html-dialog-cancel-vs-close-event-semantics` (all Apr 11, 2026, Issue #14)._
+## 4. SQLite `remove_column` + `maintain_test_schema!` can leave the dev test DB in a transient FK-corrupt state
+
+SQLite implements `remove_column` as a table-copy. `bin/rails test` runs `ActiveRecord::Base.maintain_test_schema!` on boot and mirrors schema changes from development into the test DB. When the mirror happens against a pre-existing test DB that has rows, the cascade can leave an unrelated FK relationship in a transient-broken state — a later `DELETE` hits `SQLite3::ConstraintException: FOREIGN KEY constraint failed` on a test whose code path never touches the removed column.
+
+Reproduction matrix for Issue #338 (`remove_column :llm_models, :default_model`):
+
+| Scenario | Result |
+|---|---|
+| `bin/rails test test/controllers/api/v1/admin/tasks_controller_test.rb` on the feature branch | FAIL with `InvalidForeignKey` on an unrelated `#destroy` test |
+| Same test on `main` | PASS |
+| Same test on feature branch after `bin/rails db:drop db:create db:migrate` | PASS |
+| The full suite on feature branch after the reset | PASS (908 runs, 0 failures) |
+
+CI is unaffected — CI provisions a fresh test DB per run, so the corrupt transient state never persists. Only developer-local environments that carry test-DB state across migration events see this.
+
+### Rules
+
+- When a migration that includes `remove_column` lands on a branch, after `db:migrate` **drop and recreate the local test DB** before running the suite: `bin/rails db:drop RAILS_ENV=test && bin/rails db:create db:migrate RAILS_ENV=test` (or the equivalent `db:test:prepare`). Do not rely on `maintain_test_schema!` alone on SQLite.
+- If a test suddenly fails with `InvalidForeignKey` on a `DELETE` whose code path does not touch the recently-removed column, the first hypothesis is the maintain-schema transient corruption — **not** a real FK bug. Reset the test DB first and re-run before debugging the test code.
+- If you can reproduce the failure on a single-test invocation but not after `db:drop`, document the matrix (branch vs main, before vs after reset) in the progress file. That matrix is the fastest way to convince a future reader the "failure" was a schema-sync artifact, not a regression.

--- a/docs/reference/VITE_TESTING_PITFALLS.md
+++ b/docs/reference/VITE_TESTING_PITFALLS.md
@@ -1,0 +1,44 @@
+# Vite / Vitest / vite_ruby pitfalls
+
+Collected pitfalls from Issues #292/#333 frontend-testing work. Check before adding the first `import.meta.env` reference to this codebase, configuring a new env in `config/vite.json`, or debugging a Vitest mock call-count that drifts over successive runs.
+
+## 1. `import.meta.env` needs `vite/client` type reference
+
+Accessing `import.meta.env.MODE` / `import.meta.env.PROD` from TypeScript compiles at runtime under Vite but fails `tsc --noEmit` with `Property 'env' does not exist on type 'ImportMeta'` unless the Vite client types are referenced. vite_ruby ships without this reference because boot-time configuration usually avoids `import.meta.env` — the first file to use it is the first moment the gap surfaces.
+
+### Rules
+
+- When introducing the first `import.meta.env.*` access in a Vite + TS codebase, create `app/javascript/<entry>/vite-env.d.ts` containing exactly:
+  ```ts
+  /// <reference types="vite/client" />
+  ```
+  with a single trailing `\n`. This repo's ESLint `no-multiple-empty-lines { maxEOF: 0 }` rejects an extra blank line — one newline only.
+- Prefer the scoped `vite-env.d.ts` over adding `compilerOptions.types: ["vite/client"]` to `tsconfig.json` — scoped reference keeps the project-wide type surface minimal.
+- Always run `npx tsc --noEmit` after adding any `import.meta.env` code. Runtime success is not sufficient proof the types resolve.
+
+## 2. vite_ruby cross-env dev-server contamination
+
+`config/vite.json` for a test env with `autoBuild: true` but no `port` falls back to the dev default (3036). If a dev Rails server is running with its own Vite dev server bound to 3036, a test-env Rails server on port 3100 will still detect the dev Vite dev server as its own and emit HMR script tags (`/vite-test/@vite/client`) into the HTML. Those URLs 404 because the dev Vite dev server doesn't know the test build. Symptom: **React SPA silently fails to boot in test env** — the backend returns 200 with HTML, but `<div id="admin-root"></div>` renders empty.
+
+### Rules
+
+- Every env in `config/vite.json` that can run concurrently with `development` **must declare its own port**. Current allocation: dev 3036, test 3037. Do not omit `port` in any env block.
+- Symptom triage: if a React/Vue/etc. SPA page renders blank in a test env and the backend responds 200, inspect the HTML for HMR dev-mode URLs (`/vite-*/@vite/client`) versus production-style asset URLs. Dev-mode tags in test env = vite_ruby routed through the wrong dev server.
+- Confirm with `curl http://localhost:<test-port>/<asset-path>` — a 404 on the HMR client script is the cross-contamination signature.
+- Related: Playwright `webServer.env` is silently ignored when `reuseExistingServer: true` picks up a dev server on the same port. See `PLAYWRIGHT_PITFALLS.md` §2.
+
+## 3. Vitest `vi.mock()` factory `vi.fn()` instances persist across `vi.resetModules()`
+
+A test file that does:
+```ts
+vi.mock('some-module', () => ({ someFn: vi.fn() }))
+```
+caches the `vi.fn()` instance inside the mock registry. `vi.resetModules()` clears the module cache but **does not** recreate the factory's outputs — re-importing after `vi.resetModules()` returns the same `vi.fn()` instance, with call history from prior tests intact. `vi.restoreAllMocks()` doesn't help either: `restoreAllMocks` restores `vi.spyOn`-created spies, not `vi.fn()` mocks inside a `vi.mock` factory.
+
+Symptom: a test asserts `expect(mockFn).not.toHaveBeenCalled()` and fails with "called N times" where N accumulates across earlier tests in the same describe block.
+
+### Rules
+
+- Pair every `vi.mock(...)` factory that constructs `vi.fn()` with `beforeEach(() => vi.clearAllMocks())`. `clearAllMocks` resets call history on all `vi.fn()` instances, including factory-created ones.
+- If tests need fresh module-level state inside the mocked module, order matters: `vi.resetModules()` first, then `vi.clearAllMocks()` inside `beforeEach`, then `await import(...)` for a dynamic re-import.
+- Suspect this pitfall when an assertion count drifts upward as the test file grows (`expected 1 call, got 4` where 4 is roughly the number of test cases run so far).


### PR DESCRIPTION
## Summary
- Retrospective consolidation of testing pitfalls encountered during recent work (#292, #328, #333, #338).
- Splits by stack: 3 new reference docs (`PLAYWRIGHT_PITFALLS.md`, `VITE_TESTING_PITFALLS.md`, `RAILS_TESTING_PITFALLS.md`) + 1 new section on `SYSTEM_TEST_GOTCHAS.md`.
- No code changes — documentation-only PR intended as a drop-in lookup when the same pitfalls re-surface.

## What's inside

| File | Scope |
|---|---|
| `docs/reference/PLAYWRIGHT_PITFALLS.md` (new) | Chrome weak-password warning blocking headless submit, `webServer.env` silently ignored under `reuseExistingServer:true`, strict-mode duplicate accessible names on consolidated pages, local-dev-DB vs CI-test-DB drift |
| `docs/reference/VITE_TESTING_PITFALLS.md` (new) | `import.meta.env` needs `vite/client` type reference, vite_ruby cross-env dev-server contamination when `port` is omitted, `vi.mock()` `vi.fn()` persistence across `vi.resetModules()` |
| `docs/reference/RAILS_TESTING_PITFALLS.md` (new) | CodeQL `clear-text-storage` false positive on seed passwords with dismissal comment template, `find_or_create_by!` block-on-create idempotency trap, i18n YAML cached at test-process boot |
| `docs/reference/SYSTEM_TEST_GOTCHAS.md` §4 (amplify) | SQLite `remove_column` + `maintain_test_schema!` transient FK-corrupt state; Issue #338 repro matrix |

## Test plan
- [ ] `docs/reference/` links render correctly on GitHub
- [ ] Each pitfall's "Rules" section is actionable (verb-led, no vague guidance)
- [ ] Cross-links resolve (`PLAYWRIGHT_PITFALLS §2 ↔ VITE_TESTING_PITFALLS §2`, `PLAYWRIGHT_PITFALLS §4 → RAILS_TESTING_PITFALLS §2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)