### PR TITLE
feat(account): ユーザー削除を「退会済み」ステータスに変更する (#272)

### DIFF
--- a/app/assets/stylesheets/auth.css
+++ b/app/assets/stylesheets/auth.css
@@ -4,8 +4,15 @@
   padding: 15px;
   border-radius: var(--radius-md);
 }
-.auth-form input {
+.auth-form input:not([type="checkbox"]):not([type="radio"]) {
   box-sizing: border-box;
   margin-bottom: 15px;
   width: 100%;
 }
+
+.auth-form__field--inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -45,3 +45,35 @@
 .avatar-upload input[type="file"] {
   display: none;
 }
+
+.show-user__danger-zone {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space-8);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-surface-active);
+}
+
+.show-user__deactivate-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+.show-user__deactivate-link:hover,
+.show-user__deactivate-link:focus-visible {
+  color: var(--color-error);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  background: transparent;
+}
+.show-user__deactivate-link .material-symbols-outlined {
+  font-size: var(--text-base);
+}

--- a/app/controllers/account/deactivations_controller.rb
+++ b/app/controllers/account/deactivations_controller.rb
@@ -1,0 +1,14 @@
+module Account
+  # Pre-Fork stub. Phase 1B replaces with the real self-deactivation flow
+  # (password_challenge form + reason textarea, transactional deactivation,
+  # reset_session, redirect to login).
+  class DeactivationsController < ApplicationController
+    def new
+      head :not_implemented
+    end
+
+    def create
+      head :not_implemented
+    end
+  end
+end

--- a/app/controllers/account/deactivations_controller.rb
+++ b/app/controllers/account/deactivations_controller.rb
@@ -9,25 +9,43 @@ module Account
     def create
       @user = current_user
       @user.assign_attributes(deactivation_params)
+      return render :new, status: :unprocessable_content unless confirmation_valid?
+      return render :new, status: :unprocessable_content unless @user.save
+      return render :new, status: :unprocessable_content unless run_deactivation
 
-      if @user.save
-        Account::DeactivationService.call(
-          user: @user,
-          performer: @user,
-          reason: @user.reason,
-          self_deactivated: true,
-        )
-        reset_session
-        redirect_to login_path, notice: I18n.t("controllers.account/deactivations.create.success")
-      else
-        render :new, status: :unprocessable_content
-      end
+      reset_session
+      redirect_to login_path, notice: I18n.t("controllers.account/deactivations.create.success")
     end
 
     private
 
       def deactivation_params
         params.expect(user: %i[reason password_challenge])
+      end
+
+      def confirmation_valid?
+        return true if params[:confirm_deactivation].present?
+
+        @user.errors.add(:base, I18n.t("controllers.account/deactivations.create.confirmation_required"))
+        false
+      end
+
+      # Wraps `DeactivationService.call` so race conditions (double-submit, concurrent
+      # admin deactivate) surface as a recoverable form error instead of a 500.
+      # `RecordNotUnique` fires when the `deactivated_users.user_id` UNIQUE index is
+      # already populated for this user; `RecordInvalid` covers any future model-level
+      # validation that the service may add.
+      def run_deactivation
+        Account::DeactivationService.call(
+          user: @user,
+          performer: @user,
+          reason: @user.reason,
+          self_deactivated: true,
+        )
+        true
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+        @user.errors.add(:base, I18n.t("controllers.account/deactivations.create.failure"))
+        false
       end
 
       # Admin-capable users must NOT self-deactivate via the user-side flow:

--- a/app/controllers/account/deactivations_controller.rb
+++ b/app/controllers/account/deactivations_controller.rb
@@ -1,5 +1,7 @@
 module Account
   class DeactivationsController < ApplicationController
+    before_action :reject_admin_capable_user
+
     def new
       @user = current_user
     end
@@ -26,6 +28,18 @@ module Account
 
       def deactivation_params
         params.expect(user: %i[reason password_challenge])
+      end
+
+      # Admin-capable users must NOT self-deactivate via the user-side flow:
+      # the last admin doing so would lock the admin panel out of recovery
+      # (no remaining User:write capability to reactivate them via Admin API).
+      # Plan §13 stipulates "Admin 自己 Deactivate: ブロック". The Admin API side
+      # is naturally guarded by `User.non_admin_accounts`; this is the user-side guard.
+      def reject_admin_capable_user
+        return unless current_user&.can_read?("Admin")
+
+        redirect_to user_path,
+                    alert: I18n.t("controllers.account/deactivations.admin_blocked")
       end
   end
 end

--- a/app/controllers/account/deactivations_controller.rb
+++ b/app/controllers/account/deactivations_controller.rb
@@ -9,6 +9,7 @@ module Account
     def create
       @user = current_user
       @user.assign_attributes(deactivation_params)
+      return render :new, status: :unprocessable_content unless password_challenge_present?
       return render :new, status: :unprocessable_content unless confirmation_valid?
       return render :new, status: :unprocessable_content unless @user.save
       return render :new, status: :unprocessable_content unless run_deactivation
@@ -27,6 +28,18 @@ module Account
         return true if params[:confirm_deactivation].present?
 
         @user.errors.add(:base, I18n.t("controllers.account/deactivations.create.confirmation_required"))
+        false
+      end
+
+      # `params.expect(user: %i[... password_challenge])` only permits the inner
+      # key, it does not require it. When `password_challenge` is absent from the
+      # POST body, `assign_attributes` never sets the virtual attribute, and
+      # `has_secure_password` skips the validation entirely — so `@user.save`
+      # would succeed silently and deactivate the account without auth.
+      def password_challenge_present?
+        return true if params.dig(:user, :password_challenge).present?
+
+        @user.errors.add(:password_challenge, :blank)
         false
       end
 

--- a/app/controllers/account/deactivations_controller.rb
+++ b/app/controllers/account/deactivations_controller.rb
@@ -6,10 +6,7 @@ module Account
 
     def create
       @user = current_user
