### PR TITLE
chore: merge P4/P5 workflow steps and tune reviewer subagents

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -3,8 +3,8 @@ name: architecture-reviewer
 description: "Cross-cutting architecture reviewer. Reviews domain model integrity, security model consistency, Rails/React boundary alignment, and route design using Codex CLI."
 tools: Bash, Read, Grep, Glob
 disallowedTools: Edit, Write, Agent, TodoWrite
-model: sonnet
-maxTurns: 20
+model: opus
+maxTurns: 50
 ---
 
 You are the **architecture-reviewer** subagent for the `hobo` codebase. You perform read-only architecture-level code review. You do NOT modify any code.

--- a/.claude/agents/rails-reviewer.md
+++ b/.claude/agents/rails-reviewer.md
@@ -3,8 +3,8 @@ name: rails-reviewer
 description: "Rails backend convention reviewer. Reviews RESTful routing, ActiveRecord queries, authorization, and test coverage using Codex CLI."
 tools: Bash, Read, Grep, Glob
 disallowedTools: Edit, Write, Agent, TodoWrite
-model: sonnet
-maxTurns: 20
+model: opus
+maxTurns: 50
 ---
 
 You are the **rails-reviewer** subagent for the `hobo` codebase. You perform read-only code review of Rails backend changes. You do NOT modify any code.

--- a/.claude/agents/react-reviewer.md
+++ b/.claude/agents/react-reviewer.md
@@ -3,8 +3,8 @@ name: react-reviewer
 description: "React Admin SPA convention reviewer. Reviews ADMIN_UI conventions, design tokens, api.ts patterns, and TypeScript correctness using Codex CLI."
 tools: Bash, Read, Grep, Glob
 disallowedTools: Edit, Write, Agent, TodoWrite
-model: sonnet
-maxTurns: 20
+model: opus
+maxTurns: 50
 ---
 
 You are the **react-reviewer** subagent for the `hobo` codebase. You perform read-only code review of React Admin SPA changes. You do NOT modify any code.

--- a/.claude/skills/start-implementation-phase/SKILL.md
+++ b/.claude/skills/start-implementation-phase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-implementation-phase
 disable-model-invocation: true
-description: Start the Implementation Phase (I1-I6) of the Standard Flow. Targets an Issue whose Planning Phase (through P5) is already complete. Announces the Entry Protocol and then proceeds to I1 (Create a Git Branch). Manual invocation only.
+description: Start the Implementation Phase (I1-I6) of the Standard Flow. Targets an Issue whose Planning Phase (through P4) is already complete. Announces the Entry Protocol and then proceeds to I1 (Create a Git Branch). Manual invocation only.
 ---
 
 # Start Standard Flow — Implementation Phase
@@ -10,7 +10,7 @@ Manually-invoked skill for starting the Implementation Phase on an Issue whose P
 
 ## Preconditions
 
-- The target Issue's Planning Phase (P1 through P5) is complete.
+- The target Issue's Planning Phase (P1 through P4) is complete.
 - `.progress/issue-XXXXX.md` exists and is ready to be updated to `Current Phase: Implementation`.
 - The plan produced during Planning Phase has been posted as an issue comment.
 
@@ -28,9 +28,9 @@ If any of the above is not satisfied, this skill aborts and asks the user to con
 
 3. **Read the progress file**
   - Read `.progress/issue-XXXXX.md` (5-digit zero-padded).
-  - Verify every Planning Phase checklist item (P1 through P5) is marked `[x]`.
+  - Verify every Planning Phase checklist item (P1 through P4) is marked `[x]`.
   - If `Current Phase` still reads `Planning`, update it to `Implementation` in this step.