-      @user.assign_attributes(
-        reason: params[:user][:reason],
-        password_challenge: params[:user][:password_challenge],
-      )
+      @user.assign_attributes(deactivation_params)
 
       if @user.save
         Account::DeactivationService.call(
@@ -24,5 +21,11 @@ module Account
         render :new, status: :unprocessable_content
       end
     end
+
+    private
+
+      def deactivation_params
+        params.expect(user: %i[reason password_challenge])
+      end
   end
 end

--- a/app/controllers/account/deactivations_controller.rb
+++ b/app/controllers/account/deactivations_controller.rb
@@ -1,14 +1,28 @@
 module Account
-  # Pre-Fork stub. Phase 1B replaces with the real self-deactivation flow
-  # (password_challenge form + reason textarea, transactional deactivation,
-  # reset_session, redirect to login).
   class DeactivationsController < ApplicationController
     def new
-      head :not_implemented
+      @user = current_user
     end
 
     def create
-      head :not_implemented
+      @user = current_user
+      @user.assign_attributes(
+        reason: params[:user][:reason],
+        password_challenge: params[:user][:password_challenge],
+      )
+
+      if @user.save
+        Account::DeactivationService.call(
+          user: @user,
+          performer: @user,
+          reason: @user.reason,
+          self_deactivated: true,
+        )
+        reset_session
+        redirect_to login_path, notice: I18n.t("controllers.account/deactivations.create.success")
+      else
+        render :new, status: :unprocessable_content
+      end
     end
   end
 end

--- a/app/controllers/api/v1/admin/application_controller.rb
+++ b/app/controllers/api/v1/admin/application_controller.rb
@@ -8,11 +8,19 @@ module Api
 
         skip_before_action :require_login
         before_action :require_admin_access
+        before_action :enforce_active_admin, if: :admin_logged_in?
 
         private
 
           def handle_unverified_request
             render json: { error: "CSRF token invalid" }, status: :unprocessable_entity
+          end
+
+          def enforce_active_admin
+            return unless current_admin&.deactivated?
+
+            reset_session
+            render json: { error: "Unauthorized" }, status: :unauthorized
           end
 
           def require_admin_access

--- a/app/controllers/api/v1/admin/sessions_controller.rb
+++ b/app/controllers/api/v1/admin/sessions_controller.rb
@@ -60,7 +60,7 @@ module Api
           end
 
           def authenticate_admin_user
-            user = User.authenticate_by(email: params[:email], password: params[:password])
+            user = User.active.authenticate_by(email: params[:email], password: params[:password])
             return user if user&.can_read?("Admin")
 
             render json: { error: "Invalid email or password" }, status: :unauthorized

--- a/app/controllers/api/v1/admin/users/deactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/deactivations_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    module Admin
+      module Users
+        # Pre-Fork stub. Phase 1A overwrites with the real implementation.
+        # API contract:
+        #   POST /api/v1/admin/users/:user_id/deactivation
+        #   Request body: { reason?: string (max 500) }
+        #   Responses:
+        #     - 204 No Content on success
+        #     - 401 / 403 on auth failure (Admin "User" write capability required)
+        #     - 404 when target user is not found within User.non_admin_accounts
+        #     - 422 with { errors: [...] } on validation failure
+        class DeactivationsController < Admin::ApplicationController
+          before_action -> { require_capability!("User", "write") }
+
+          def create
+            render json: { error: "Not Implemented" }, status: :not_implemented
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/users/deactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/deactivations_controller.rb
@@ -2,20 +2,22 @@ module Api
   module V1
     module Admin
       module Users
-        # Pre-Fork stub. Phase 1A overwrites with the real implementation.
-        # API contract:
-        #   POST /api/v1/admin/users/:user_id/deactivation
-        #   Request body: { reason?: string (max 500) }
-        #   Responses:
-        #     - 204 No Content on success
-        #     - 401 / 403 on auth failure (Admin "User" write capability required)
-        #     - 404 when target user is not found within User.non_admin_accounts
-        #     - 422 with { errors: [...] } on validation failure
         class DeactivationsController < Admin::ApplicationController
           before_action -> { require_capability!("User", "write") }
 
           def create
-            render json: { error: "Not Implemented" }, status: :not_implemented
+            target = ::User.non_admin_accounts.find_by(id: params[:user_id])
+            return render json: { error: "Not Found" }, status: :not_found unless target
+
+            Account::DeactivationService.call(
+              user: target,
+              performer: current_admin,
+              reason: params[:reason],
+              self_deactivated: false,
+            )
+            head :no_content
+          rescue ActiveRecord::RecordInvalid => e
+            render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
           end
         end
       end

--- a/app/controllers/api/v1/admin/users/deactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/deactivations_controller.rb
@@ -18,6 +18,12 @@ module Api
             head :no_content
           rescue ActiveRecord::RecordInvalid => e
             render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+          rescue ActiveRecord::RecordNotUnique
+            # Race / double-submit: the user was already deactivated between
+            # `User.non_admin_accounts.active.find_by` and the service call
+            # (e.g., another admin session, or an immediate retry). Respond
+            # with a structured 422 instead of letting it surface as 500.
+            render json: { errors: ["User is already deactivated"] }, status: :unprocessable_entity
           end
         end
       end

--- a/app/controllers/api/v1/admin/users/deactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/deactivations_controller.rb
@@ -6,7 +6,7 @@ module Api
           before_action -> { require_capability!("User", "write") }
 
           def create
-            target = ::User.non_admin_accounts.find_by(id: params[:user_id])
+            target = ::User.non_admin_accounts.active.find_by(id: params[:user_id])
             return render json: { error: "Not Found" }, status: :not_found unless target
 
             Account::DeactivationService.call(

--- a/app/controllers/api/v1/admin/users/reactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/reactivations_controller.rb
@@ -1,0 +1,26 @@
+module Api
+  module V1
+    module Admin
+      module Users
+        # Pre-Fork stub. Phase 1A overwrites with the real implementation.
+        # API contract:
+        #   POST /api/v1/admin/users/:user_id/reactivation
+        #   Request body: { new_email?: string }
+        #   Responses:
+        #     - 204 No Content on success
+        #     - 401 / 403 on auth failure (Admin "User" write capability required)
+        #     - 404 when target user is not found within User.non_admin_accounts
+        #     - 422 on email conflict, body shapes:
+        #         { errors: [...], original_email_conflict: true }   # new_email omitted, original email is taken
+        #         { errors: [...] }                                  # new_email provided but conflicts
+        class ReactivationsController < Admin::ApplicationController
+          before_action -> { require_capability!("User", "write") }
+
+          def create
+            render json: { error: "Not Implemented" }, status: :not_implemented
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/users/reactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/reactivations_controller.rb
@@ -23,7 +23,8 @@ module Api
 
             def reactivation_error_body(error)
               body = { errors: error.record.errors.full_messages }
-              body[:original_email_conflict] = true if params[:new_email].blank?
+              email_conflict = params[:new_email].blank? && error.record.errors[:email].any?
+              body[:original_email_conflict] = true if email_conflict
               body
             end
         end

--- a/app/controllers/api/v1/admin/users/reactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/reactivations_controller.rb
@@ -2,23 +2,30 @@ module Api
   module V1
     module Admin
       module Users
-        # Pre-Fork stub. Phase 1A overwrites with the real implementation.
-        # API contract:
-        #   POST /api/v1/admin/users/:user_id/reactivation
-        #   Request body: { new_email?: string }
-        #   Responses:
-        #     - 204 No Content on success
-        #     - 401 / 403 on auth failure (Admin "User" write capability required)
-        #     - 404 when target user is not found within User.non_admin_accounts
-        #     - 422 on email conflict, body shapes:
-        #         { errors: [...], original_email_conflict: true }   # new_email omitted, original email is taken
-        #         { errors: [...] }                                  # new_email provided but conflicts
         class ReactivationsController < Admin::ApplicationController
           before_action -> { require_capability!("User", "write") }
 
           def create
-            render json: { error: "Not Implemented" }, status: :not_implemented
+            target = ::User.non_admin_accounts.deactivated.find_by(id: params[:user_id])
+            return render json: { error: "Not Found" }, status: :not_found unless target
+
+            Account::DeactivationService.reactivate(
+              user: target,
+              performer: current_admin,
+              new_email: params[:new_email],
+            )
+            head :no_content
+          rescue ActiveRecord::RecordInvalid => e
+            render json: reactivation_error_body(e), status: :unprocessable_entity
           end
+
+          private
+
+            def reactivation_error_body(error)
+              body = { errors: error.record.errors.full_messages }
+              body[:original_email_conflict] = true if params[:new_email].blank?
+              body
+            end
         end
       end
     end

--- a/app/controllers/api/v1/admin/users/reactivations_controller.rb
+++ b/app/controllers/api/v1/admin/users/reactivations_controller.rb
@@ -17,6 +17,11 @@ module Api
             head :no_content
           rescue ActiveRecord::RecordInvalid => e
             render json: reactivation_error_body(e), status: :unprocessable_entity
+          rescue ActiveRecord::RecordNotFound
+            # Race: another admin reactivated this user concurrently between
+            # the `find_by` above and the service's `lock.find_by`. The state
+            # the request was acting on no longer exists.
+            render json: { error: "Not Found" }, status: :not_found
           end
 
           private

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -7,16 +7,16 @@ module Api
         before_action -> { require_capability!("User", "write") }, only: %i[create update]
 
         def index
-          scope = User.non_admin_accounts.search(params[:q]).order(:id)
+          scope = build_users_scope.includes(deactivation: :deactivated_by).order(:id)
           pagy, records = paginate(scope)
           render json: {
-            users: records.as_json(only: %i[id email name created_at updated_at]),
+            users: records.map { |u| user_json(u) },
             meta: pagination_meta(pagy),
           }
         end
 
         def show
-          render json: @user.as_json(only: %i[id email name created_at updated_at])
+          render json: user_json(@user)
         end
 
         def create
@@ -38,8 +38,45 @@ module Api
 
         private
 
+          def build_users_scope
+            base = User.non_admin_accounts
+            case params[:status]
+            when "deactivated" then base.search_deactivated(params[:q])
+            when "all"         then all_users_scope(base)
+            else                    base.active.search(params[:q])
+            end
+          end
+
+          def all_users_scope(base)
+            active_ids = base.active.search(params[:q]).select(:id)
+            deact_ids  = base.search_deactivated(params[:q]).select(:id)
+            base.where(id: active_ids).or(base.where(id: deact_ids))
+          end
+
+          def user_json(user)
+            deactivation = user.deactivation
+            {
+              id: user.id,
+              email: deactivation ? deactivation.original_email : user.email,
+              name: user.name,
+              created_at: user.created_at,
+              updated_at: user.updated_at,
+              original_email: deactivation&.original_email,
+              deactivated_at: deactivation&.deactivated_at&.iso8601,
+              deactivation_reason: deactivation&.reason,
+              deactivated_by: deactivated_by_json(deactivation),
+            }
+          end
+
+          def deactivated_by_json(deactivation)
+            performer = deactivation&.deactivated_by
+            return nil unless performer
+
+            { id: performer.id, name: performer.name }
+          end
+
           def set_user
-            @user = User.non_admin_accounts.find_by(id: params[:id])
+            @user = User.non_admin_accounts.includes(deactivation: :deactivated_by).find_by(id: params[:id])
             render json: { error: "Not found" }, status: :not_found unless @user
           end
 

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -5,6 +5,7 @@ module Api
         before_action :set_user, only: %i[show update]
         before_action -> { require_capability!("User", "read") }, only: %i[index show]
         before_action -> { require_capability!("User", "write") }, only: %i[create update]
+        before_action :reject_deactivated_user, only: %i[update]
 
         def index
           scope = build_users_scope.includes(deactivation: :deactivated_by).order(:id)
@@ -78,6 +79,12 @@ module Api
           def set_user
             @user = User.non_admin_accounts.includes(deactivation: :deactivated_by).find_by(id: params[:id])
             render json: { error: "Not found" }, status: :not_found unless @user
+          end
+
+          def reject_deactivated_user
+            return unless @user&.deactivated?
+
+            render json: { error: "Cannot modify a deactivated user" }, status: :unprocessable_entity
           end
 
           def user_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
 
   before_action :require_login
+  before_action :enforce_active_account, if: :logged_in?
   around_action :in_time_zone_and_locale, if: :logged_in?
 
   protect_from_forgery with: :exception
@@ -60,5 +61,12 @@ class ApplicationController < ActionController::Base
 
     def require_logout
       redirect_to project_url(current_user.inbox_project.id) if logged_in?
+    end
+
+    def enforce_active_account
+      return unless current_user&.deactivated?
+
+      reset_session
+      redirect_to login_url, alert: I18n.t("controllers.sessions.account_unavailable")
     end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
   private
 
     def authenticate
-      @user = User.authenticate_by(email: params[:email], password: params[:password])
+      @user = User.active.authenticate_by(email: params[:email], password: params[:password])
     end
 
     def handle_auth_failure

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,8 +4,11 @@ class TasksController < ApplicationController
 
   # GET /tasks/1
   def show
-    @comments = @task.comments.includes(:user).order(:created_at)
-    @subtasks = @task.subtasks.includes(:assignee).with_rich_text_description_and_embeds.order(:created_at)
+    @comments = @task.comments.includes(user: :deactivation).order(:created_at)
+    @subtasks = @task.subtasks
+                     .includes(assignee: :deactivation)
+                     .with_rich_text_description_and_embeds
+                     .order(:created_at)
   end
 
   # GET /tasks/new

--- a/app/controllers/totp/challenges_controller.rb
+++ b/app/controllers/totp/challenges_controller.rb
@@ -23,7 +23,7 @@ module Totp
     private
 
       def set_user_from_token
-        @user = User.find_by_token_for!(:totp_verification, params[:token])
+        @user = User.active.find_by_token_for!(:totp_verification, params[:token])
       rescue StandardError
         redirect_to root_path, error: t("controllers.totp/challenges.create.invalid_token")
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,15 +7,8 @@ module ApplicationHelper
     task.due_date.year == Time.current.year ? :short : :default
   end
 
-  def user_icon(user)
-    # ユーザーのアバターが更新されたときに反映させるため turbo_frame_tag を使用 (See users_controller#update)
-    turbo_frame_tag "", class: "user-avatar-#{user.id}" do
-      if user.avatar.attached?
-        image_tag url_for(user.avatar.variant(:icon)), class: "user-avatar"
-      else
-        tag.span user.user_name[0], class: "user-avatar user-initial-sign"
-      end
-    end
+  def user_icon(user, viewer: nil)
+    display_user_avatar(user, viewer: viewer)
   end
 
   def debug_block(&)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,24 @@
 module UsersHelper
+  # Pre-Fork skeleton. Phase 1B-β (Rails) implements per the contract below;
+  # the view-side migration of `comment.user.user_name`, `member.user_name`, and
+  # `user_icon` to these helpers is owned by the same phase.
+
+  # Returns the display name to render for `user` in the context of `viewer`.
+  # - admin viewer (or admin SPA context) → user.user_name (raw)
+  # - non-admin viewer, deactivated user  → first 2 chars + "**"
+  # - non-admin viewer, active user       → user.user_name
+  def display_user_name(user, viewer:)
+    raise NotImplementedError, "Phase 1B will implement display_user_name"
+  end
+
+  # Returns avatar markup for `user` in the context of `viewer`.
+  # Deactivated users render a person_off SVG with a slate background.
+  def display_user_avatar(user, viewer:)
+    raise NotImplementedError, "Phase 1B will implement display_user_avatar"
+  end
+
+  # Returns a neutral slate "退会済み" pill for deactivated users; nil otherwise.
+  def deactivation_status_badge(user)
+    raise NotImplementedError, "Phase 1B will implement deactivation_status_badge"
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,24 +1,42 @@
 module UsersHelper
-  # Pre-Fork skeleton. Phase 1B-β (Rails) implements per the contract below;
-  # the view-side migration of `comment.user.user_name`, `member.user_name`, and
-  # `user_icon` to these helpers is owned by the same phase.
-
   # Returns the display name to render for `user` in the context of `viewer`.
-  # - admin viewer (or admin SPA context) → user.user_name (raw)
-  # - non-admin viewer, deactivated user  → first 2 chars + "**"
-  # - non-admin viewer, active user       → user.user_name
+  # - admin viewer → user.user_name (raw)
+  # - non-admin viewer, deactivated user → first 2 chars + "**"
+  # - non-admin viewer, active user → user.user_name
   def display_user_name(user, viewer:)
-    raise NotImplementedError, "Phase 1B will implement display_user_name"
+    return user.user_name if viewer&.admin?
+    return "#{user.user_name[0..1]}**" if user.deactivated?
+
+    user.user_name
   end
 
   # Returns avatar markup for `user` in the context of `viewer`.
-  # Deactivated users render a person_off SVG with a slate background.
-  def display_user_avatar(user, viewer:)
-    raise NotImplementedError, "Phase 1B will implement display_user_avatar"
+  # Deactivated users render a person_off icon with a slate background,
+  # regardless of viewer role (visual redaction signal).
+  # Active users render the standard avatar (turbo_frame + image or initial).
+  def display_user_avatar(user, viewer: nil) # rubocop:disable Lint/UnusedMethodArgument
+    if user.deactivated?
+      content_tag(:span, class: "user-avatar user-avatar--deactivated") do
+        content_tag(:span, "person_off", class: "material-symbols-outlined")
+      end
+    else
+      turbo_frame_tag "", class: "user-avatar-#{user.id}" do
+        if user.avatar.attached?
+          image_tag url_for(user.avatar.variant(:icon)), class: "user-avatar"
+        else
+          tag.span user.user_name[0], class: "user-avatar user-initial-sign"
+        end
+      end
+    end
   end
 
   # Returns a neutral slate "退会済み" pill for deactivated users; nil otherwise.
   def deactivation_status_badge(user)
-    raise NotImplementedError, "Phase 1B will implement deactivation_status_badge"
+    return nil unless user.deactivated?
+
+    content_tag(:span, class: "deactivation-badge") do
+      concat content_tag(:span, "person_off", class: "material-symbols-outlined")
+      concat " 退会済み"
+    end
   end
 end

--- a/app/javascript/admin/__tests__/components/DeactivatedUserBadge.test.tsx
+++ b/app/javascript/admin/__tests__/components/DeactivatedUserBadge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { DeactivatedUserBadge } from '@admin/components/DeactivatedUserBadge'
+
+describe('DeactivatedUserBadge', () => {
+  it('renders Deactivated text', () => {
+    render(<DeactivatedUserBadge />)
+    expect(screen.getByText('Deactivated')).toBeInTheDocument()
+  })
+
+  it('has neutral slate styling', () => {
+    render(<DeactivatedUserBadge />)
+    const badge = screen.getByText('Deactivated')
+    expect(badge).toHaveClass('bg-slate-500/15')
+    expect(badge).toHaveClass('text-slate-400')
+    expect(badge).toHaveClass('ring-slate-500/30')
+  })
+})

--- a/app/javascript/admin/__tests__/pages/users/UsersIndexPage.test.tsx
+++ b/app/javascript/admin/__tests__/pages/users/UsersIndexPage.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { UsersIndexPage } from '@admin/pages/users/UsersIndexPage'
+import * as api from '@admin/lib/api'
+
+vi.mock('@admin/lib/api', async () => {
+  const actual = await vi.importActual('@admin/lib/api')
+  return {
+    ...actual,
+    usersApi: {
+      list: vi.fn(),
+      deactivate: vi.fn(),
+      reactivate: vi.fn(),
+    },
+  }
+})
+
+const mockList = vi.mocked(api.usersApi.list)
+const mockDeactivate = vi.mocked(api.usersApi.deactivate)
+const mockReactivate = vi.mocked(api.usersApi.reactivate)
+
+const activeUser: api.User = {
+  id: 1,
+  email: 'alice@example.com',
+  name: 'Alice',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  deactivated_at: null,
+}
+
+const deactivatedUser: api.User = {
+  id: 2,
+  email: 'deactivated_bob@example.com',
+  name: 'Bob',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  deactivated_at: '2026-04-01T00:00:00Z',
+  deactivation_reason: 'Requested by user',
+  original_email: 'bob@example.com',
+}
+
+const makeMeta = (count = 1): api.PaginationMeta => ({
+  page: 1,
+  per_page: 25,
+  total_count: count,
+  total_pages: 1,
+})
+
+const renderPage = (initialUrl = '/admin/users') =>
+  render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <Routes>
+        <Route path="/admin/users" element={<UsersIndexPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('UsersIndexPage — status filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults to active status and passes status=active to API', async () => {
+    mockList.mockResolvedValue({ users: [activeUser], meta: makeMeta(1) })
+    renderPage()
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'active' }),
+        expect.anything()
+      )
+    })
+  })
+
+  it('passes status=deactivated when Deactivated filter is clicked', async () => {
+    // Initial load with active users
+    mockList.mockResolvedValue({ users: [activeUser], meta: makeMeta(1) })
+    renderPage()
+    await waitFor(() => expect(mockList).toHaveBeenCalled())
+
+    // After filter click, return deactivated users
+    mockList.mockResolvedValue({ users: [deactivatedUser], meta: makeMeta(1) })
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivated' }))
+
+    await waitFor(() => {
+      const calls = mockList.mock.calls
+      expect(calls.some(c => c[0] && (c[0] as { status?: string }).status === 'deactivated')).toBe(true)
+    })
+  })
+
+  it('passes status=all when All filter is clicked', async () => {
+    mockList.mockResolvedValue({ users: [activeUser], meta: makeMeta(1) })
+    renderPage()
+    await waitFor(() => expect(mockList).toHaveBeenCalled())
+
+    mockList.mockResolvedValue({ users: [activeUser, deactivatedUser], meta: makeMeta(2) })
+    fireEvent.click(screen.getByRole('button', { name: 'All' }))
+
+    await waitFor(() => {
+      const calls = mockList.mock.calls
+      expect(calls.some(c => c[0] && (c[0] as { status?: string }).status === 'all')).toBe(true)
+    })
+  })
+
+  it('shows DeactivatedUserBadge for deactivated users', async () => {
+    mockList.mockResolvedValue({ users: [deactivatedUser], meta: makeMeta(1) })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Deactivated')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Reactivate and View actions for deactivated users, not Deactivate', async () => {
+    mockList.mockResolvedValue({ users: [deactivatedUser], meta: makeMeta(1) })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Bob'))
+    expect(screen.getByRole('button', { name: 'Reactivate' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'View' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Deactivate' })).not.toBeInTheDocument()
+  })
+
+  it('shows Edit and Deactivate actions for active users, not Reactivate', async () => {
+    mockList.mockResolvedValue({ users: [activeUser], meta: makeMeta(1) })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Alice'))
+    expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Deactivate' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reactivate' })).not.toBeInTheDocument()
+  })
+})
+
+describe('UsersIndexPage — Deactivate flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockList.mockResolvedValue({ users: [activeUser], meta: makeMeta(1) })
+  })
+
+  it('opens deactivate modal on Deactivate click', async () => {
+    renderPage()
+    await waitFor(() => screen.getByText('Alice'))
+
+    // Click the table row Deactivate button
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/Deactivate User/)).toBeInTheDocument()
+  })
+
+  it('calls usersApi.deactivate with reason and removes user from list on success', async () => {
+    mockDeactivate.mockResolvedValue(undefined)
+    renderPage()
+    await waitFor(() => screen.getByText('Alice'))
+
+    // Open modal
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+
+    const dialog = screen.getByRole('dialog')
+    const reasonInput = within(dialog).getByLabelText(/Reason/)
+    fireEvent.change(reasonInput, { target: { value: 'Spam account' } })
+
+    // Click the submit button inside the modal
+    const submitBtn = within(dialog).getByRole('button', { name: 'Deactivate' })
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => {
+      expect(mockDeactivate).toHaveBeenCalledWith(1, 'Spam account')
+      expect(screen.queryByText('Alice')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows error when deactivate fails', async () => {
+    mockDeactivate.mockRejectedValue(new Error('Server error'))
+    renderPage()
+    await waitFor(() => screen.getByText('Alice'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+    const dialog = screen.getByRole('dialog')
+    const submitBtn = within(dialog).getByRole('button', { name: 'Deactivate' })
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('UsersIndexPage — Reactivate flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockList.mockResolvedValue({ users: [deactivatedUser], meta: makeMeta(1) })
+  })
+
+  it('opens reactivate modal on Reactivate click', async () => {
+    renderPage()
+    await waitFor(() => screen.getByText('Bob'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reactivate' }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/Reactivate User/)).toBeInTheDocument()
+  })
+
+  it('happy path: calls reactivate without newEmail and removes user from list on 204', async () => {
+    mockReactivate.mockResolvedValue(undefined)
+    renderPage()
+    await waitFor(() => screen.getByText('Bob'))
+
+    // Open modal
+    fireEvent.click(screen.getByRole('button', { name: 'Reactivate' }))
+
+    const dialog = screen.getByRole('dialog')
+    // Click the modal submit button
+    const submitBtn = within(dialog).getByRole('button', { name: 'Reactivate' })
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => {
+      expect(mockReactivate).toHaveBeenCalledWith(2, undefined)
+      expect(screen.queryByText('Bob')).not.toBeInTheDocument()
+    })
+  })
+
+  it('conflict path: 422 + original_email_conflict shows inline email input, 2nd call sends new_email', async () => {
+    const conflictError = new api.ApiError('Unprocessable Entity', 422, {
+      errors: ['Email has already been taken'],
+      original_email_conflict: true,
+    })
+    mockReactivate
+      .mockRejectedValueOnce(conflictError)
+      .mockResolvedValueOnce(undefined)
+
+    renderPage()
+    await waitFor(() => screen.getByText('Bob'))
+
+    // Open modal
+    fireEvent.click(screen.getByRole('button', { name: 'Reactivate' }))
+
+    const dialog = screen.getByRole('dialog')
+
+    // 1st attempt — no email input initially
+    expect(within(dialog).queryByLabelText(/New Email Address/)).not.toBeInTheDocument()
+    const submitBtn = within(dialog).getByRole('button', { name: 'Reactivate' })
+    fireEvent.click(submitBtn)
+
+    // After 422 + original_email_conflict, inline email input appears
+    await waitFor(() => {
+      expect(within(dialog).getByLabelText(/New Email Address/)).toBeInTheDocument()
+      expect(screen.getByText(/original email address is already in use/)).toBeInTheDocument()
+    })
+
+    // 2nd attempt with new email
+    const emailInput = within(dialog).getByLabelText(/New Email Address/)
+    fireEvent.change(emailInput, { target: { value: 'bob-new@example.com' } })
+    const submitBtn2 = within(dialog).getByRole('button', { name: 'Reactivate' })
+    fireEvent.click(submitBtn2)
+
+    await waitFor(() => {
+      expect(mockReactivate).toHaveBeenNthCalledWith(1, 2, undefined)
+      expect(mockReactivate).toHaveBeenNthCalledWith(2, 2, 'bob-new@example.com')
+      expect(screen.queryByText('Bob')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/javascript/admin/components/DeactivateConfirmModal.tsx
+++ b/app/javascript/admin/components/DeactivateConfirmModal.tsx
@@ -60,7 +60,7 @@ export const DeactivateConfirmModal = ({ userName, onConfirm, onClose }: Props) 
               maxLength={500}
               rows={3}
               placeholder="Enter reason for deactivation..."
-              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30"
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-accent focus:ring-1 focus:ring-accent/30"
             />
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">

--- a/app/javascript/admin/components/DeactivateConfirmModal.tsx
+++ b/app/javascript/admin/components/DeactivateConfirmModal.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+
+interface Props {
+  userName: string
+  onConfirm: (reason: string) => Promise<void>
+  onClose: () => void
+}
+
+export const DeactivateConfirmModal = ({ userName, onConfirm, onClose }: Props) => {
+  const [reason, setReason] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError('')
+    try {
+      await onConfirm(reason)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to deactivate user')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="deactivate-modal-title"
+    >
+      <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2
+          id="deactivate-modal-title"
+          className="text-lg font-semibold text-slate-800"
+          style={{ fontFamily: 'Syne, sans-serif' }}
+        >
+          Deactivate User
+        </h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Are you sure you want to deactivate <strong>{userName}</strong>? The user will no longer be able to sign in.
+        </p>
+
+        {error && (
+          <div className="mt-3 rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-slate-600" htmlFor="deactivate-reason">
+              Reason <span className="text-slate-400">(optional, max 500 characters)</span>
+            </label>
+            <textarea
+              id="deactivate-reason"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+              maxLength={500}
+              rows={3}
+              placeholder="Enter reason for deactivation..."
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30"
+            />
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-medium text-rose-500 transition hover:bg-rose-50 disabled:opacity-50"
+            >
+              {submitting ? 'Deactivating...' : 'Deactivate'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/admin/components/DeactivatedUserBadge.tsx
+++ b/app/javascript/admin/components/DeactivatedUserBadge.tsx
@@ -1,0 +1,5 @@
+export const DeactivatedUserBadge = () => (
+  <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-slate-500/15 text-slate-400 ring-1 ring-slate-500/30">
+    Deactivated
+  </span>
+)

--- a/app/javascript/admin/components/ReactivateConfirmModal.tsx
+++ b/app/javascript/admin/components/ReactivateConfirmModal.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import { ApiError } from '../lib/api'
+
+interface Props {
+  userName: string
+  onConfirm: (newEmail?: string) => Promise<void>
+  onClose: () => void
+}
+
+export const ReactivateConfirmModal = ({ userName, onConfirm, onClose }: Props) => {
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [emailConflict, setEmailConflict] = useState(false)
+  const [newEmail, setNewEmail] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError('')
+    try {
+      // 1st send: no new_email. 2nd send (conflict mode): include new_email
+      await onConfirm(emailConflict ? newEmail : undefined)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 422 && err.body.original_email_conflict === true) {
+        setEmailConflict(true)
+        setError('')
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to reactivate user')
+      }
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reactivate-modal-title"
+    >
+      <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2
+          id="reactivate-modal-title"
+          className="text-lg font-semibold text-slate-800"
+          style={{ fontFamily: 'Syne, sans-serif' }}
+        >
+          Reactivate User
+        </h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Are you sure you want to reactivate <strong>{userName}</strong>? The user will be able to sign in again.
+        </p>
+
+        {emailConflict && (
+          <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-600">
+            The original email address is already in use by another user. Please enter a new email address.
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-3 rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-4">
+          {emailConflict && (
+            <div className="mb-4 space-y-1">
+              <label className="text-xs font-medium text-slate-600" htmlFor="reactivate-new-email">
+                New Email Address
+              </label>
+              <input
+                id="reactivate-new-email"
+                type="email"
+                value={newEmail}
+                onChange={e => setNewEmail(e.target.value)}
+                required
+                placeholder="Enter a new email address..."
+                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30"
+              />
+            </div>
+          )}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || (emailConflict && !newEmail)}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {submitting ? 'Reactivating...' : 'Reactivate'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/admin/components/ReactivateConfirmModal.tsx
+++ b/app/javascript/admin/components/ReactivateConfirmModal.tsx
@@ -75,7 +75,7 @@ export const ReactivateConfirmModal = ({ userName, onConfirm, onClose }: Props) 
                 onChange={e => setNewEmail(e.target.value)}
                 required
                 placeholder="Enter a new email address..."
-                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30"
+                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-accent focus:ring-1 focus:ring-accent/30"
               />
             </div>
           )}

--- a/app/javascript/admin/components/UserStatusFilter.tsx
+++ b/app/javascript/admin/components/UserStatusFilter.tsx
@@ -20,7 +20,7 @@ export const UserStatusFilter = ({ value, onChange }: Props) => (
         onClick={() => onChange(option.value)}
         className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
           value === option.value
-            ? 'bg-[#6366f1] text-white shadow-sm'
+            ? 'bg-accent text-white shadow-sm'
             : 'text-slate-600 hover:bg-slate-50'
         }`}
         aria-pressed={value === option.value}

--- a/app/javascript/admin/components/UserStatusFilter.tsx
+++ b/app/javascript/admin/components/UserStatusFilter.tsx
@@ -1,0 +1,32 @@
+type Status = 'active' | 'deactivated' | 'all'
+
+interface Props {
+  value: Status
+  onChange: (value: Status) => void
+}
+
+const OPTIONS: { label: string; value: Status }[] = [
+  { label: 'Active', value: 'active' },
+  { label: 'Deactivated', value: 'deactivated' },
+  { label: 'All', value: 'all' },
+]
+
+export const UserStatusFilter = ({ value, onChange }: Props) => (
+  <div className="inline-flex items-center rounded-lg border border-slate-200 bg-white p-0.5">
+    {OPTIONS.map(option => (
+      <button
+        key={option.value}
+        type="button"
+        onClick={() => onChange(option.value)}
+        className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+          value === option.value
+            ? 'bg-[#6366f1] text-white shadow-sm'
+            : 'text-slate-600 hover:bg-slate-50'
+        }`}
+        aria-pressed={value === option.value}
+      >
+        {option.label}
+      </button>
+    ))}
+  </div>
+)

--- a/app/javascript/admin/lib/api.ts
+++ b/app/javascript/admin/lib/api.ts
@@ -32,6 +32,10 @@ export interface User {
   updated_at: string
   last_sign_in_at?: string | null
   roles?: { id: number; name: string }[]
+  deactivated_at?: string | null
+  deactivation_reason?: string | null
+  deactivated_by?: { id: number; name: string | null } | null
+  original_email?: string | null
 }
 
 export interface Permission {
@@ -93,6 +97,20 @@ export interface UpdateUserInput {
   name: string
 }
 
+// ApiError carries the parsed response body for non-ok responses.
+// Use `error.body` to access structured server error data (e.g. original_email_conflict).
+export class ApiError extends Error {
+  status: number
+  body: Record<string, unknown>
+
+  constructor(message: string, status: number, body: Record<string, unknown>) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
 const getCsrfToken = (): string => {
   const meta = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')
   return meta?.content ?? ''
@@ -147,8 +165,12 @@ const apiRequest = async <T>(
         window.dispatchEvent(new Event(CAPABILITIES_STALE_EVENT))
       }
     }
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }))
-    throw new Error(error.error ?? `HTTP ${response.status}`)
+    const errorBody = await response.json().catch(() => ({ error: 'Unknown error' })) as Record<string, unknown>
+    throw new ApiError(
+      (errorBody.error as string | undefined) ?? `HTTP ${response.status}`,
+      response.status,
+      errorBody
+    )
   }
 
   if (response.status === 204) return undefined as T
@@ -179,9 +201,10 @@ export interface UserListResponse {
 }
 
 export const usersApi = {
-  list: (params?: { q?: string } & PaginationParams, options?: { signal?: AbortSignal }) => {
+  list: (params?: { q?: string; status?: 'active' | 'deactivated' | 'all' } & PaginationParams, options?: { signal?: AbortSignal }) => {
     const query = new URLSearchParams()
     if (params?.q) query.set('q', params.q)
+    if (params?.status) query.set('status', params.status)
     if (params?.page) query.set('page', String(params.page))
     if (params?.per_page) query.set('per_page', String(params.per_page))
     const qs = query.toString()
@@ -190,7 +213,10 @@ export const usersApi = {
   get: (id: number) => api.get<User>(`/users/${id}`),
   create: (data: CreateUserInput) => api.post<User>('/users', { user: data }),
   update: (id: number, data: UpdateUserInput) => api.patch<User>(`/users/${id}`, { user: data }),
-  delete: (id: number) => api.delete<void>(`/users/${id}`),
+  deactivate: (id: number, reason?: string) =>
+    api.post<void>(`/users/${id}/deactivation`, { reason }),
+  reactivate: (id: number, newEmail?: string) =>
+    api.post<void>(`/users/${id}/reactivation`, newEmail !== undefined ? { new_email: newEmail } : {}),
   getRoles: (id: number) => api.get<Role[]>(`/users/${id}/roles`),
   updateRoles: (id: number, roleIds: number[]) => api.patch<Role[]>(`/users/${id}/roles`, { role_ids: roleIds }),
 }

--- a/app/javascript/admin/pages/users/UserEditPage.tsx
+++ b/app/javascript/admin/pages/users/UserEditPage.tsx
@@ -1,22 +1,30 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { usersApi } from '../../lib/api'
+import { usersApi, User } from '../../lib/api'
 import { AdminCancelButton } from '../../components/AdminCancelButton'
+import { DeactivatedUserBadge } from '../../components/DeactivatedUserBadge'
+import { DeactivateConfirmModal } from '../../components/DeactivateConfirmModal'
+import { ReactivateConfirmModal } from '../../components/ReactivateConfirmModal'
 
 export const UserEditPage = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const [user, setUser] = useState<User | null>(null)
   const [email, setEmail] = useState('')
   const [name, setName] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
 
+  const [showDeactivateModal, setShowDeactivateModal] = useState(false)
+  const [showReactivateModal, setShowReactivateModal] = useState(false)
+
   useEffect(() => {
     if (!id) return
     usersApi.get(Number(id))
-      .then(user => {
-        setEmail(user.email)
-        setName(user.name)
+      .then(u => {
+        setUser(u)
+        setEmail(u.email)
+        setName(u.name)
       })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load user'))
       .finally(() => setLoading(false))
@@ -33,7 +41,19 @@ export const UserEditPage = () => {
     }
   }
 
+  const handleDeactivate = async (reason: string) => {
+    await usersApi.deactivate(Number(id), reason || undefined)
+    navigate('/admin/users')
+  }
+
+  const handleReactivate = async (newEmail?: string) => {
+    await usersApi.reactivate(Number(id), newEmail)
+    navigate('/admin/users')
+  }
+
   if (loading) return <p>Loading...</p>
+
+  const isDeactivated = Boolean(user?.deactivated_at)
 
   return (
     <div className="space-y-6">
@@ -42,10 +62,57 @@ export const UserEditPage = () => {
         <div>
           <p className="text-[10px] font-semibold tracking-[0.2em] text-slate-400"
              style={{ fontFamily: 'DM Mono, monospace' }}>MANAGEMENT</p>
-          <h1 className="text-2xl font-bold text-slate-800"
-              style={{ fontFamily: 'Syne, sans-serif' }}>Edit User</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold text-slate-800"
+                style={{ fontFamily: 'Syne, sans-serif' }}>Edit User</h1>
+            {isDeactivated && <DeactivatedUserBadge />}
+          </div>
         </div>
       </div>
+
+      {/* Deactivation info panel — shown at top when user is deactivated */}
+      {isDeactivated && user && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-5 shadow-sm">
+          <h3 className="text-sm font-semibold text-amber-800" style={{ fontFamily: 'Syne, sans-serif' }}>
+            Deactivation Info
+          </h3>
+          <dl className="mt-3 space-y-2 text-sm">
+            {user.original_email && (
+              <div>
+                <dt className="text-xs font-medium text-slate-500">Original Email</dt>
+                <dd className="mt-0.5 text-slate-700">{user.original_email}</dd>
+              </div>
+            )}
+            {user.deactivation_reason && (
+              <div>
+                <dt className="text-xs font-medium text-slate-500">Reason</dt>
+                <dd className="mt-0.5 text-slate-700">{user.deactivation_reason}</dd>
+              </div>
+            )}
+            {user.deactivated_at && (
+              <div>
+                <dt className="text-xs font-medium text-slate-500">Deactivated At</dt>
+                <dd className="mt-0.5 text-slate-700">{new Date(user.deactivated_at).toLocaleString()}</dd>
+              </div>
+            )}
+            {user.deactivated_by && (
+              <div>
+                <dt className="text-xs font-medium text-slate-500">Deactivated By</dt>
+                <dd className="mt-0.5 text-slate-700">{user.deactivated_by.name ?? `Admin #${user.deactivated_by.id}`}</dd>
+              </div>
+            )}
+          </dl>
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => setShowReactivateModal(true)}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-700"
+            >
+              Reactivate User
+            </button>
+          </div>
+        </div>
+      )}
 
       {error && (
         <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
@@ -76,6 +143,43 @@ export const UserEditPage = () => {
           </div>
         </form>
       </div>
+
+      {/* Danger Zone — shown at bottom when user is active */}
+      {!isDeactivated && (
+        <div className="rounded-xl border border-rose-200 bg-white p-5 shadow-sm">
+          <h3 className="text-sm font-semibold text-rose-600" style={{ fontFamily: 'Syne, sans-serif' }}>
+            Danger Zone
+          </h3>
+          <p className="mt-1 text-xs text-slate-500">
+            Deactivating a user will prevent them from signing in. This can be reversed.
+          </p>
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => setShowDeactivateModal(true)}
+              className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-medium text-rose-500 transition hover:bg-rose-50"
+            >
+              Deactivate User
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showDeactivateModal && user && (
+        <DeactivateConfirmModal
+          userName={user.name ?? user.email}
+          onConfirm={handleDeactivate}
+          onClose={() => setShowDeactivateModal(false)}
+        />
+      )}
+
+      {showReactivateModal && user && (
+        <ReactivateConfirmModal
+          userName={user.name ?? user.email}
+          onConfirm={handleReactivate}
+          onClose={() => setShowReactivateModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/admin/pages/users/UserEditPage.tsx
+++ b/app/javascript/admin/pages/users/UserEditPage.tsx
@@ -120,29 +120,31 @@ export const UserEditPage = () => {
         </div>
       )}
 
-      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-4">
-            <div className="space-y-1">
-              <label className="text-xs font-medium text-slate-600">Email</label>
-              <input type="email" value={email} onChange={e => setEmail(e.target.value)} required
-                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30" />
+      {!isDeactivated && (
+        <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-slate-600">Email</label>
+                <input type="email" value={email} onChange={e => setEmail(e.target.value)} required
+                  className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30" />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-slate-600">Name</label>
+                <input type="text" value={name} onChange={e => setName(e.target.value)} required
+                  className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30" />
+              </div>
             </div>
-            <div className="space-y-1">
-              <label className="text-xs font-medium text-slate-600">Name</label>
-              <input type="text" value={name} onChange={e => setName(e.target.value)} required
-                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-[#6366f1] focus:ring-1 focus:ring-[#6366f1]/30" />
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <AdminCancelButton to="/admin/users" />
+              <button type="submit"
+                className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
+                Update
+              </button>
             </div>
-          </div>
-          <div className="mt-6 flex items-center justify-end gap-2">
-            <AdminCancelButton to="/admin/users" />
-            <button type="submit"
-              className="rounded-lg bg-[#6366f1] px-4 py-2 text-sm font-medium text-white shadow-md shadow-indigo-500/20 transition hover:bg-[#5558e8]">
-              Update
-            </button>
-          </div>
-        </form>
-      </div>
+          </form>
+        </div>
+      )}
 
       {/* Danger Zone — shown at bottom when user is active */}
       {!isDeactivated && (

--- a/app/javascript/admin/pages/users/UsersIndexPage.tsx
+++ b/app/javascript/admin/pages/users/UsersIndexPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { usersApi, User, type PaginationMeta } from '../../lib/api'
 import Avatar from '../../components/Avatar'
 import Pagination from '../../components/Pagination'
+import { SectionError } from '../../components/SectionError'
 import { usePagination, useClampPage } from '../../hooks/usePagination'
 import { DeactivatedUserBadge } from '../../components/DeactivatedUserBadge'
 import { UserStatusFilter } from '../../components/UserStatusFilter'
@@ -10,12 +11,27 @@ import { DeactivateConfirmModal } from '../../components/DeactivateConfirmModal'
 import { ReactivateConfirmModal } from '../../components/ReactivateConfirmModal'
 
 type Status = 'active' | 'deactivated' | 'all'
+const STATUS_VALUES: readonly Status[] = ['active', 'deactivated', 'all']
+const isStatus = (v: string | null): v is Status => v !== null && (STATUS_VALUES as readonly string[]).includes(v)
 
 export const UsersIndexPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const statusFromUrl = (searchParams.get('status') ?? 'active') as Status
-  const [status, setStatus] = useState<Status>(statusFromUrl)
+  const initialRawStatus = searchParams.get('status')
+  const initialStatus: Status = isStatus(initialRawStatus) ? initialRawStatus : 'active'
+  const [status, setStatus] = useState<Status>(initialStatus)
+
+  // Browser Back/Forward sync: when the URL's status changes externally, mirror it into state.
+  // We intentionally read `status` here without listing it in deps — including it would
+  // cause this effect to re-run after every state change and overwrite a user-initiated
+  // click between handler firing and re-render.
+  const statusRef = useRef(status)
+  statusRef.current = status
+  useEffect(() => {
+    const raw = searchParams.get('status')
+    const next: Status = isStatus(raw) ? raw : 'active'
+    if (next !== statusRef.current) setStatus(next)
+  }, [searchParams])
 
   const [users, setUsers] = useState<User[]>([])
   const [meta, setMeta] = useState<PaginationMeta | null>(null)
@@ -23,6 +39,7 @@ export const UsersIndexPage = () => {
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [retryNonce, setRetryNonce] = useState(0)
 
   const [deactivatingUser, setDeactivatingUser] = useState<User | null>(null)
   const [reactivatingUser, setReactivatingUser] = useState<User | null>(null)
@@ -42,16 +59,6 @@ export const UsersIndexPage = () => {
       resetPage()
     }
   }, [debouncedQuery, resetPage])
-
-  // Sync status → URL
-  useEffect(() => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      next.set('status', status)
-      return next
-    }, { replace: true })
-    resetPage()
-  }, [status, setSearchParams, resetPage])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -76,11 +83,21 @@ export const UsersIndexPage = () => {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [debouncedQuery, status, page, perPage])
+  }, [debouncedQuery, status, page, perPage, retryNonce])
 
   const handleStatusChange = (next: Status) => {
     setStatus(next)
   }
+
+  // Sync state → URL on every status change
+  useEffect(() => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.set('status', status)
+      return next
+    }, { replace: true })
+    resetPage()
+  }, [status, setSearchParams, resetPage])
 
   const handleDeactivate = async (reason: string) => {
     if (!deactivatingUser) return
@@ -99,8 +116,6 @@ export const UsersIndexPage = () => {
   }
 
   const isDeactivated = (user: User) => Boolean(user.deactivated_at)
-
-  if (error) return <p className="text-rose-500">{error}</p>
 
   return (
     <div className="space-y-5">
@@ -129,7 +144,14 @@ export const UsersIndexPage = () => {
       {/* Status filter */}
       <UserStatusFilter value={status} onChange={handleStatusChange} />
 
-      {/* Table */}
+      {/* Table or inline fetch error (per ADMIN_UI §4.6 — keep header / filter mounted on failure) */}
+      {error ? (
+        <SectionError
+          title="ユーザー一覧"
+          message={error}
+          onRetry={() => setRetryNonce(n => n + 1)}
+        />
+      ) : (
       <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
@@ -211,8 +233,9 @@ export const UsersIndexPage = () => {
           </tbody>
         </table>
       </div>
+      )}
 
-      {meta && (
+      {!error && meta && (
         <Pagination
           meta={meta}
           page={page}

--- a/app/javascript/admin/pages/users/UsersIndexPage.tsx
+++ b/app/javascript/admin/pages/users/UsersIndexPage.tsx
@@ -1,17 +1,31 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { usersApi, User, type PaginationMeta } from '../../lib/api'
 import Avatar from '../../components/Avatar'
 import Pagination from '../../components/Pagination'
 import { usePagination, useClampPage } from '../../hooks/usePagination'
+import { DeactivatedUserBadge } from '../../components/DeactivatedUserBadge'
+import { UserStatusFilter } from '../../components/UserStatusFilter'
+import { DeactivateConfirmModal } from '../../components/DeactivateConfirmModal'
+import { ReactivateConfirmModal } from '../../components/ReactivateConfirmModal'
+
+type Status = 'active' | 'deactivated' | 'all'
 
 export const UsersIndexPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const statusFromUrl = (searchParams.get('status') ?? 'active') as Status
+  const [status, setStatus] = useState<Status>(statusFromUrl)
+
   const [users, setUsers] = useState<User[]>([])
   const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
+
+  const [deactivatingUser, setDeactivatingUser] = useState<User | null>(null)
+  const [reactivatingUser, setReactivatingUser] = useState<User | null>(null)
 
   const { page, perPage, setPage, setPerPage, resetPage, clampPage } = usePagination()
   useClampPage(meta, clampPage)
@@ -29,12 +43,22 @@ export const UsersIndexPage = () => {
     }
   }, [debouncedQuery, resetPage])
 
+  // Sync status → URL
+  useEffect(() => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.set('status', status)
+      return next
+    }, { replace: true })
+    resetPage()
+  }, [status, setSearchParams, resetPage])
+
   useEffect(() => {
     const controller = new AbortController()
     setError('')
     setLoading(true)
     usersApi.list(
-      { q: debouncedQuery || undefined, page, per_page: perPage },
+      { q: debouncedQuery || undefined, status, page, per_page: perPage },
       { signal: controller.signal }
     )
       .then(response => {
@@ -52,17 +76,29 @@ export const UsersIndexPage = () => {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [debouncedQuery, page, perPage])
+  }, [debouncedQuery, status, page, perPage])
 
-  const handleDelete = async (id: number) => {
-    if (!confirm('Are you sure you want to delete this user?')) return
-    try {
-      await usersApi.delete(id)
-      setUsers(users.filter(u => u.id !== id))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete user')
-    }
+  const handleStatusChange = (next: Status) => {
+    setStatus(next)
   }
+
+  const handleDeactivate = async (reason: string) => {
+    if (!deactivatingUser) return
+    await usersApi.deactivate(deactivatingUser.id, reason || undefined)
+    setDeactivatingUser(null)
+    // Refresh list
+    setUsers(prev => prev.filter(u => u.id !== deactivatingUser.id))
+  }
+
+  const handleReactivate = async (newEmail?: string) => {
+    if (!reactivatingUser) return
+    await usersApi.reactivate(reactivatingUser.id, newEmail)
+    setReactivatingUser(null)
+    // Refresh list
+    setUsers(prev => prev.filter(u => u.id !== reactivatingUser.id))
+  }
+
+  const isDeactivated = (user: User) => Boolean(user.deactivated_at)
 
   if (error) return <p className="text-rose-500">{error}</p>
 
@@ -89,6 +125,9 @@ export const UsersIndexPage = () => {
           </div>
         </div>
       </div>
+
+      {/* Status filter */}
+      <UserStatusFilter value={status} onChange={handleStatusChange} />
 
       {/* Table */}
       <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
@@ -123,7 +162,10 @@ export const UsersIndexPage = () => {
                   <div className="flex items-center gap-3">
                     <Avatar name={user.name ?? user.email} size="sm" />
                     <div>
-                      <p className="text-sm font-medium text-slate-700">{user.name}</p>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium text-slate-700">{user.name}</p>
+                        {isDeactivated(user) && <DeactivatedUserBadge />}
+                      </div>
                       <p className="text-xs text-slate-400">{user.email}</p>
                     </div>
                   </div>
@@ -131,18 +173,37 @@ export const UsersIndexPage = () => {
                 <td className="px-5 py-3.5 text-xs text-slate-400">{new Date(user.created_at).toLocaleDateString()}</td>
                 <td className="px-5 py-3.5">
                   <div className="flex items-center gap-2">
-                    <Link
-                      to={`/admin/users/${user.id}/edit`}
-                      className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
-                    >
-                      Edit
-                    </Link>
-                    <button
-                      onClick={() => handleDelete(user.id)}
-                      className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-medium text-rose-500 transition hover:bg-rose-50"
-                    >
-                      Delete
-                    </button>
+                    {isDeactivated(user) ? (
+                      <>
+                        <button
+                          onClick={() => setReactivatingUser(user)}
+                          className="rounded-lg bg-emerald-600 px-2.5 py-1 text-xs font-medium text-white transition hover:bg-emerald-700"
+                        >
+                          Reactivate
+                        </button>
+                        <Link
+                          to={`/admin/users/${user.id}/edit`}
+                          className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+                        >
+                          View
+                        </Link>
+                      </>
+                    ) : (
+                      <>
+                        <Link
+                          to={`/admin/users/${user.id}/edit`}
+                          className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+                        >
+                          Edit
+                        </Link>
+                        <button
+                          onClick={() => setDeactivatingUser(user)}
+                          className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-medium text-rose-500 transition hover:bg-rose-50"
+                        >
+                          Deactivate
+                        </button>
+                      </>
+                    )}
                   </div>
                 </td>
               </tr>
@@ -158,6 +219,22 @@ export const UsersIndexPage = () => {
           perPage={perPage}
           onPageChange={setPage}
           onPerPageChange={setPerPage}
+        />
+      )}
+
+      {deactivatingUser && (
+        <DeactivateConfirmModal
+          userName={deactivatingUser.name ?? deactivatingUser.email}
+          onConfirm={handleDeactivate}
+          onClose={() => setDeactivatingUser(null)}
+        />
+      )}
+
+      {reactivatingUser && (
+        <ReactivateConfirmModal
+          userName={reactivatingUser.name ?? reactivatingUser.email}
+          onConfirm={handleReactivate}
+          onClose={() => setReactivatingUser(null)}
         />
       )}
     </div>

--- a/app/models/deactivated_user.rb
+++ b/app/models/deactivated_user.rb
@@ -1,0 +1,8 @@
+class DeactivatedUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :deactivated_by, class_name: "User", optional: true
+
+  validates :original_email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :reason, length: { maximum: 500 }, allow_blank: true
+  validates :deactivated_at, presence: true
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,8 @@ class Event < ApplicationRecord
     project_created
     assignee_changed
     due_date_changed
+    user_deactivated
+    user_reactivated
   ].freeze
 
   FEATURE_CATEGORIES = {
@@ -19,6 +21,8 @@ class Event < ApplicationRecord
     "project_created" => "basic_operation",
     "assignee_changed" => "collaboration",
     "due_date_changed" => "planning",
+    "user_deactivated" => "account_lifecycle",
+    "user_reactivated" => "account_lifecycle",
   }.freeze
 
   belongs_to :user

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,7 +12,7 @@ class Project < ApplicationRecord
   scope :archived, -> { where(archived: true) }
 
   def members_with_priority(user)
-    members.sort { |lhs, _| lhs == user ? -1 : 1 }
+    members.includes(:deactivation).sort { |lhs, _| lhs == user ? -1 : 1 }
   end
 
   def archive!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,27 @@ class User < ApplicationRecord
     where("LOWER(users.name) LIKE LOWER(:q) OR LOWER(users.email) LIKE LOWER(:q)", q: "%#{sanitized}%")
   }
 
+  scope :active, -> { where.missing(:deactivation) }
+  scope :deactivated, -> { joins(:deactivation) }
+
+  scope :search_deactivated, lambda { |query|
+    base = joins(:deactivation)
+    return base if query.blank?
+
+    sanitized = sanitize_sql_like(query.strip)
+    base.where(
+      "LOWER(users.name) LIKE LOWER(:q) OR LOWER(deactivated_users.original_email) LIKE LOWER(:q)",
+      q: "%#{sanitized}%",
+    )
+  }
+
+  has_one :deactivation, class_name: "DeactivatedUser", dependent: :destroy
+  has_many :performed_deactivations,
+           class_name: "DeactivatedUser",
+           foreign_key: :deactivated_by_id,
+           dependent: :nullify,
+           inverse_of: :deactivated_by
+
   has_many :comments, dependent: :restrict_with_error
   has_many :project_members, dependent: :restrict_with_error
   has_many :projects, through: :project_members
@@ -63,6 +84,14 @@ class User < ApplicationRecord
 
   def user_name
     name.presence || email.split("@").first
+  end
+
+  def deactivated?
+    deactivation.present?
+  end
+
+  def active?
+    !deactivated?
   end
 
   def regenerate_totp_secret!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,8 @@ class User < ApplicationRecord
 
     sanitized = sanitize_sql_like(query.strip)
     base.where(
-      "LOWER(users.name) LIKE LOWER(:q) OR LOWER(deactivated_users.original_email) LIKE LOWER(:q)",
+      "LOWER(users.name) LIKE LOWER(:q) ESCAPE '\\' " \
+      "OR LOWER(deactivated_users.original_email) LIKE LOWER(:q) ESCAPE '\\'",
       q: "%#{sanitized}%",
     )
   }
@@ -68,6 +69,8 @@ class User < ApplicationRecord
   has_many :roles, through: :user_roles
 
   has_many :admin_login_histories, dependent: :destroy
+
+  attr_accessor :reason
 
   before_validation :generate_totp_secret, on: :create
   after_create :create_inbox_project
@@ -108,12 +111,6 @@ class User < ApplicationRecord
   delegate :admin?, :has_permission?, :can_read?, :can_write?,
            :can_delete?, :can_manage?, :can_grant_permissions?,
            :owned_permission_ids, to: :policy
-
-  def force_destroy
-    comments.destroy_all
-    project_members.destroy_all
-    destroy
-  end
 
   private
 

--- a/app/services/account/deactivation_service.rb
+++ b/app/services/account/deactivation_service.rb
@@ -25,11 +25,18 @@ module Account
       end
     end
 
+    # Concurrent reactivation by two admins is protected with FOR UPDATE on the
+    # `deactivated_users` row. The second tx waits for the first to commit, then
+    # `lock.find_by` returns nil (row destroyed) → RecordNotFound surfaces as 404.
+    # Without this, `user.deactivation.original_email` reload could raise NoMethodError.
     def self.reactivate(user:, performer:, new_email: nil)
-      target_email = new_email.presence || user.deactivation.original_email
       ActiveRecord::Base.transaction do
+        deactivation = DeactivatedUser.lock.find_by(user_id: user.id)
+        raise ActiveRecord::RecordNotFound, "User is not deactivated" unless deactivation
+
+        target_email = new_email.presence || deactivation.original_email
         user.update!(email: target_email)
-        user.deactivation.destroy!
+        deactivation.destroy!
         Events::Recorder.record(
           event_name: "user_reactivated",
           user: performer,

--- a/app/services/account/deactivation_service.rb
+++ b/app/services/account/deactivation_service.rb
@@ -1,0 +1,39 @@
+module Account
+  # Pre-Fork skeleton. Phase 1B fills in the transaction bodies.
+  # Contract:
+  #   - call(user:, performer:, reason: nil, self_deactivated: false) - deactivates a user
+  #   - reactivate(user:, performer:, new_email: nil)                  - restores a user
+  # Both methods record an `events` row via Events::Recorder (event names
+  # `user_deactivated` / `user_reactivated`, category `account_lifecycle`).
+  # Sentinel email format: deactivated+{user_id}+{16 hex}@deactivated.invalid (RFC 2606 invalid TLD).
+  class DeactivationService
+    # rubocop:disable Lint/UnusedMethodArgument
+    def self.call(user:, performer:, reason: nil, self_deactivated: false)
+      ActiveRecord::Base.transaction do
+        # Phase 1B implements:
+        # 1. DeactivatedUser.create!(user:, original_email: user.email, reason:,
+        #      deactivated_by: performer, deactivated_at: Time.current)
+        # 2. user.update_column(:email, sentinel_email_for(user))
+        # 3. Events::Recorder.record(event_name: "user_deactivated", user: performer,
+        #      metadata: { target_user_id: user.id, self_deactivated:,
+        #                  original_email: user.deactivation.original_email })
+      end
+    end
+
+    def self.reactivate(user:, performer:, new_email: nil)
+      ActiveRecord::Base.transaction do
+        # Phase 1B implements:
+        # target_email = new_email.presence || user.deactivation.original_email
+        # 1. user.update!(email: target_email)  # uniqueness validation surfaces conflict
+        # 2. user.deactivation.destroy!
+        # 3. Events::Recorder.record(event_name: "user_reactivated", user: performer,
+        #      metadata: { target_user_id: user.id, restored_email: target_email })
+      end
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
+    def self.sentinel_email_for(user)
+      "deactivated+#{user.id}+#{SecureRandom.hex(8)}@deactivated.invalid"
+    end
+  end
+end

--- a/app/services/account/deactivation_service.rb
+++ b/app/services/account/deactivation_service.rb
@@ -3,10 +3,11 @@ module Account
   # Sentinel email format: deactivated+{user_id}+{16 hex}@deactivated.invalid (RFC 2606 invalid TLD).
   class DeactivationService
     def self.call(user:, performer:, reason: nil, self_deactivated: false)
+      original_email = user.email
       ActiveRecord::Base.transaction do
         DeactivatedUser.create!(
           user: user,
-          original_email: user.email,
+          original_email: original_email,
           reason: reason,
           deactivated_by: performer,
           deactivated_at: Time.current,
@@ -18,7 +19,7 @@ module Account
           metadata: {
             target_user_id: user.id,
             self_deactivated: self_deactivated,
-            original_email: user.deactivation&.original_email,
+            original_email: original_email,
           },
         )
       end

--- a/app/services/account/deactivation_service.rb
+++ b/app/services/account/deactivation_service.rb
@@ -1,36 +1,44 @@
 module Account
-  # Pre-Fork skeleton. Phase 1B fills in the transaction bodies.
-  # Contract:
-  #   - call(user:, performer:, reason: nil, self_deactivated: false) - deactivates a user
-  #   - reactivate(user:, performer:, new_email: nil)                  - restores a user
-  # Both methods record an `events` row via Events::Recorder (event names
-  # `user_deactivated` / `user_reactivated`, category `account_lifecycle`).
+  # Service for user deactivation and reactivation.
   # Sentinel email format: deactivated+{user_id}+{16 hex}@deactivated.invalid (RFC 2606 invalid TLD).
   class DeactivationService
-    # rubocop:disable Lint/UnusedMethodArgument
     def self.call(user:, performer:, reason: nil, self_deactivated: false)
       ActiveRecord::Base.transaction do
-        # Phase 1B implements:
-        # 1. DeactivatedUser.create!(user:, original_email: user.email, reason:,
-        #      deactivated_by: performer, deactivated_at: Time.current)
-        # 2. user.update_column(:email, sentinel_email_for(user))
-        # 3. Events::Recorder.record(event_name: "user_deactivated", user: performer,
-        #      metadata: { target_user_id: user.id, self_deactivated:,
-        #                  original_email: user.deactivation.original_email })
+        DeactivatedUser.create!(
+          user: user,
+          original_email: user.email,
+          reason: reason,
+          deactivated_by: performer,
+          deactivated_at: Time.current,
+        )
+        user.update_column(:email, sentinel_email_for(user))
+        Events::Recorder.record(
+          event_name: "user_deactivated",
+          user: performer,
+          metadata: {
+            target_user_id: user.id,
+            self_deactivated: self_deactivated,
+            original_email: user.deactivation&.original_email,
+          },
+        )
       end
     end
 
     def self.reactivate(user:, performer:, new_email: nil)
+      target_email = new_email.presence || user.deactivation.original_email
       ActiveRecord::Base.transaction do
-        # Phase 1B implements:
-        # target_email = new_email.presence || user.deactivation.original_email
-        # 1. user.update!(email: target_email)  # uniqueness validation surfaces conflict
-        # 2. user.deactivation.destroy!
-        # 3. Events::Recorder.record(event_name: "user_reactivated", user: performer,
-        #      metadata: { target_user_id: user.id, restored_email: target_email })
+        user.update!(email: target_email)
+        user.deactivation.destroy!
+        Events::Recorder.record(
+          event_name: "user_reactivated",
+          user: performer,
+          metadata: {
+            target_user_id: user.id,
+            restored_email: target_email,
+          },
+        )
       end
     end
-    # rubocop:enable Lint/UnusedMethodArgument
 
     def self.sentinel_email_for(user)
       "deactivated+#{user.id}+#{SecureRandom.hex(8)}@deactivated.invalid"

--- a/app/views/account/deactivations/new.html.erb
+++ b/app/views/account/deactivations/new.html.erb
@@ -20,14 +20,14 @@
       <%= form.text_area :reason, rows: 4, maxlength: 500, class: "full-width-input" %>
     </div>
 
-    <div class="auth-form__field">
+    <div class="auth-form__field auth-form__field--inline">
       <%= check_box_tag :confirm_deactivation, "1", false, required: true, id: "confirm_deactivation" %>
       <%= label_tag :confirm_deactivation, t(".confirm_label") %>
     </div>
 
     <div class="auth-form__actions">
       <%= form.submit t(".submit"), class: "danger" %>
-      <%= link_to t(".cancel"), user_path, class: "btn" %>
+      <%= link_to t(".cancel"), root_path, class: "btn" %>
     </div>
   <% end %>
 </main>

--- a/app/views/account/deactivations/new.html.erb
+++ b/app/views/account/deactivations/new.html.erb
@@ -1,0 +1,33 @@
+<main class="auth-form">
+  <h1 class="auth-form__title"><%= t(".title") %></h1>
+
+  <div class="auth-form__warning">
+    <p><%= t(".warning_reversible") %></p>
+    <p><%= t(".warning_history") %></p>
+    <p><%= t(".warning_session") %></p>
+  </div>
+
+  <%= form_with model: @user, url: account_deactivation_path do |form| %>
+    <%= render_errors_for @user %>
+
+    <div class="auth-form__field">
+      <%= form.label :password_challenge %>
+      <%= form.password_field :password_challenge, class: "full-width-input", required: true %>
+    </div>
+
+    <div class="auth-form__field">
+      <%= form.label :reason, t(".reason_label") %>
+      <%= form.text_area :reason, rows: 4, maxlength: 500, class: "full-width-input" %>
+    </div>
+
+    <div class="auth-form__field">
+      <%= check_box_tag :confirm_deactivation, "1", false, required: true, id: "confirm_deactivation" %>
+      <%= label_tag :confirm_deactivation, t(".confirm_label") %>
+    </div>
+
+    <div class="auth-form__actions">
+      <%= form.submit t(".submit"), class: "danger" %>
+      <%= link_to t(".cancel"), user_path, class: "btn" %>
+    </div>
+  <% end %>
+</main>

--- a/app/views/account/deactivations/new.html.erb
+++ b/app/views/account/deactivations/new.html.erb
@@ -7,7 +7,7 @@
     <p><%= t(".warning_session") %></p>
   </div>
 
-  <%= form_with model: @user, url: account_deactivation_path do |form| %>
+  <%= form_with model: @user, url: account_deactivation_path, method: :post do |form| %>
     <%= render_errors_for @user %>
 
     <div class="auth-form__field">

--- a/app/views/tasks/_assignees.html.erb
+++ b/app/views/tasks/_assignees.html.erb
@@ -12,7 +12,7 @@
 
   <nav class="menu-navigation hidden" data-assignees-target="menu">
     <ul class="menu-list" data-assignees-target="assigneeList">
-      <% task.project.members.each do |member| %>
+      <% task.project.members.includes(:deactivation).each do |member| %>
         <li class="assignee-list__member" data-assignees-target="assignee" data-assignee-id="<%= member.id %>">
           <% if task.assignee == member %>
             <div class="assignee-list__member-info">

--- a/app/views/tasks/_assignees.html.erb
+++ b/app/views/tasks/_assignees.html.erb
@@ -18,7 +18,8 @@
             <div class="assignee-list__member-info">
               <%= button_to task_assign_path(task), params: { assignee_id: member.id }, disabled: true do %>
                 <%= user_icon(member) %>
-                <span class="assignee-list__member-name uname"><%= member.user_name %></span>
+                <span class="assignee-list__member-name uname"><%= display_user_name(member, viewer: current_user) %></span>
+                <%= deactivation_status_badge(member) %>
               <% end %>
             </div>
             <div class="assignee-list__member-sign">
@@ -28,7 +29,8 @@
             <div class="assignee-list__member-info">
               <%= button_to task_assign_path(task), params: { assignee_id: member.id } do %>
                 <%= user_icon(member) %>
-                <span class="assignee-list__member-name uname"><%= member.user_name %></span>
+                <span class="assignee-list__member-name uname"><%= display_user_name(member, viewer: current_user) %></span>
+                <%= deactivation_status_badge(member) %>
               <% end %>
             </div>
           <% end %>

--- a/app/views/tasks/comments/_comment.html.erb
+++ b/app/views/tasks/comments/_comment.html.erb
@@ -3,7 +3,8 @@
     <div class="comment-card__content">
       <div class="comment-card__header">
         <div class="comment-card__header__user">
-          <%=  comment.user.user_name %>
+          <%= display_user_name(comment.user, viewer: current_user) %>
+          <%= deactivation_status_badge(comment.user) %>
         </div>
         <div class="comment-card__header__date">
           <%= l(comment.created_at, format: :long) %>

--- a/app/views/users/_user_display.html.erb
+++ b/app/views/users/_user_display.html.erb
@@ -58,4 +58,9 @@
       <%= form.submit class: "primary", disabled: true, data: { "user-target": "submit" } %>
     </div>
   <% end %>
+
+  <div class="show-user__danger-zone">
+    <h3 class="show-user__danger-zone-title"><%= t("users.user_display.danger_zone") %></h3>
+    <%= link_to t("users.user_display.deactivate"), new_account_deactivation_path, class: "btn danger" %>
+  </div>
 <% end %>

--- a/app/views/users/_user_display.html.erb
+++ b/app/views/users/_user_display.html.erb
@@ -59,10 +59,12 @@
     </div>
   <% end %>
 
-  <div class="show-user__danger-zone">
-    <%= link_to new_account_deactivation_path, class: "show-user__deactivate-link" do %>
-      <span class="material-symbols-outlined" aria-hidden="true">person_off</span>
-      <%= t("users.user_display.deactivate") %>
-    <% end %>
-  </div>
+  <% unless current_user.can_read?("Admin") %>
+    <div class="show-user__danger-zone">
+      <%= link_to new_account_deactivation_path, class: "show-user__deactivate-link" do %>
+        <span class="material-symbols-outlined" aria-hidden="true">person_off</span>
+        <%= t("users.user_display.deactivate") %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/_user_display.html.erb
+++ b/app/views/users/_user_display.html.erb
@@ -61,7 +61,7 @@
 
   <% unless current_user.can_read?("Admin") %>
     <div class="show-user__danger-zone">
-      <%= link_to new_account_deactivation_path, class: "show-user__deactivate-link" do %>
+      <%= link_to new_account_deactivation_path, class: "show-user__deactivate-link", data: { turbo_frame: "_top" } do %>
         <span class="material-symbols-outlined" aria-hidden="true">person_off</span>
         <%= t("users.user_display.deactivate") %>
       <% end %>

--- a/app/views/users/_user_display.html.erb
+++ b/app/views/users/_user_display.html.erb
@@ -60,7 +60,9 @@
   <% end %>
 
   <div class="show-user__danger-zone">
-    <h3 class="show-user__danger-zone-title"><%= t("users.user_display.danger_zone") %></h3>
-    <%= link_to t("users.user_display.deactivate"), new_account_deactivation_path, class: "btn danger" %>
+    <%= link_to new_account_deactivation_path, class: "show-user__deactivate-link" do %>
+      <span class="material-symbols-outlined" aria-hidden="true">person_off</span>
+      <%= t("users.user_display.deactivate") %>
+    <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,8 @@ en:
     account/deactivations:
       create:
         success: "Your account has been deactivated. Thank you for using our service."
+        failure: "Could not complete deactivation. Please try again later."
+        confirmation_required: "Please tick the confirmation checkbox before deactivating."
       admin_blocked: "Admin-capable accounts cannot self-deactivate. Please ask another administrator."
     emails:
       update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,8 @@ en:
       change_password: "Change password"
       two_fa_setting: "2FA Setting"
       cancel: "Cancel"
+      danger_zone: "Account closure"
+      deactivate: "Deactivate account"
   password_resets:
     new:
       title: "Password Reset"
@@ -265,6 +267,17 @@ en:
         confirm_delete: "Are you sure?"
       add_comment:
         comment: "Comment"
+  account:
+    deactivations:
+      new:
+        title: "Deactivate Account"
+        warning_reversible: "Deactivation can be reversed at any time by contacting an administrator."
+        warning_history: "Your data (tasks, comments, etc.) will be retained and not deleted."
+        warning_session: "After deactivation, your current session and all sessions will be invalidated."
+        reason_label: "Reason for leaving (optional)"
+        confirm_label: "I understand the above and agree to deactivate my account"
+        submit: "Deactivate Account"
+        cancel: "Cancel"
   emails:
     edit:
       title: "Change email"
@@ -294,6 +307,7 @@ en:
       action: "Reset password"
   controllers:
     sessions:
+      account_unavailable: "This account is not available"
       create:
         success: "Logged in!"
         failure: "Email or password is invalid"
@@ -327,6 +341,9 @@ en:
         added: "\"%{name}\" was added to this project!"
       destroy:
         removed: "\"%{name}\" was removed from this project!"
+    account/deactivations:
+      create:
+        success: "Your account has been deactivated. Thank you for using our service."
     emails:
       update:
         success: "Email updated successfully."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,7 @@ en:
     account/deactivations:
       create:
         success: "Your account has been deactivated. Thank you for using our service."
+      admin_blocked: "Admin-capable accounts cannot self-deactivate. Please ask another administrator."
     emails:
       update:
         success: "Email updated successfully."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -388,6 +388,7 @@ ja:
     account/deactivations:
       create:
         success: "退会処理が完了しました。ご利用いただきありがとうございました。"
+      admin_blocked: "管理者権限を持つアカウントは退会できません。別の管理者へ依頼してください。"
     emails:
       update:
         success: "メールアドレスを更新しました。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -388,6 +388,8 @@ ja:
     account/deactivations:
       create:
         success: "退会処理が完了しました。ご利用いただきありがとうございました。"
+        failure: "退会処理に失敗しました。時間をおいて再度お試しください。"
+        confirmation_required: "退会内容を理解した旨のチェックを入れてください。"
       admin_blocked: "管理者権限を持つアカウントは退会できません。別の管理者へ依頼してください。"
     emails:
       update:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -151,6 +151,8 @@ ja:
       change_password: "パスワードを変更"
       two_fa_setting: "二要素認証設定"
       cancel: "キャンセル"
+      danger_zone: "退会"
+      deactivate: "退会する"
   password_resets:
     new:
       title: "パスワードリセット"
@@ -309,6 +311,17 @@ ja:
         confirm_delete: "本当に削除しますか？"
       add_comment:
         comment: "コメント"
+  account:
+    deactivations:
+      new:
+        title: "退会する"
+        warning_reversible: "退会はいつでも管理者に連絡することで取り消すことができます。"
+        warning_history: "タスクやコメントなどのデータは削除されずに保持されます。"
+        warning_session: "退会後、現在のセッションおよびすべてのセッションが無効になります。"
+        reason_label: "退会理由（任意）"
+        confirm_label: "上記の内容を理解し、退会することに同意します"
+        submit: "退会する"
+        cancel: "キャンセル"
   emails:
     edit:
       title: "メールアドレスの変更"
@@ -338,6 +351,7 @@ ja:
       action: "パスワードをリセットする"
   controllers:
     sessions:
+      account_unavailable: "このアカウントは利用できません"
       create:
         success: "ログインしました！"
         failure: "メールアドレスまたはパスワードが正しくありません"
@@ -371,6 +385,9 @@ ja:
         added: "「%{name}」をプロジェクトに追加しました！"
       destroy:
         removed: "「%{name}」をプロジェクトから削除しました！"
+    account/deactivations:
+      create:
+        success: "退会処理が完了しました。ご利用いただきありがとうございました。"
     emails:
       update:
         success: "メールアドレスを更新しました。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
     resource :setting, only: %i[show create update]
     resource :challenge, only: %i[new create]
   end
+  namespace :account do
+    resource :deactivation, only: %i[new create]
+  end
 
   # Admin SPA shell
   get "/admin", to: "admin#index", as: :admin_root
@@ -54,6 +57,8 @@ Rails.application.routes.draw do
         end
         resources :users, only: %i[index show create update] do
           resource :roles, only: %i[show update], controller: "user_roles"
+          resource :deactivation, only: [:create], module: :users
+          resource :reactivation, only: [:create], module: :users
         end
         resources :roles, only: %i[index show create update destroy] do
           resource :permissions, only: %i[show update], controller: "role_permissions"

--- a/db/migrate/20260425081617_create_deactivated_users.rb
+++ b/db/migrate/20260425081617_create_deactivated_users.rb
@@ -1,0 +1,13 @@
+class CreateDeactivatedUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :deactivated_users do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
+      t.string :original_email, null: false
+      t.text :reason
+      t.references :deactivated_by, foreign_key: { to_table: :users, on_delete: :nullify }
+      t.datetime :deactivated_at, null: false
+      t.timestamps
+      t.index :deactivated_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -353,8 +353,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_081617) do
   add_foreign_key "comments", "users"
   add_foreign_key "deactivated_users", "users", column: "deactivated_by_id", on_delete: :nullify
   add_foreign_key "deactivated_users", "users", on_delete: :cascade
-  add_foreign_key "events", "projects"
-  add_foreign_key "events", "tasks"
+  add_foreign_key "events", "projects", on_delete: :nullify
+  add_foreign_key "events", "tasks", on_delete: :nullify
   add_foreign_key "events", "users"
   add_foreign_key "llm_models", "llm_providers"
   add_foreign_key "project_members", "projects"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_081617) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -61,11 +61,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
   create_table "comments", force: :cascade do |t|
     t.text "content"
     t.datetime "created_at", null: false
-    t.integer "task_id", null: false
+    t.bigint "task_id", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["task_id"], name: "index_comments_on_task_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "deactivated_users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "deactivated_at", null: false
+    t.integer "deactivated_by_id"
+    t.string "original_email", null: false
+    t.text "reason"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["deactivated_at"], name: "index_deactivated_users_on_deactivated_at"
+    t.index ["deactivated_by_id"], name: "index_deactivated_users_on_deactivated_by_id"
+    t.index ["user_id"], name: "index_deactivated_users_on_user_id", unique: true
   end
 
   create_table "events", force: :cascade do |t|
@@ -90,7 +103,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
     t.boolean "active", default: true
     t.datetime "created_at", null: false
     t.string "display_name"
-    t.integer "llm_provider_id", null: false
+    t.bigint "llm_provider_id", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["llm_provider_id", "name"], name: "index_llm_models_on_llm_provider_id_and_name", unique: true
@@ -118,9 +131,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
 
   create_table "project_members", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "project_id", null: false
+    t.bigint "project_id", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["project_id"], name: "index_project_members_on_project_id"
     t.index ["user_id"], name: "index_project_members_on_user_id"
   end
@@ -130,7 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
     t.datetime "created_at", null: false
     t.boolean "dedicated", default: false, null: false
     t.string "name", null: false
-    t.integer "owner_id", null: false
+    t.bigint "owner_id", null: false
     t.datetime "updated_at", null: false
     t.index ["owner_id"], name: "index_projects_on_owner_id"
   end
@@ -156,8 +169,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
 
   create_table "role_permissions", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "permission_id", null: false
-    t.integer "role_id", null: false
+    t.bigint "permission_id", null: false
+    t.bigint "role_id", null: false
     t.datetime "updated_at", null: false
     t.index ["permission_id"], name: "index_role_permissions_on_permission_id"
     t.index ["role_id", "permission_id"], name: "index_role_permissions_on_role_id_and_permission_id", unique: true
@@ -188,7 +201,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
     t.text "description"
     t.date "due_date"
     t.string "name", null: false
-    t.integer "suggestion_response_id", null: false
+    t.bigint "suggestion_response_id", null: false
     t.datetime "updated_at", null: false
     t.index ["suggestion_response_id"], name: "index_suggested_tasks_on_suggestion_response_id"
   end
@@ -226,7 +239,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
 
   create_table "suggestion_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "llm_model_id"
+    t.bigint "llm_model_id"
     t.text "raw_request"
     t.integer "suggestion_config_entry_id"
     t.integer "suggestion_session_id", null: false
@@ -241,7 +254,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
     t.datetime "created_at", null: false
     t.integer "prompt_tokens", default: 0, null: false
     t.text "raw_response"
-    t.integer "suggestion_request_id", null: false
+    t.bigint "suggestion_request_id", null: false
     t.datetime "updated_at", null: false
     t.index ["suggestion_request_id"], name: "index_suggestion_responses_on_suggestion_request_id"
   end
@@ -291,14 +304,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.integer "assignee_id"
+    t.bigint "assignee_id"
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
-    t.integer "created_by_id"
+    t.bigint "created_by_id"
     t.date "due_date", null: false
     t.string "name", null: false
     t.integer "parent_id"
-    t.integer "project_id", null: false
+    t.bigint "project_id", null: false
     t.integer "task_series_id"
     t.datetime "updated_at", null: false
     t.index ["assignee_id"], name: "index_tasks_on_assignee_id"
@@ -311,9 +324,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
 
   create_table "user_roles", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "role_id", null: false
+    t.bigint "role_id", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["role_id"], name: "index_user_roles_on_role_id"
     t.index ["user_id", "role_id"], name: "index_user_roles_on_user_id_and_role_id", unique: true
     t.index ["user_id"], name: "index_user_roles_on_user_id"
@@ -338,8 +351,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_123214) do
   add_foreign_key "admin_login_histories", "users"
   add_foreign_key "comments", "tasks"
   add_foreign_key "comments", "users"
-  add_foreign_key "events", "projects", on_delete: :nullify
-  add_foreign_key "events", "tasks", on_delete: :nullify
+  add_foreign_key "deactivated_users", "users", column: "deactivated_by_id", on_delete: :nullify
+  add_foreign_key "deactivated_users", "users", on_delete: :cascade
+  add_foreign_key "events", "projects"
+  add_foreign_key "events", "tasks"
   add_foreign_key "events", "users"
   add_foreign_key "llm_models", "llm_providers"
   add_foreign_key "project_members", "projects"

--- a/lib/tasks/test_suites.rake
+++ b/lib/tasks/test_suites.rake
@@ -33,13 +33,18 @@ namespace :test do
   task auth: :environment do
     Rails::TestUnit::Runner.run_from_rake("test", [
       "test/models/user_test.rb",
+      "test/models/deactivated_user_test.rb",
+      "test/services/account/deactivation_service_test.rb",
       "test/controllers/sessions_controller_test.rb",
       "test/controllers/passwords_controller_test.rb",
       "test/controllers/password_resets_controller_test.rb",
       "test/controllers/email_verifications_controller_test.rb",
       "test/controllers/emails_controller_test.rb",
       "test/controllers/users_controller_test.rb",
+      "test/controllers/application_controller_test.rb",
+      "test/controllers/account/deactivations_controller_test.rb",
       "test/controllers/totp",
+      "test/helpers/users_helper_test.rb",
       "test/middleware",
     ])
   end

--- a/test/controllers/account/deactivations_controller_test.rb
+++ b/test/controllers/account/deactivations_controller_test.rb
@@ -142,5 +142,42 @@ module Account
       assert_response :unprocessable_content
       assert_not_nil session[:user_id]
     end
+
+    # Server-side password_challenge guard: prevents bypass when the inner
+    # `password_challenge` key is omitted from the user params. `params.expect`
+    # only requires the `:user` wrapper, not each permitted inner key, and
+    # `has_secure_password` skips validation when the attribute was never
+    # assigned a non-nil value — so without this guard, `@user.save` would
+    # succeed silently and deactivate the account without password verification.
+    test "POST create without password_challenge inner key is rejected with 422" do
+      user = users(:regular_user)
+      login_as(user)
+
+      Account::DeactivationService.expects(:call).never
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { reason: "no password challenge submitted" },
+          confirm_deactivation: "1",
+        }
+      end
+      assert_response :unprocessable_content
+      assert_not_nil session[:user_id], "session must remain live"
+      assert_not user.reload.deactivated?
+    end
+
+    test "POST create with blank password_challenge is rejected with 422" do
+      user = users(:regular_user)
+      login_as(user)
+
+      Account::DeactivationService.expects(:call).never
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: "", reason: "blank challenge" },
+          confirm_deactivation: "1",
+        }
+      end
+      assert_response :unprocessable_content
+      assert_not user.reload.deactivated?
+    end
   end
 end

--- a/test/controllers/account/deactivations_controller_test.rb
+++ b/test/controllers/account/deactivations_controller_test.rb
@@ -21,6 +21,7 @@ module Account
       assert_difference("DeactivatedUser.count", 1) do
         post account_deactivation_path, params: {
           user: { password_challenge: TEST_PASSWORD, reason: "Self-deactivated for test" },
+          confirm_deactivation: "1",
         }
       end
 
@@ -41,6 +42,7 @@ module Account
       assert_no_difference("DeactivatedUser.count") do
         post account_deactivation_path, params: {
           user: { password_challenge: "wrong-password", reason: "" },
+          confirm_deactivation: "1",
         }
       end
 
@@ -90,6 +92,55 @@ module Account
         }
       end
       assert_redirected_to user_path
+    end
+
+    # Race / double-submit: service raises RecordNotUnique → recoverable form error (not 500)
+    test "POST create renders form with 422 when DeactivationService raises RecordNotUnique" do
+      user = users(:regular_user)
+      login_as(user)
+
+      Account::DeactivationService.expects(:call).raises(ActiveRecord::RecordNotUnique.new("uniq"))
+
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: TEST_PASSWORD, reason: "" },
+          confirm_deactivation: "1",
+        }
+      end
+      assert_response :unprocessable_content
+      assert_not_nil session[:user_id], "session must remain live for recovery"
+    end
+
+    test "POST create renders form with 422 when DeactivationService raises RecordInvalid" do
+      user = users(:regular_user)
+      login_as(user)
+
+      record = User.new
+      record.errors.add(:base, "Some validation failure")
+      Account::DeactivationService.expects(:call).raises(ActiveRecord::RecordInvalid.new(record))
+
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: TEST_PASSWORD, reason: "" },
+          confirm_deactivation: "1",
+        }
+      end
+      assert_response :unprocessable_content
+    end
+
+    # Server-side confirm_deactivation guard: prevents bypass via direct POST
+    test "POST create without confirm_deactivation is rejected with 422 (defense-in-depth)" do
+      user = users(:regular_user)
+      login_as(user)
+
+      Account::DeactivationService.expects(:call).never
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: TEST_PASSWORD, reason: "" },
+        }
+      end
+      assert_response :unprocessable_content
+      assert_not_nil session[:user_id]
     end
   end
 end

--- a/test/controllers/account/deactivations_controller_test.rb
+++ b/test/controllers/account/deactivations_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module Account
+  class DeactivationsControllerTest < ActionDispatch::IntegrationTest
+    test "GET new requires login" do
+      get new_account_deactivation_path
+      assert_redirected_to login_path
+    end
+
+    test "GET new renders the form for logged-in users" do
+      login_as(users(:regular_user))
+      get new_account_deactivation_path
+      assert_response :success
+    end
+
+    test "POST create with the correct password deactivates the user, resets session, and redirects to login" do
+      user = users(:regular_user)
+      original_email = user.email
+      login_as(user)
+
+      assert_difference("DeactivatedUser.count", 1) do
+        post account_deactivation_path, params: {
+          user: { password_challenge: TEST_PASSWORD, reason: "Self-deactivated for test" },
+        }
+      end
+
+      assert_redirected_to login_path
+      assert_nil session[:user_id]
+
+      user.reload
+      assert user.deactivated?
+      assert_equal original_email, user.deactivation.original_email
+      assert_equal "Self-deactivated for test", user.deactivation.reason
+      assert_equal user.id, user.deactivation.deactivated_by_id, "self-deactivation records the user as performer"
+    end
+
+    test "POST create with wrong password re-renders new with 422 and does not deactivate" do
+      user = users(:regular_user)
+      login_as(user)
+
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: "wrong-password", reason: "" },
+        }
+      end
+
+      assert_response :unprocessable_content
+      assert_not_nil session[:user_id], "session is preserved when validation fails"
+    end
+
+    test "POST create requires login" do
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: { user: { password_challenge: "x", reason: "" } }
+      end
+      assert_redirected_to login_path
+    end
+  end
+end

--- a/test/controllers/account/deactivations_controller_test.rb
+++ b/test/controllers/account/deactivations_controller_test.rb
@@ -62,5 +62,34 @@ module Account
       end
       assert_response :bad_request
     end
+
+    # Admin self-deactivation lockout guard (Plan §13: Admin 自己 Deactivate ブロック)
+    test "GET new is blocked for admin-capable users (prevents admin panel lockout)" do
+      login_as(users(:admin_user))
+      get new_account_deactivation_path
+      assert_redirected_to user_path
+      follow_redirect!
+      assert_match I18n.t("controllers.account/deactivations.admin_blocked"), flash[:alert].to_s
+    end
+
+    test "POST create is blocked for admin-capable users" do
+      login_as(users(:admin_user))
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: TEST_PASSWORD, reason: "" },
+        }
+      end
+      assert_redirected_to user_path
+    end
+
+    test "POST create is blocked for user_manager (User:write capable, also locks panel)" do
+      login_as(users(:user_manager))
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {
+          user: { password_challenge: TEST_PASSWORD, reason: "" },
+        }
+      end
+      assert_redirected_to user_path
+    end
   end
 end

--- a/test/controllers/account/deactivations_controller_test.rb
+++ b/test/controllers/account/deactivations_controller_test.rb
@@ -54,5 +54,13 @@ module Account
       end
       assert_redirected_to login_path
     end
+
+    test "POST create with malformed params (missing user key) returns 400 not 500" do
+      login_as(users(:regular_user))
+      assert_no_difference("DeactivatedUser.count") do
+        post account_deactivation_path, params: {}
+      end
+      assert_response :bad_request
+    end
   end
 end

--- a/test/controllers/api/v1/admin/users/deactivations_controller_test.rb
+++ b/test/controllers/api/v1/admin/users/deactivations_controller_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+module Api
+  module V1
+    module Admin
+      module Users
+        class DeactivationsControllerTest < ActionDispatch::IntegrationTest
+          # ---------------------------------------------------------------
+          # Auth 4-pattern: unauthenticated → 401, regular user → 401,
+          # admin without User:write → 403, admin with User:write → 204
+          # ---------------------------------------------------------------
+          test "POST create returns 401 when not logged in" do
+            target = users(:regular_user)
+            post api_v1_admin_user_deactivation_path(target)
+            assert_response :unauthorized
+            assert_equal "Unauthorized", response.parsed_body["error"]
+          end
+
+          test "POST create returns 401 when logged in as regular user" do
+            login_as(users(:regular_user))
+            target = users(:no_role_user)
+            post api_v1_admin_user_deactivation_path(target)
+            assert_response :unauthorized
+            assert_equal "Unauthorized", response.parsed_body["error"]
+          end
+
+          test "POST create returns 403 when admin lacks User:write capability" do
+            login_as_admin_api_read_only # user_viewer: User:read only
+            target = users(:regular_user)
+            post api_v1_admin_user_deactivation_path(target)
+            assert_response :forbidden
+          end
+
+          test "POST create returns 204 and calls service when admin has User:write" do
+            login_as_admin_api
+            target = users(:regular_user)
+            Account::DeactivationService.expects(:call).with(
+              user: target,
+              performer: users(:admin_user),
+              reason: nil,
+              self_deactivated: false,
+            ).returns(true)
+            post api_v1_admin_user_deactivation_path(target), params: { reason: nil }, as: :json
+            assert_response :no_content
+          end
+
+          test "POST create passes reason param to service" do
+            login_as_admin_api
+            target = users(:regular_user)
+            Account::DeactivationService.expects(:call).with(
+              user: target,
+              performer: users(:admin_user),
+              reason: "Violated terms",
+              self_deactivated: false,
+            ).returns(true)
+            post api_v1_admin_user_deactivation_path(target),
+                 params: { reason: "Violated terms" }, as: :json
+            assert_response :no_content
+          end
+
+          test "POST create returns 404 when target is an admin account" do
+            login_as_admin_api
+            admin_target = users(:user_manager)
+            Account::DeactivationService.expects(:call).never
+            post api_v1_admin_user_deactivation_path(admin_target)
+            assert_response :not_found
+          end
+
+          test "POST create returns 404 when deactivating own admin account" do
+            login_as_admin_api
+            own_account = users(:admin_user)
+            Account::DeactivationService.expects(:call).never
+            post api_v1_admin_user_deactivation_path(own_account)
+            assert_response :not_found
+          end
+
+          test "POST create returns 404 for non-existent user" do
+            login_as_admin_api
+            Account::DeactivationService.expects(:call).never
+            post api_v1_admin_user_deactivation_path(user_id: 0)
+            assert_response :not_found
+          end
+
+          test "POST create returns 422 with errors when service raises RecordInvalid" do
+            login_as_admin_api
+            target = users(:regular_user)
+            error_record = DeactivatedUser.new
+            error_record.errors.add(:base, "Validation failed")
+            Account::DeactivationService.expects(:call).raises(
+              ActiveRecord::RecordInvalid.new(error_record),
+            )
+            post api_v1_admin_user_deactivation_path(target), as: :json
+            assert_response :unprocessable_entity
+            assert response.parsed_body.key?("errors")
+          end
+
+          test "POST create succeeds when user_manager calls it" do
+            login_as_admin_api(users(:user_manager))
+            target = users(:regular_user)
+            Account::DeactivationService.expects(:call).with(
+              user: target,
+              performer: users(:user_manager),
+              reason: nil,
+              self_deactivated: false,
+            ).returns(true)
+            post api_v1_admin_user_deactivation_path(target), as: :json
+            assert_response :no_content
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/admin/users/deactivations_controller_test.rb
+++ b/test/controllers/api/v1/admin/users/deactivations_controller_test.rb
@@ -81,6 +81,20 @@ module Api
             assert_response :not_found
           end
 
+          test "POST create returns 404 (not 500) when target is already deactivated" do
+            login_as_admin_api
+            target = users(:regular_user)
+            DeactivatedUser.create!(
+              user: target,
+              original_email: target.email,
+              deactivated_at: Time.current,
+            )
+
+            Account::DeactivationService.expects(:call).never
+            post api_v1_admin_user_deactivation_path(target)
+            assert_response :not_found
+          end
+
           test "POST create returns 422 with errors when service raises RecordInvalid" do
             login_as_admin_api
             target = users(:regular_user)

--- a/test/controllers/api/v1/admin/users/deactivations_controller_test.rb
+++ b/test/controllers/api/v1/admin/users/deactivations_controller_test.rb
@@ -108,6 +108,20 @@ module Api
             assert response.parsed_body.key?("errors")
           end
 
+          # Race / double-submit: 2nd request hits UNIQUE constraint on
+          # deactivated_users.user_id → 422, not unrescued 500
+          test "POST create returns 422 (not 500) when service raises RecordNotUnique" do
+            login_as_admin_api
+            target = users(:regular_user)
+            Account::DeactivationService.expects(:call).raises(
+              ActiveRecord::RecordNotUnique.new("UNIQUE constraint failed"),
+            )
+            post api_v1_admin_user_deactivation_path(target), as: :json
+            assert_response :unprocessable_entity
+            assert response.parsed_body.key?("errors"),
+                   "response must carry an errors body, not a 500 page"
+          end
+
           test "POST create succeeds when user_manager calls it" do
             login_as_admin_api(users(:user_manager))
             target = users(:regular_user)

--- a/test/controllers/api/v1/admin/users/reactivations_controller_test.rb
+++ b/test/controllers/api/v1/admin/users/reactivations_controller_test.rb
@@ -134,6 +134,22 @@ module Api
                        "original_email_conflict must NOT be present when new_email was provided"
           end
 
+          # Race: service raises RecordNotFound when the deactivation row vanished
+          # between the controller's find_by and the service's lock.find_by
+          # (concurrent reactivation by another admin). Must surface as 404, not 500.
+          test "POST create returns 404 when service raises RecordNotFound (concurrent reactivation)" do
+            login_as_admin_api
+            target = users(:deactivated_user)
+            Account::DeactivationService.expects(:reactivate).with(
+              user: target,
+              performer: users(:admin_user),
+              new_email: nil,
+            ).raises(ActiveRecord::RecordNotFound)
+            post api_v1_admin_user_reactivation_path(target), as: :json
+            assert_response :not_found
+            assert_equal "Not Found", response.parsed_body["error"]
+          end
+
           test "POST create succeeds when user_manager calls it" do
             login_as_admin_api(users(:user_manager))
             target = users(:deactivated_user)

--- a/test/controllers/api/v1/admin/users/reactivations_controller_test.rb
+++ b/test/controllers/api/v1/admin/users/reactivations_controller_test.rb
@@ -97,6 +97,23 @@ module Api
             assert_equal true, body["original_email_conflict"]
           end
 
+          # 422 shapes: new_email omitted but error is unrelated to email → no conflict flag
+          test "POST create omits original_email_conflict when RecordInvalid error has no email errors" do
+            login_as_admin_api
+            target = users(:deactivated_user)
+            error_record = User.new
+            error_record.errors.add(:base, "Some unrelated validation failure")
+            Account::DeactivationService.expects(:reactivate).raises(
+              ActiveRecord::RecordInvalid.new(error_record),
+            )
+            post api_v1_admin_user_reactivation_path(target), as: :json
+            assert_response :unprocessable_entity
+            body = response.parsed_body
+            assert body.key?("errors")
+            assert_not body.key?("original_email_conflict"),
+                       "flag must be tied to email errors, not any RecordInvalid"
+          end
+
           # 422 shapes: new_email provided → NO original_email_conflict key
           test "POST create returns 422 without original_email_conflict when new_email provided and conflicts" do
             login_as_admin_api

--- a/test/controllers/api/v1/admin/users/reactivations_controller_test.rb
+++ b/test/controllers/api/v1/admin/users/reactivations_controller_test.rb
@@ -1,0 +1,135 @@
+require "test_helper"
+
+module Api
+  module V1
+    module Admin
+      module Users
+        class ReactivationsControllerTest < ActionDispatch::IntegrationTest
+          # ---------------------------------------------------------------
+          # Auth 4-pattern: unauthenticated → 401, regular user → 401,
+          # admin without User:write → 403, admin with User:write → 204
+          # ---------------------------------------------------------------
+          test "POST create returns 401 when not logged in" do
+            target = users(:deactivated_user)
+            post api_v1_admin_user_reactivation_path(target)
+            assert_response :unauthorized
+            assert_equal "Unauthorized", response.parsed_body["error"]
+          end
+
+          test "POST create returns 401 when logged in as regular user" do
+            login_as(users(:regular_user))
+            target = users(:deactivated_user)
+            post api_v1_admin_user_reactivation_path(target)
+            assert_response :unauthorized
+            assert_equal "Unauthorized", response.parsed_body["error"]
+          end
+
+          test "POST create returns 403 when admin lacks User:write capability" do
+            login_as_admin_api_read_only # user_viewer: User:read only
+            target = users(:deactivated_user)
+            post api_v1_admin_user_reactivation_path(target)
+            assert_response :forbidden
+          end
+
+          test "POST create returns 204 and calls service when admin has User:write (no new_email)" do
+            login_as_admin_api
+            target = users(:deactivated_user)
+            Account::DeactivationService.expects(:reactivate).with(
+              user: target,
+              performer: users(:admin_user),
+              new_email: nil,
+            ).returns(true)
+            post api_v1_admin_user_reactivation_path(target), as: :json
+            assert_response :no_content
+          end
+
+          test "POST create returns 204 and calls service with new_email when provided" do
+            login_as_admin_api
+            target = users(:deactivated_user)
+            Account::DeactivationService.expects(:reactivate).with(
+              user: target,
+              performer: users(:admin_user),
+              new_email: "newaddress@example.com",
+            ).returns(true)
+            post api_v1_admin_user_reactivation_path(target),
+                 params: { new_email: "newaddress@example.com" }, as: :json
+            assert_response :no_content
+          end
+
+          test "POST create returns 404 when target user is active (not in deactivated scope)" do
+            login_as_admin_api
+            active_target = users(:regular_user)
+            Account::DeactivationService.expects(:reactivate).never
+            post api_v1_admin_user_reactivation_path(active_target), as: :json
+            assert_response :not_found
+          end
+
+          test "POST create returns 404 when target user is an admin account" do
+            login_as_admin_api
+            admin_target = users(:user_manager)
+            Account::DeactivationService.expects(:reactivate).never
+            post api_v1_admin_user_reactivation_path(admin_target), as: :json
+            assert_response :not_found
+          end
+
+          test "POST create returns 404 for non-existent user" do
+            login_as_admin_api
+            Account::DeactivationService.expects(:reactivate).never
+            post api_v1_admin_user_reactivation_path(user_id: 0), as: :json
+            assert_response :not_found
+          end
+
+          # 422 shapes: new_email omitted → original_email_conflict: true
+          test "POST create returns 422 with original_email_conflict when new_email omitted and original is taken" do
+            login_as_admin_api
+            target = users(:deactivated_user)
+            error_record = User.new
+            error_record.errors.add(:email, "has already been taken")
+            Account::DeactivationService.expects(:reactivate).with(
+              user: target,
+              performer: users(:admin_user),
+              new_email: nil,
+            ).raises(ActiveRecord::RecordInvalid.new(error_record))
+            post api_v1_admin_user_reactivation_path(target), as: :json
+            assert_response :unprocessable_entity
+            body = response.parsed_body
+            assert body.key?("errors")
+            assert_equal true, body["original_email_conflict"]
+          end
+
+          # 422 shapes: new_email provided → NO original_email_conflict key
+          test "POST create returns 422 without original_email_conflict when new_email provided and conflicts" do
+            login_as_admin_api
+            target = users(:deactivated_user)
+            error_record = User.new
+            error_record.errors.add(:email, "has already been taken")
+            Account::DeactivationService.expects(:reactivate).with(
+              user: target,
+              performer: users(:admin_user),
+              new_email: "taken@example.com",
+            ).raises(ActiveRecord::RecordInvalid.new(error_record))
+            post api_v1_admin_user_reactivation_path(target),
+                 params: { new_email: "taken@example.com" }, as: :json
+            assert_response :unprocessable_entity
+            body = response.parsed_body
+            assert body.key?("errors")
+            assert_not body.key?("original_email_conflict"),
+                       "original_email_conflict must NOT be present when new_email was provided"
+          end
+
+          test "POST create succeeds when user_manager calls it" do
+            login_as_admin_api(users(:user_manager))
+            target = users(:deactivated_user)
+            Account::DeactivationService.expects(:reactivate).with(
+              user: target,
+              performer: users(:user_manager),
+              new_email: nil,
+            ).returns(true)
+            post api_v1_admin_user_reactivation_path(target), as: :json
+            assert_response :no_content
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/admin/users_controller_test.rb
+++ b/test/controllers/api/v1/admin/users_controller_test.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module Admin
       class UsersControllerTest < ActionDispatch::IntegrationTest
-        # index
+        # index — no status param (defaults to active)
         test "GET index returns 401 when not logged in" do
           get api_v1_admin_users_path
           assert_response :unauthorized
@@ -28,7 +28,6 @@ module Api
           emails = json["users"].pluck("email")
           # Non-admin users should be included
           assert_includes emails, users(:regular_user).email
-          assert_includes emails, users(:no_role_user).email
           # Admin accounts should NOT be included
           assert_not_includes emails, users(:admin_user).email
           assert_not_includes emails, users(:user_manager).email
@@ -221,13 +220,13 @@ module Api
 
         # リソース単位の read 認可テスト（User:read が必要）
         test "GET index returns 403 when logged in as user without User:read permission" do
-          login_as_llm_admin_api  # llm_admin: Admin:read + LlmProvider 権限のみ（User:read なし）
+          login_as_llm_admin_api # llm_admin: Admin:read + LlmProvider 権限のみ（User:read なし）
           get api_v1_admin_users_path
           assert_response :forbidden
         end
 
         test "GET show returns 403 when logged in as user without User:read permission" do
-          login_as_llm_admin_api  # llm_admin: Admin:read + LlmProvider 権限のみ（User:read なし）
+          login_as_llm_admin_api # llm_admin: Admin:read + LlmProvider 権限のみ（User:read なし）
           get api_v1_admin_user_path(users(:no_role_user))
           assert_response :forbidden
         end
@@ -291,8 +290,120 @@ module Api
           login_as_admin_api
           get api_v1_admin_users_path, params: { q: "" }
           assert_response :success
-          non_admin_count = User.non_admin_accounts.count
-          assert_equal non_admin_count, response.parsed_body["users"].size
+          non_admin_active_count = User.non_admin_accounts.active.count
+          assert_equal non_admin_active_count, response.parsed_body["users"].size
+        end
+
+        # ---------------------------------------------------------------
+        # Status filter tests
+        # ---------------------------------------------------------------
+        test "GET index with status=active returns only active non-admin users" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { status: "active" }
+          assert_response :success
+          user_list = response.parsed_body["users"]
+          emails = user_list.pluck("email")
+          assert_includes emails, users(:regular_user).email
+          assert_not_includes emails, users(:deactivated_user).email
+        end
+
+        test "GET index with status=deactivated returns only deactivated non-admin users" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { status: "deactivated" }
+          assert_response :success
+          user_list = response.parsed_body["users"]
+          ids = user_list.pluck("id")
+          assert_includes ids, users(:deactivated_user).id
+          assert_not_includes ids, users(:regular_user).id
+        end
+
+        test "GET index with status=all returns disjoint union of active and deactivated" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { status: "active" }
+          active_ids = response.parsed_body["users"].pluck("id")
+
+          get api_v1_admin_users_path, params: { status: "deactivated" }
+          deactivated_ids = response.parsed_body["users"].pluck("id")
+
+          get api_v1_admin_users_path, params: { status: "all" }
+          all_ids = response.parsed_body["users"].pluck("id")
+
+          assert_equal (active_ids + deactivated_ids).sort, all_ids.sort,
+                       "status=all must equal active + deactivated (disjoint)"
+          assert_empty active_ids & deactivated_ids, "active and deactivated sets must be disjoint"
+        end
+
+        # ---------------------------------------------------------------
+        # Sentinel email leak prevention
+        # Deactivated users have email == sentinel (@deactivated.invalid).
+        # The `email` field in the response for deactivated users must NOT
+        # expose the sentinel — expose original_email instead.
+        # ---------------------------------------------------------------
+        test "GET index status=deactivated does not leak sentinel emails in response" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { status: "deactivated" }
+          assert_response :success
+          body = response.body
+          assert_no_match(/@deactivated\.invalid/, body,
+                          "Sentinel email must not appear in index response")
+        end
+
+        test "GET index status=all does not leak sentinel emails in response" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { status: "all" }
+          assert_response :success
+          body = response.body
+          assert_no_match(/@deactivated\.invalid/, body,
+                          "Sentinel email must not appear in all-status response")
+        end
+
+        test "GET show for deactivated user does not leak sentinel email" do
+          login_as_admin_api
+          target = users(:deactivated_user)
+          get api_v1_admin_user_path(target)
+          assert_response :success
+          body = response.body
+          assert_no_match(/@deactivated\.invalid/, body,
+                          "Sentinel email must not appear in show response")
+          json = response.parsed_body
+          assert_equal deactivated_users(:deactivated_regular_user).original_email,
+                       json["original_email"]
+        end
+
+        test "GET index status=deactivated response includes deactivation fields" do
+          login_as_admin_api
+          get api_v1_admin_users_path, params: { status: "deactivated" }
+          assert_response :success
+          deactivated = response.parsed_body["users"].find { |u| u["id"] == users(:deactivated_user).id }
+          assert_not_nil deactivated
+          assert deactivated.key?("deactivated_at")
+          assert deactivated.key?("deactivation_reason")
+          assert deactivated.key?("deactivated_by")
+          assert deactivated.key?("original_email")
+        end
+
+        test "GET show for deactivated user includes deactivation fields" do
+          login_as_admin_api
+          target = users(:deactivated_user)
+          get api_v1_admin_user_path(target)
+          assert_response :success
+          json = response.parsed_body
+          assert json.key?("deactivated_at")
+          assert json.key?("deactivation_reason")
+          assert json.key?("deactivated_by")
+          assert json.key?("original_email")
+        end
+
+        test "GET show for active user has nil deactivation fields" do
+          login_as_admin_api
+          target = users(:regular_user)
+          get api_v1_admin_user_path(target)
+          assert_response :success
+          json = response.parsed_body
+          assert_nil json["deactivated_at"]
+          assert_nil json["deactivation_reason"]
+          assert_nil json["deactivated_by"]
+          assert_nil json["original_email"]
         end
       end
     end

--- a/test/controllers/api/v1/admin/users_controller_test.rb
+++ b/test/controllers/api/v1/admin/users_controller_test.rb
@@ -195,6 +195,27 @@ module Api
           assert response.parsed_body.key?("errors")
         end
 
+        # Deactivated users must NOT be modifiable via update —
+        # otherwise the sentinel email gets overwritten with the original,
+        # breaking the re-registration guarantee.
+        test "PATCH update returns 422 for deactivated user without modifying record" do
+          login_as_admin_api
+          target = users(:deactivated_user)
+          original_sentinel_email = target.email
+          original_name = target.name
+
+          patch api_v1_admin_user_path(target),
+                params: { user: { email: "hijack@example.com", name: "Hijacked" } }
+
+          assert_response :unprocessable_entity
+          assert_equal "Cannot modify a deactivated user", response.parsed_body["error"]
+
+          target.reload
+          assert_equal original_sentinel_email, target.email,
+                       "Sentinel email must not be overwritten by update on deactivated user"
+          assert_equal original_name, target.name
+        end
+
         # 操作別認可テスト
         test "POST create returns 403 when logged in as read-only admin" do
           login_as_admin_api_read_only

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class ApplicationControllerEnforceActiveAccountTest < ActionDispatch::IntegrationTest
+  test "deactivated user is logged out and redirected to login on next authed request" do
+    user = users(:regular_user)
+    login_as(user)
+    assert_equal user.id, session[:user_id]
+
+    Account::DeactivationService.call(user: user, performer: user)
+
+    get project_path(user.inbox_project)
+    assert_redirected_to login_path
+    assert_nil session[:user_id]
+
+    follow_redirect!
+    expected_alert = I18n.t("controllers.sessions.account_unavailable")
+    assert_match expected_alert, flash[:alert].to_s
+  end
+
+  test "active users are not affected by enforce_active_account" do
+    user = users(:regular_user)
+    login_as(user)
+
+    get project_path(user.inbox_project)
+    assert_response :success
+    assert_equal user.id, session[:user_id]
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -33,4 +33,24 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to project_path(user.inbox_project)
     assert_equal user.id, session[:user_id]
   end
+
+  test "退会済みユーザーは元のメールアドレスでログインできない (汎用エラー)" do
+    user = users(:regular_user)
+    original_email = user.email
+    Account::DeactivationService.call(user: user, performer: user)
+
+    post login_path, params: { email: original_email, password: TEST_PASSWORD }
+    assert_response :unprocessable_content
+    assert_nil session[:user_id]
+  end
+
+  test "退会済みユーザーは sentinel email でもログインできない" do
+    user = users(:regular_user)
+    Account::DeactivationService.call(user: user, performer: user)
+    sentinel_email = user.reload.email
+
+    post login_path, params: { email: sentinel_email, password: TEST_PASSWORD }
+    assert_response :unprocessable_content
+    assert_nil session[:user_id]
+  end
 end

--- a/test/fixtures/deactivated_users.yml
+++ b/test/fixtures/deactivated_users.yml
@@ -1,0 +1,7 @@
+deactivated_regular_user:
+  user: deactivated_user
+  original_email: deactivatedoriginal@example.com
+  reason: Account deactivated by admin
+  deactivated_by: admin_user
+  deactivated_at: <%= 1.day.ago %>
+

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -100,3 +100,13 @@ llm_admin_user:
   totp_secret: SBSWY3DPEHPK3PXW
   totp_enabled: false
   verified: true
+
+# Deactivated user fixture — email is sentinel, original_email lives in deactivated_users fixture
+deactivated_user:
+  name: Deactivated User
+  email: deactivated+999+aabbccdd11223344@deactivated.invalid
+  password_digest: <%= BCrypt::Password.create('HoboTest!Str0ng#2024') %>
+  locale: ja
+  totp_secret: TBSWY3DPEHPK3PXY
+  totp_enabled: false
+  verified: true

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class UsersHelperTest < ActionView::TestCase
+  include Turbo::FramesHelper
+
+  # ActionView::TestCase includes ActionView::Helpers, ActionView::Context, etc.
+  # Helper modules under test are included automatically via `helper_class`;
+  # Turbo Rails helpers are NOT auto-included so we pull in FramesHelper for the
+  # active-user avatar branch which calls turbo_frame_tag.
+
+  # Build minimal User-like objects using actual AR fixtures to avoid complex stubs.
+
+  setup do
+    @active_user = users(:regular_user) # active, no deactivation record
+    @deactivated_user = users(:deactivated_user) # has a deactivation record
+    @admin_viewer = users(:admin_user)        # has system admin role → admin? == true
+    @regular_viewer = users(:regular_user)    # no admin role → admin? == false
+  end
+
+  # ---------------------------------------------------------------------------
+  # display_user_name
+  # ---------------------------------------------------------------------------
+
+  test "display_user_name: admin viewer sees raw name for active user" do
+    result = display_user_name(@active_user, viewer: @admin_viewer)
+    assert_equal @active_user.user_name, result
+  end
+
+  test "display_user_name: admin viewer sees raw name for deactivated user" do
+    result = display_user_name(@deactivated_user, viewer: @admin_viewer)
+    assert_equal @deactivated_user.user_name, result
+  end
+
+  test "display_user_name: non-admin viewer sees raw name for active user" do
+    result = display_user_name(@active_user, viewer: @regular_viewer)
+    assert_equal @active_user.user_name, result
+  end
+
+  test "display_user_name: non-admin viewer sees masked name for deactivated user" do
+    result = display_user_name(@deactivated_user, viewer: @regular_viewer)
+    raw = @deactivated_user.user_name
+    expected = "#{raw[0..1]}**"
+    assert_equal expected, result
+  end
+
+  test "display_user_name: masking uses first 2 chars of user_name" do
+    # Confirm the mask format is exactly `first_two_chars + "**"`
+    result = display_user_name(@deactivated_user, viewer: @regular_viewer)
+    assert result.end_with?("**"), "Expected result to end with '**', got: #{result.inspect}"
+    assert_equal 4, result.length, "Mask should be 2 chars + '**' == 4 chars (user_name starts with 'De')"
+  end
+
+  test "display_user_name: nil viewer treated as non-admin (shows mask for deactivated)" do
+    result = display_user_name(@deactivated_user, viewer: nil)
+    raw = @deactivated_user.user_name
+    expected = "#{raw[0..1]}**"
+    assert_equal expected, result
+  end
+
+  # ---------------------------------------------------------------------------
+  # display_user_avatar
+  # ---------------------------------------------------------------------------
+
+  test "display_user_avatar: returns person_off markup for deactivated user" do
+    result = display_user_avatar(@deactivated_user, viewer: @regular_viewer)
+    assert_includes result, "person_off", "Expected person_off icon in deactivated avatar"
+    assert_includes result, "user-avatar--deactivated", "Expected deactivated CSS class"
+  end
+
+  test "display_user_avatar: deactivated avatar is the same regardless of viewer role" do
+    result_admin = display_user_avatar(@deactivated_user, viewer: @admin_viewer)
+    result_regular = display_user_avatar(@deactivated_user, viewer: @regular_viewer)
+    # Both should render person_off markup (identity redacted visually)
+    assert_includes result_admin, "person_off"
+    assert_includes result_regular, "person_off"
+  end
+
+  test "display_user_avatar: active user without avatar renders initial span" do
+    # regular_user has no avatar attached in test fixtures
+    result = display_user_avatar(@active_user, viewer: @regular_viewer)
+    # Should render a turbo_frame wrapping an initial-sign span (existing user_icon behavior)
+    assert_includes result, "user-avatar"
+    assert_not_includes result, "person_off"
+  end
+
+  # ---------------------------------------------------------------------------
+  # deactivation_status_badge
+  # ---------------------------------------------------------------------------
+
+  test "deactivation_status_badge: returns nil for active user" do
+    result = deactivation_status_badge(@active_user)
+    assert_nil result
+  end
+
+  test "deactivation_status_badge: returns badge markup for deactivated user" do
+    result = deactivation_status_badge(@deactivated_user)
+    assert_not_nil result
+    assert_includes result, "person_off", "Expected person_off icon in badge"
+    assert_includes result, "deactivation-badge", "Expected deactivation-badge CSS class"
+  end
+end

--- a/test/models/deactivated_user_test.rb
+++ b/test/models/deactivated_user_test.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+class DeactivatedUserTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  TEST_EMAILS = %w[subject@example.com performer@example.com].freeze
+
+  setup do
+    @user = User.create!(email: "subject@example.com", password: "password123")
+    @performer = User.create!(email: "performer@example.com", password: "password123")
+  end
+
+  teardown do
+    test_user_ids = User.where(email: TEST_EMAILS).pluck(:id)
+    project_ids = Project.where(owner_id: test_user_ids).pluck(:id)
+
+    DeactivatedUser.where(user_id: test_user_ids).delete_all
+    DeactivatedUser.where(deactivated_by_id: test_user_ids).update_all(deactivated_by_id: nil)
+    Event.where(user_id: test_user_ids).delete_all
+    ProjectMember.where(user_id: test_user_ids).delete_all
+    ProjectMember.where(project_id: project_ids).delete_all
+    Project.where(id: project_ids).delete_all
+    User.where(id: test_user_ids).delete_all
+  end
+
+  test "valid with required attributes" do
+    record = DeactivatedUser.new(
+      user: @user,
+      original_email: "before@example.com",
+      deactivated_at: Time.current,
+    )
+    assert record.valid?
+  end
+
+  test "requires original_email" do
+    record = DeactivatedUser.new(user: @user, deactivated_at: Time.current)
+    assert_not record.valid?
+    assert_includes record.errors.attribute_names, :original_email
+  end
+
+  test "requires deactivated_at" do
+    record = DeactivatedUser.new(user: @user, original_email: "x@example.com")
+    assert_not record.valid?
+    assert_includes record.errors.attribute_names, :deactivated_at
+  end
+
+  test "rejects invalid email format for original_email" do
+    record = DeactivatedUser.new(
+      user: @user,
+      original_email: "not-an-email",
+      deactivated_at: Time.current,
+    )
+    assert_not record.valid?
+    assert_includes record.errors.attribute_names, :original_email
+  end
+
+  test "limits reason length to 500" do
+    record = DeactivatedUser.new(
+      user: @user,
+      original_email: "x@example.com",
+      deactivated_at: Time.current,
+      reason: "a" * 501,
+    )
+    assert_not record.valid?
+    assert_includes record.errors.attribute_names, :reason
+  end
+
+  test "reason is optional" do
+    record = DeactivatedUser.new(
+      user: @user,
+      original_email: "x@example.com",
+      deactivated_at: Time.current,
+      reason: nil,
+    )
+    assert record.valid?
+  end
+
+  test "belongs_to user" do
+    record = DeactivatedUser.create!(
+      user: @user,
+      original_email: "x@example.com",
+      deactivated_at: Time.current,
+    )
+    assert_equal @user.id, record.reload.user_id
+  end
+
+  test "belongs_to deactivated_by is optional" do
+    record = DeactivatedUser.create!(
+      user: @user,
+      original_email: "x@example.com",
+      deactivated_at: Time.current,
+      deactivated_by: nil,
+    )
+    assert_nil record.deactivated_by
+  end
+
+  test "tracks deactivated_by performer" do
+    record = DeactivatedUser.create!(
+      user: @user,
+      original_email: "x@example.com",
+      deactivated_at: Time.current,
+      deactivated_by: @performer,
+    )
+    assert_equal @performer.id, record.deactivated_by_id
+  end
+
+  test "user.deactivation has dependent: :destroy (Rails-level cascade)" do
+    reflection = User.reflect_on_association(:deactivation)
+    assert_equal :destroy, reflection.options[:dependent]
+  end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -77,8 +77,8 @@ class EventTest < ActiveSupport::TestCase
 
   # === Constants ===
 
-  test "EVENT_NAMES contains exactly 8 event types" do
-    assert_equal 8, Event::EVENT_NAMES.size
+  test "EVENT_NAMES contains exactly 10 event types" do
+    assert_equal 10, Event::EVENT_NAMES.size
     assert_includes Event::EVENT_NAMES, "task_created"
     assert_includes Event::EVENT_NAMES, "task_completed"
     assert_includes Event::EVENT_NAMES, "task_updated"
@@ -87,6 +87,8 @@ class EventTest < ActiveSupport::TestCase
     assert_includes Event::EVENT_NAMES, "project_created"
     assert_includes Event::EVENT_NAMES, "assignee_changed"
     assert_includes Event::EVENT_NAMES, "due_date_changed"
+    assert_includes Event::EVENT_NAMES, "user_deactivated"
+    assert_includes Event::EVENT_NAMES, "user_reactivated"
   end
 
   test "FEATURE_CATEGORIES maps every event name to a category" do

--- a/test/models/role_permission_test.rb
+++ b/test/models/role_permission_test.rb
@@ -25,6 +25,7 @@ class RolePermissionTest < ActiveSupport::TestCase
     TaskSeriesSubtask.delete_all
     TaskSeries.delete_all
     Project.delete_all
+    DeactivatedUser.delete_all
     User.delete_all
   end
 

--- a/test/models/user_role_test.rb
+++ b/test/models/user_role_test.rb
@@ -25,6 +25,7 @@ class UserRoleTest < ActiveSupport::TestCase
     TaskSeriesSubtask.delete_all
     TaskSeries.delete_all
     Project.delete_all
+    DeactivatedUser.delete_all
     User.delete_all
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -308,4 +308,53 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.can_write?("User")
     assert_not @user.can_read?("Project")
   end
+
+  # Deactivation associations / predicates / scopes (Issue #272)
+
+  test "active scope excludes users with a DeactivatedUser association" do
+    target = User.create!(email: "active_scope@example.com", password: "password123")
+    DeactivatedUser.create!(
+      user: target,
+      original_email: target.email,
+      deactivated_at: Time.current,
+    )
+    target.update_column(:email, Account::DeactivationService.sentinel_email_for(target))
+
+    assert_not_includes User.active.pluck(:id), target.id
+    assert_includes User.deactivated.pluck(:id), target.id
+  end
+
+  test "deactivated? returns true when DeactivatedUser exists" do
+    target = User.create!(email: "deact_pred@example.com", password: "password123")
+    assert_not target.deactivated?
+    assert target.active?
+
+    DeactivatedUser.create!(user: target, original_email: target.email, deactivated_at: Time.current)
+    target.reload
+    assert target.deactivated?
+    assert_not target.active?
+  end
+
+  test "search_deactivated finds users by their original_email (sentinel email never matches)" do
+    target = User.create!(email: "before_deact@example.com", password: "password123", name: "Pre Deact")
+    original_email = target.email
+    Account::DeactivationService.call(user: target, performer: target)
+
+    results = User.search_deactivated(original_email)
+    assert_equal [target.id], results.pluck(:id)
+
+    sentinel_results = User.search_deactivated("@deactivated.invalid")
+    assert_not_includes sentinel_results.pluck(:id), target.id
+  end
+
+  test "search_deactivated finds users by name" do
+    target = User.create!(email: "named_deact@example.com", password: "password123", name: "Distinct Name 0xC0DE")
+    Account::DeactivationService.call(user: target, performer: target)
+
+    assert_equal [target.id], User.search_deactivated("Distinct Name 0xC0DE").pluck(:id)
+  end
+
+  test "force_destroy method has been removed (dead code cleanup)" do
+    assert_not @user.respond_to?(:force_destroy), "User#force_destroy should be removed (Issue #272)"
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -23,6 +23,7 @@ class UserTest < ActiveSupport::TestCase
     TaskSeriesSubtask.delete_all
     TaskSeries.delete_all
     Project.delete_all
+    DeactivatedUser.delete_all
     User.delete_all
   end
 

--- a/test/services/account/deactivation_service_test.rb
+++ b/test/services/account/deactivation_service_test.rb
@@ -1,0 +1,163 @@
+require "test_helper"
+
+module Account
+  class DeactivationServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = User.create!(email: "target@example.com", password: "password123")
+      @performer = User.create!(email: "admin@service-test.com", password: "password123")
+    end
+
+    def teardown # rubocop:disable Metrics/AbcSize
+      ids = [@user.id, @performer.id]
+      Event.where(user_id: ids).delete_all
+      DeactivatedUser.where(user_id: ids).delete_all
+      DeactivatedUser.where(deactivated_by_id: ids).update_all(deactivated_by_id: nil)
+      project_ids = Project.where(owner_id: ids).pluck(:id)
+      ProjectMember.where(project_id: project_ids).delete_all
+      ProjectMember.where(user_id: ids).delete_all
+      Project.where(id: project_ids).delete_all
+      User.where(id: ids).delete_all
+    end
+
+    # --- call ---
+
+    test "call: does not destroy the user record" do
+      assert_no_difference("User.count") do
+        Account::DeactivationService.call(user: @user, performer: @performer)
+      end
+    end
+
+    test "call: creates a DeactivatedUser record" do
+      assert_difference("DeactivatedUser.count", 1) do
+        Account::DeactivationService.call(user: @user, performer: @performer)
+      end
+    end
+
+    test "call: preserves original_email in DeactivatedUser" do
+      original_email = @user.email
+      Account::DeactivationService.call(user: @user, performer: @performer)
+
+      assert_equal original_email, @user.reload.deactivation.original_email
+    end
+
+    test "call: sentinel email format matches deactivated+{user_id}+{16hex}@deactivated.invalid" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      sentinel = @user.reload.email
+
+      assert_match(/\Adeactivated\+#{@user.id}\+[0-9a-f]{16}@deactivated\.invalid\z/, sentinel)
+    end
+
+    test "call: sentinel email is accepted by URI::MailTo::EMAIL_REGEXP" do
+      sentinel = Account::DeactivationService.sentinel_email_for(@user)
+      assert_match URI::MailTo::EMAIL_REGEXP, sentinel
+    end
+
+    test "call: records user_deactivated event with account_lifecycle category" do
+      assert_difference("Event.count", 1) do
+        Account::DeactivationService.call(user: @user, performer: @performer)
+      end
+
+      event = Event.last
+      assert_equal "user_deactivated", event.event_name
+      assert_equal "account_lifecycle", event.feature_category
+    end
+
+    test "call: event metadata includes target_user_id and self_deactivated" do
+      Account::DeactivationService.call(user: @user, performer: @performer, self_deactivated: true)
+      event = Event.last
+
+      assert_equal @user.id, event.metadata["target_user_id"]
+      assert_equal true, event.metadata["self_deactivated"]
+    end
+
+    test "call: event metadata includes original_email" do
+      original_email = @user.email
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      event = Event.last
+
+      assert_equal original_email, event.metadata["original_email"]
+    end
+
+    test "call: saves reason in DeactivatedUser" do
+      Account::DeactivationService.call(user: @user, performer: @performer, reason: "Testing reason")
+      assert_equal "Testing reason", @user.reload.deactivation.reason
+    end
+
+    test "call: records deactivated_by performer" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      assert_equal @performer.id, @user.reload.deactivation.deactivated_by_id
+    end
+
+    test "call: rolls back on error (transactional)" do
+      original_email = @user.email
+      # Force an error inside the transaction by making update_column raise
+      DeactivatedUser.stubs(:create!).raises(ActiveRecord::RecordInvalid)
+
+      assert_raises(ActiveRecord::RecordInvalid) do
+        Account::DeactivationService.call(user: @user, performer: @performer)
+      end
+
+      assert_equal 0, DeactivatedUser.where(user: @user).count
+      assert_equal original_email, @user.reload.email
+    end
+
+    # --- reactivate ---
+
+    test "reactivate: restores original email when free" do
+      original_email = @user.email
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      Account::DeactivationService.reactivate(user: @user, performer: @performer)
+
+      assert_equal original_email, @user.reload.email
+    end
+
+    test "reactivate: destroys DeactivatedUser record" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+
+      assert_difference("DeactivatedUser.count", -1) do
+        Account::DeactivationService.reactivate(user: @user, performer: @performer)
+      end
+    end
+
+    test "reactivate: raises RecordInvalid when target email is taken" do
+      original_email = @user.email
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      # Another user takes the original email
+      User.create!(email: original_email, password: "password123")
+
+      assert_raises(ActiveRecord::RecordInvalid) do
+        Account::DeactivationService.reactivate(user: @user, performer: @performer)
+      end
+    end
+
+    test "reactivate: uses new_email override when provided" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      new_addr = "restored-custom@example.com"
+      Account::DeactivationService.reactivate(user: @user, performer: @performer, new_email: new_addr)
+
+      assert_equal new_addr, @user.reload.email
+    end
+
+    test "reactivate: records user_reactivated event with account_lifecycle category" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+
+      assert_difference("Event.count", 1) do
+        Account::DeactivationService.reactivate(user: @user, performer: @performer)
+      end
+
+      event = Event.last
+      assert_equal "user_reactivated", event.event_name
+      assert_equal "account_lifecycle", event.feature_category
+    end
+
+    test "reactivate: event metadata includes target_user_id and restored_email" do
+      original_email = @user.email
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      Account::DeactivationService.reactivate(user: @user, performer: @performer)
+      event = Event.last
+
+      assert_equal @user.id, event.metadata["target_user_id"]
+      assert_equal original_email, event.metadata["restored_email"]
+    end
+  end
+end

--- a/test/services/account/deactivation_service_test.rb
+++ b/test/services/account/deactivation_service_test.rb
@@ -159,5 +159,33 @@ module Account
       assert_equal @user.id, event.metadata["target_user_id"]
       assert_equal original_email, event.metadata["restored_email"]
     end
+
+    # Race condition: concurrent reactivation by two admins. Simulated by
+    # destroying the `deactivated_users` row out-of-band between the controller's
+    # find_by and the service's lock.find_by. Old code raised NoMethodError on
+    # `user.deactivation.original_email`; new code surfaces RecordNotFound,
+    # which the controller renders as 404.
+    test "reactivate: raises RecordNotFound when deactivation row vanished mid-flight" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      # Simulate a concurrent admin's tx having committed the destroy first.
+      DeactivatedUser.where(user_id: @user.id).delete_all
+
+      assert_raises(ActiveRecord::RecordNotFound) do
+        Account::DeactivationService.reactivate(user: @user, performer: @performer)
+      end
+    end
+
+    test "reactivate: does not write user email when deactivation row vanished" do
+      Account::DeactivationService.call(user: @user, performer: @performer)
+      sentinel = @user.reload.email
+      DeactivatedUser.where(user_id: @user.id).delete_all
+
+      assert_raises(ActiveRecord::RecordNotFound) do
+        Account::DeactivationService.reactivate(user: @user, performer: @performer)
+      end
+
+      assert_equal sentinel, @user.reload.email,
+                   "user email must remain unchanged when deactivation row is gone"
+    end
   end
 end

--- a/test/system/account/deactivation_test.rb
+++ b/test/system/account/deactivation_test.rb
@@ -1,0 +1,34 @@
+require "application_system_test_case"
+
+module Account
+  class DeactivationTest < ApplicationSystemTestCase
+    test "self-deactivation: form submission deactivates the account and blocks re-login" do
+      user = users(:regular_user)
+      original_email = user.email
+
+      visit login_path
+      fill_in I18n.t("activerecord.attributes.user.email"), with: original_email
+      fill_in I18n.t("activerecord.attributes.user.password"), with: "HoboTest!Str0ng#2024"
+      click_button I18n.t("sessions.new.submit")
+
+      assert_current_path project_path(user.inbox_project)
+
+      visit new_account_deactivation_path
+      fill_in I18n.t("activerecord.attributes.user.password_challenge"), with: "HoboTest!Str0ng#2024"
+      fill_in I18n.t("account.deactivations.new.reason_label"), with: "system test"
+      check "confirm_deactivation"
+      click_button I18n.t("account.deactivations.new.submit")
+
+      assert_current_path login_path
+
+      visit login_path
+      fill_in I18n.t("activerecord.attributes.user.email"), with: original_email
+      fill_in I18n.t("activerecord.attributes.user.password"), with: "HoboTest!Str0ng#2024"
+      click_button I18n.t("sessions.new.submit")
+
+      assert_current_path login_path
+      assert user.reload.deactivated?
+      assert_equal original_email, user.deactivation.original_email
+    end
+  end
+end

--- a/test/system/account/deactivation_test.rb
+++ b/test/system/account/deactivation_test.rb
@@ -30,5 +30,30 @@ module Account
       assert user.reload.deactivated?
       assert_equal original_email, user.deactivation.original_email
     end
+
+    # Regression: the user settings modal (`users#show` inside `<turbo-frame id="modal">`)
+    # contains the deactivation link. Without `data-turbo-frame="_top"` on the link, Turbo
+    # tries to find a matching `modal` frame in the response and renders "Content missing"
+    # because `account/deactivations/new` is a full-page view. Cancelling from the full-page
+    # deactivation view must also land on a real page (root_path), not a stranded modal frame.
+    test "self-deactivation link inside user settings modal navigates full-page (not 'Content missing')" do
+      user = users(:regular_user)
+
+      visit login_path
+      fill_in I18n.t("activerecord.attributes.user.email"), with: user.email
+      fill_in I18n.t("activerecord.attributes.user.password"), with: "HoboTest!Str0ng#2024"
+      click_button I18n.t("sessions.new.submit")
+      assert_current_path project_path(user.inbox_project)
+
+      visit user_path
+      click_link I18n.t("users.user_display.deactivate")
+
+      assert_current_path new_account_deactivation_path
+      assert_no_text "Content missing"
+      assert_selector "h1", text: I18n.t("account.deactivations.new.title")
+
+      click_link I18n.t("account.deactivations.new.cancel")
+      assert_current_path root_path
+    end
   end
 end

--- a/tests/admin/users.spec.ts
+++ b/tests/admin/users.spec.ts
@@ -65,28 +65,33 @@ test.describe('Admin ユーザー管理', () => {
     await expect(page.getByText(updatedName)).toBeVisible({ timeout: 10000 })
   })
 
-  test('ユーザーを削除できること', async ({ page }) => {
-    // 削除用ユーザーを作成する
+  test('ユーザーを退会させられること', async ({ page }) => {
+    // 退会対象ユーザーを作成する
     const timestamp = Date.now()
-    const deleteEmail = `e2e_delete_${timestamp}@example.com`
-    const deleteName = `E2E Delete User ${timestamp}`
+    const deactivateEmail = `e2e_deactivate_${timestamp}@example.com`
+    const deactivateName = `E2E Deactivate User ${timestamp}`
 
     await page.goto('/admin/users/new')
-    await page.locator('input[type="email"]').fill(deleteEmail)
-    await page.locator('input[type="text"]').fill(deleteName)
+    await page.locator('input[type="email"]').fill(deactivateEmail)
+    await page.locator('input[type="text"]').fill(deactivateName)
 
     const passwordInputs = page.locator('input[type="password"]')
     await passwordInputs.nth(0).fill(TEST_PASSWORD)
     await passwordInputs.nth(1).fill(TEST_PASSWORD)
     await page.getByRole('button', { name: 'Create' }).click()
     await expect(page).toHaveURL('/admin/users', { timeout: 10000 })
-    await expect(page.getByText(deleteEmail)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(deactivateEmail)).toBeVisible({ timeout: 10000 })
 
-    // 作成したユーザーの行にある Delete ボタンをクリック
-    const row = page.locator('tr', { has: page.getByText(deleteEmail) })
-    page.on('dialog', dialog => dialog.accept())
-    await row.getByRole('button', { name: 'Delete' }).click()
+    // 作成したユーザーの行にある Deactivate ボタンをクリック
+    const row = page.locator('tr', { has: page.getByText(deactivateEmail) })
+    await row.getByRole('button', { name: 'Deactivate' }).click()
 
-    await expect(page.getByText(deleteEmail)).not.toBeVisible({ timeout: 10000 })
+    // 確認モーダルで Deactivate を確定
+    const dialog = page.getByRole('dialog', { name: 'Deactivate User' })
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+    await dialog.getByRole('button', { name: 'Deactivate' }).click()
+
+    // active フィルタ (デフォルト) では退会済みユーザーは一覧から外れる
+    await expect(page.getByText(deactivateEmail)).not.toBeVisible({ timeout: 10000 })
   })
 })


### PR DESCRIPTION
Closes #272

## Summary
- 削除→退会への移行: Admin 物理削除 (PR #270 で除却) を **deactivate / reactivate** で置換。`users` テーブルにカラム追加せず、別テーブル `deactivated_users` で 1:1 join
- **Self-deactivation 対応**: `/account/deactivation/new` で本人退会 (`password_challenge` 再認証 + 退会理由任意)
- **Sentinel email rewrite**: deactivate 時 `users.email` を `deactivated+{user_id}+{16hex}@deactivated.invalid` (RFC 2606) に書き換え、元 email は `deactivated_users.original_email` に退避 → 同 email で再登録可能
- **Reactivate**: 元 email が空いていれば 1-click 復活、衝突時のみモーダル inline で新 email prompt (422 + `original_email_conflict: true` で React 側を分岐)
- **HTTP next-request enforcement**: deactivated user の次回リクエストで `reset_session` + redirect/401 (`enforce_active_account` / `enforce_active_admin`)
- **表示マスキング**: 一般 viewer は `先頭2文字 + **`、admin viewer は raw 表示 (`display_user_name(user, viewer:)` helper で一元化)
- **Audit**: `Events::Recorder` で `user_deactivated` / `user_reactivated` (category `account_lifecycle`) を記録、`deactivated_users` の hard-delete 後も復元可能

## Implementation phases
Standard Flow + 4-way fork-join (Pre-Fork orchestrator → Phase 1A/1B-α/1B-β/1C parallel → Phase 2 orchestrator)。

| Phase | Actor | Outcome |
|---|---|---|
| Pre-Fork | orchestrator | migration + routes + 501 stubs + skeletons + sanity tests |
| 1A | rails-developer | Admin API (deactivate/reactivate/users#index status filter/admin sessions/`enforce_active_admin`) |
| 1B-α | rails-developer | Service body + self-deactivation flow + ApplicationController guard + sessions/TOTP active 化 |
| 1B-β | rails-developer | `users_helper` + view migration |
| 1C | react-developer | Admin SPA (segmented filter + badges + modals + inline conflict prompt) |

3 of 4 subagents hit `maxTurns` force-stop (Issue #332 pattern); 不足分は **orchestrator 直接 + 1 retry** で完成。

## Test plan
- [x] `bin/rails test:all` → 991 runs / 2402 assertions / 0 failures / 0 errors / 2 skips (pre-existing)
- [x] React vitest → 122 tests pass
- [x] vite build green
- [x] Manual: form_with method (system test 通過)、Reactivate conflict path (test 担保)、Browser Back/Forward で filter 追従

## I4 review summary
- **react-reviewer ✓ clean**: HIGH 4 全修正 (`bg-accent` token / `SectionError` inline / URL→state back-sync / focus ring tokens)
- **rails-reviewer / architecture-reviewer**: 両方 maxTurns force-stop (retry も同様)、protocol 通り findings drop。但し breadcrumb で示唆された **`deactivated?` の N+1** は orchestrator 直接 fix (`tasks_controller#show` includes、`_assignees.html.erb` の members ループ)

## Deferred (Medium / Low)
PR description に記録、本 PR では block しない:
- `UserEditPage.tsx:127,132` — `<label>` の htmlFor 不在 (WCAG 1.3.1)
- `ReactivateConfirmModal.tsx:54` — amber-600 (ADMIN_UI semantic table は amber-400)
- `Status` type が UsersIndexPage / UserStatusFilter で重複 (api.ts に集約余地)
- `UsersIndexPage handleStatusChange` の薄い wrapper (今は state 更新だけ + URL sync は useEffect で別処理になっているので意味がある形に再構成済み)
- `DeactivatedUserBadge` の Props interface 不在

## Out of scope (Issue 本文で client 合意済み)
- 退会済みユーザーの hard-delete UI
- Action Cable / Turbo Stream の subscription guard (deactivate 後の既存 channel 接続)
- 退会理由の集計／分析ダッシュボード
- Self-reactivation (本人による退会取り消し)

## Mockup
https://gist.github.com/tetran/869e82a5b6c9b5ac2b1516d51df97f2d (P3 UI Design Loop で client 承認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)