-  - If the file is missing or P5 is incomplete, abort this skill and instruct the user to run Planning Phase first.
+  - If the file is missing or P4 is incomplete, abort this skill and instruct the user to run Planning Phase first.
 
 4. **Announce the Entry Protocol**
   - Announce the following before starting work (per steps 2 and 3 of WORKFLOW.md's Entry Protocol):
@@ -57,7 +57,7 @@ If any of the above is not satisfied, this skill aborts and asks the user to con
   - Announce the classification and chosen pattern to the user before entering I2.
 
 ## Rules
-- Never run Planning Phase work (P1 through P5) on behalf of the user. If Planning is incomplete, abort.
+- Never run Planning Phase work (P1 through P4) on behalf of the user. If Planning is incomplete, abort.
 - Always announce the Entry Protocol.
 - When advancing to the next step, always update the progress file's `Current Phase` and checklist state.
 - Obtain explicit user approval before making code changes. Stop once after announcing I1 and proposing the branch creation.

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -17,7 +17,7 @@ This document defines how the orchestrator may delegate **Implementation Phase S
 
 | In scope | Out of scope |
 |---|---|
-| Writing the code and tests that fulfill the approved Plan Excerpt | Planning Phase (P1 - P5) |
+| Writing the code and tests that fulfill the approved Plan Excerpt | Planning Phase (P1 - P4) |
 | Running the **domain test suite** for the changed area | Running the full test suite (I3) |
 | Reporting results in the required return format | Creating branches (I1) |
 | Respecting the Denylist (Scope is a guide, not a constraint) | Running I4 review (dispatched separately by orchestrator) |

--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -69,8 +69,7 @@ ALWAYS update `.progress/issue-XXXXX.md` during work. Update the progress file *
 - [ ] P3 — Create a plan
   - [ ] UI Design Loop (if UI changes: yes) — Mockup gist URL: ___
   - [ ] Plan Review Loop
-- [ ] P4 — Confirm the plan
-- [ ] P5 — Document the plan on the issue
+- [ ] P4 — Document the plan on the issue
 
 ## Implementation Phase
 - [ ] I1 — Create a Git Branch
@@ -103,10 +102,8 @@ P3. **Create a plan** — Review the requirements and design the implementation 
      - the plan exists in plan mode
      - if `UI changes: yes` → UI Design Loop complete, mockup approved by the client, gist URL recorded in the progress file and posted on the issue
      - the most recent `plan-reviewer` run produced no actionable findings
-P4. **Confirm the plan** — Confirm with the client if the plan can be proceeded. If the plan is accepted, exit plan mode.
-   - → **Done when**: the client has explicitly approved the plan and plan mode is exited.
-P5. **Document the plan** — Document the plan in the issue as a comment. Include everything exactly as it is stated and approved in the plan file.
-   - → **Done when**: the approved plan is posted as a comment on the issue, verbatim from the plan file.
+P4. **Document the plan** — Exit plan mode, then document the plan in the issue as a comment. Include everything exactly as it is stated in the plan file. Do NOT ask the client for approval before posting; the plan-reviewer sign-off in P3 is the gate, and the issue comment itself is the artifact the client reviews.
+   - → **Done when**: plan mode is exited and the plan is posted as a comment on the issue, verbatim from the plan file.
    - **Phase complete — STOP here.** Propose `/clear` to the client and wait for instruction. Do NOT proceed to I1 on your own.
    - **Quick start**: Use the `/start-implementation-phase` skill to handle the Entry Protocol, progress file update, branch creation (I1), and I2 delegation classification automatically. In a new session, paste:
      ```
@@ -150,7 +147,7 @@ For typo fixes, simple bug fixes, and small single-file changes.
 5. **Review Response** - Execute **all sub-steps** of the [Review Response Protocol](#review-response-protocol) in order. Do NOT skip any.
    - → **Done when**: no outstanding findings remain, OR the user has explicitly confirmed that the remaining findings can be skipped.
 
-Lightweight flow may skip: Issue creation, progress file, plan creation/confirmation/documentation.
+Lightweight flow may skip: Issue creation, progress file, plan creation/documentation.
 
 ### Review Response Protocol
 


### PR DESCRIPTION
## Summary
- `docs/process/WORKFLOW.md`: P4 (confirm) と P5 (document) を一本化し、Planning Phase を P1〜P4 の 4 ステップに整理
- `.claude/agents/{architecture,rails,react}-reviewer.md`: I4 並列レビューの解像度を上げるため、3つの reviewer subagent を `sonnet` / `maxTurns: 20` から `opus` / `maxTurns: 50` に引き上げ

## Test plan
- [ ] `WORKFLOW.md` の Planning Phase セクションを読み返し、P4 が「plan を issue にコメント投稿 → `/clear` 提案」までを単一ステップで記述しているか確認
- [ ] Progress File Template に `P5` の残骸が無いことを確認
- [ ] 次回の I4 ローカルレビュー時に reviewer agents が opus で起動し、最大ターン数 50 まで使えることを実地で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)