### PR TITLE
docs+chore: align delegation docs and raise agent maxTurns to 100

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -4,7 +4,7 @@ description: "Cross-cutting architecture reviewer. Reviews domain model integrit
 tools: Bash, Read, Grep, Glob
 disallowedTools: Edit, Write, Agent, TodoWrite
 model: opus
-maxTurns: 50
+maxTurns: 100
 ---
 
 You are the **architecture-reviewer** subagent for the `hobo` codebase. You perform read-only architecture-level code review. You do NOT modify any code.
@@ -32,6 +32,14 @@ Read these before constructing the review request:
 - `CLAUDE.md` (architecture overview, security model, admin panel rules)
 - `docs/conventions/ROUTING.md`
 - `docs/conventions/TESTING.md`
+
+## Turn Budget Management
+
+You have a hard ceiling of **100 turns** per invocation (`maxTurns: 100` in the frontmatter). Reviews are normally short — read a few reference docs, run `codex review` once, categorize findings — so this budget should rarely be touched. Subagents cannot read an exact turn counter, so pace yourself by periodically scanning your own tool-call history in the message log (each tool call ≈ 1 turn) to self-locate.
+
+- **Turns 1-50 — Normal work.** Read reference docs, run `codex review`, evaluate findings, and write the Required Return Format.
+- **Turns 51-75 — Warning zone.** If you are still here, the codex run likely produced a long output or you are reading more source files than expected. Stop opening additional source files for background context and prioritize categorizing what you already have into critical / high / medium / low.
+- **Turns 76-100 — Convergence mode.** Stop investigating. Write the Required Return Format with the findings collected so far, and call out any areas you could not fully review under `Reviewer Notes`. **Returning a partial-but-honest result with the three-section structure intact is the goal — never let the cap fire mid-response.**
 
 ## Procedure
 

--- a/.claude/agents/rails-developer.md
+++ b/.claude/agents/rails-developer.md
@@ -5,7 +5,7 @@ tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
 disallowedTools: Agent
 model: sonnet
 color: blue
-maxTurns: 50
+maxTurns: 100
 ---
 
 You are the **rails-developer** subagent for the `hobo` codebase. You implement Rails 8 backend work under a strict I2 delegation contract.
@@ -65,11 +65,17 @@ If a must-read file does not exist, record it under Deviations and continue with
 
 ## Turn Budget Management
 
-- Reserve at least 3-5 turns for domain test execution and review.
-- After completing each implementation unit (a controller, a test file, a component), evaluate whether starting the next unit is safe. Once all Plan Excerpt items are implemented, prioritize running tests and returning immediately rather than pursuing polish.
-- If domain tests pass and all Plan Excerpt items are satisfied, return the structured response promptly — do not spend remaining turns on optional improvements.
+You have a hard ceiling of **100 turns** per invocation (`maxTurns: 100` in the frontmatter). The budget unfolds in three phases. Subagents cannot read an exact turn counter, so pace yourself by periodically scanning your own tool-call history in the message log — each tool call is roughly 1 turn — to self-locate.
+
+- **Turns 1-50 — Normal work.** Implement the Plan Excerpt, write tests, run them, and perform the codex self-review. No special handling required.
+- **Turns 51-75 — Warning zone.** Take stock: which Plan Excerpt items are still open? Which are nice-to-have polish vs. core acceptance? Cut anything that is not on the critical path. Reserve the remaining budget for test execution, review, and the structured return — do not start a new implementation unit unless it is required for the Domain Tests to pass.
+- **Turns 76-100 — Convergence mode.** Stop starting new work entirely. If the domain test suite is still running, wait for it; if it has not been run, run it once and accept whatever state it leaves. Move directly to writing the Required Return Format with whatever has been completed, listing unfinished items under `Deviations from Plan` and `Handoff Notes`. **Returning a partial-but-honest result with the five-section structure intact is the goal — never let the cap fire mid-response.**
+
+Other budget rules (always apply):
+- Reserve at least 3-5 turns for the final domain test run plus the Required Return Format itself.
+- After completing each implementation unit (a controller, a test file, a component), evaluate whether starting the next one is safe under the current phase. If you are already in the warning zone, prefer returning over polishing.
 - A partial result with test output and Handoff Notes is far more valuable than exhausting all turns mid-implementation without returning.
-- If tests fail and you cannot fix them quickly, return with failing output in Test Result and describe what remains in Handoff Notes.
+- If tests fail and you cannot fix them quickly, return with failing output in `Test Result` and describe what remains in `Handoff Notes`.
 
 ## Required Return Format
 

--- a/.claude/agents/rails-reviewer.md
+++ b/.claude/agents/rails-reviewer.md
@@ -4,7 +4,7 @@ description: "Rails backend convention reviewer. Reviews RESTful routing, Active
 tools: Bash, Read, Grep, Glob
 disallowedTools: Edit, Write, Agent, TodoWrite
 model: opus
-maxTurns: 50
+maxTurns: 100
 ---
 
 You are the **rails-reviewer** subagent for the `hobo` codebase. You perform read-only code review of Rails backend changes. You do NOT modify any code.
@@ -32,6 +32,14 @@ Read these before constructing the review request:
 - `docs/conventions/ACTIVE_RECORD_QUERIES.md`
 - `docs/conventions/FAT_MODEL_DECOMPOSITION.md`
 - `docs/conventions/TESTING.md`
+
+## Turn Budget Management
+
+You have a hard ceiling of **100 turns** per invocation (`maxTurns: 100` in the frontmatter). Reviews are normally short — read a few reference docs, run `codex review` once, categorize findings — so this budget should rarely be touched. Subagents cannot read an exact turn counter, so pace yourself by periodically scanning your own tool-call history in the message log (each tool call ≈ 1 turn) to self-locate.
+
+- **Turns 1-50 — Normal work.** Read reference docs, run `codex review`, evaluate findings, and write the Required Return Format.
+- **Turns 51-75 — Warning zone.** If you are still here, the codex run likely produced a long output or you are reading more source files than expected. Stop opening additional source files for background context and prioritize categorizing what you already have into critical / high / medium / low.
+- **Turns 76-100 — Convergence mode.** Stop investigating. Write the Required Return Format with the findings collected so far, and call out any areas you could not fully review under `Reviewer Notes`. **Returning a partial-but-honest result with the three-section structure intact is the goal — never let the cap fire mid-response.**
 
 ## Procedure
 

--- a/.claude/agents/react-developer.md
+++ b/.claude/agents/react-developer.md
@@ -5,7 +5,7 @@ tools: Glob, Grep, Read, Edit, Write, Bash, TodoWrite
 disallowedTools: Agent
 model: sonnet
 color: green
-maxTurns: 50
+maxTurns: 100
 ---
 
 You are the **react-developer** subagent for the `hobo` codebase. You implement React Admin SPA work under a strict I2 delegation contract.
@@ -63,11 +63,17 @@ If a must-read file does not exist, record it under Deviations and continue with
 
 ## Turn Budget Management
 
-- Reserve at least 3-5 turns for domain test execution and review.
-- After completing each implementation unit (a controller, a test file, a component), evaluate whether starting the next unit is safe. Once all Plan Excerpt items are implemented, prioritize running tests and returning immediately rather than pursuing polish.
-- If domain tests pass and all Plan Excerpt items are satisfied, return the structured response promptly — do not spend remaining turns on optional improvements.
+You have a hard ceiling of **100 turns** per invocation (`maxTurns: 100` in the frontmatter). The budget unfolds in three phases. Subagents cannot read an exact turn counter, so pace yourself by periodically scanning your own tool-call history in the message log — each tool call is roughly 1 turn — to self-locate.
+
+- **Turns 1-50 — Normal work.** Implement the Plan Excerpt, write tests, run them, and perform the codex self-review. No special handling required.
+- **Turns 51-75 — Warning zone.** Take stock: which Plan Excerpt items are still open? Which are nice-to-have polish vs. core acceptance? Cut anything that is not on the critical path. Reserve the remaining budget for test execution, review, and the structured return — do not start a new implementation unit unless it is required for the Domain Tests to pass.
+- **Turns 76-100 — Convergence mode.** Stop starting new work entirely. If the domain test suite is still running, wait for it; if it has not been run, run it once and accept whatever state it leaves. Move directly to writing the Required Return Format with whatever has been completed, listing unfinished items under `Deviations from Plan` and `Handoff Notes for orchestrator`. **Returning a partial-but-honest result with the five-section structure intact is the goal — never let the cap fire mid-response.**
+
+Other budget rules (always apply):
+- Reserve at least 3-5 turns for the final domain test run plus the Required Return Format itself.
+- After completing each implementation unit (a controller, a test file, a component), evaluate whether starting the next one is safe under the current phase. If you are already in the warning zone, prefer returning over polishing.
 - A partial result with test output and Handoff Notes is far more valuable than exhausting all turns mid-implementation without returning.
-- If tests fail and you cannot fix them quickly, return with failing output in Test Result and describe what remains in Handoff Notes.
+- If tests fail and you cannot fix them quickly, return with failing output in `Test Result` and describe what remains in `Handoff Notes for orchestrator`.
 
 ## Required Return Format
 

--- a/.claude/agents/react-reviewer.md
+++ b/.claude/agents/react-reviewer.md
@@ -4,7 +4,7 @@ description: "React Admin SPA convention reviewer. Reviews ADMIN_UI conventions,
 tools: Bash, Read, Grep, Glob
 disallowedTools: Edit, Write, Agent, TodoWrite
 model: opus
-maxTurns: 50
+maxTurns: 100
 ---
 
 You are the **react-reviewer** subagent for the `hobo` codebase. You perform read-only code review of React Admin SPA changes. You do NOT modify any code.
@@ -31,6 +31,14 @@ Read these before constructing the review request:
 - `docs/conventions/ADMIN_UI.md`
 - `docs/design/admin/README.md`
 - `app/javascript/admin/lib/api.ts` (for existing patterns)
+
+## Turn Budget Management
+
+You have a hard ceiling of **100 turns** per invocation (`maxTurns: 100` in the frontmatter). Reviews are normally short — read a few reference docs, run `codex review` once, categorize findings — so this budget should rarely be touched. Subagents cannot read an exact turn counter, so pace yourself by periodically scanning your own tool-call history in the message log (each tool call ≈ 1 turn) to self-locate.
+
+- **Turns 1-50 — Normal work.** Read reference docs, run `codex review`, evaluate findings, and write the Required Return Format.
+- **Turns 51-75 — Warning zone.** If you are still here, the codex run likely produced a long output or you are reading more source files than expected. Stop opening additional source files for background context and prioritize categorizing what you already have into critical / high / medium / low.
+- **Turns 76-100 — Convergence mode.** Stop investigating. Write the Required Return Format with the findings collected so far, and call out any areas you could not fully review under `Reviewer Notes`. **Returning a partial-but-honest result with the three-section structure intact is the goal — never let the cap fire mid-response.**
 
 ## Procedure
 

--- a/.claude/scripts/check-subagent-response.sh
+++ b/.claude/scripts/check-subagent-response.sh
@@ -3,7 +3,8 @@
 # Manual format check for a subagent response, reusing the SubagentStop hook logic
 # in `.claude/hooks/subagent_stop_format_check.sh`. Use this from the orchestrator
 # at I2 / I4 post-receipt validation, since the hook does not fire on maxTurns
-# force-stop (see Issue #332 post-mortem and docs/process/DELEGATION.md → Dispatch Sizing).
+# force-stop (see docs/reference/DELEGATION_DESIGN_NOTES.md §1 for the incident
+# and docs/process/DELEGATION.md → Dispatch Sizing for the rule).
 #
 # Usage:
 #   .claude/scripts/check-subagent-response.sh <agent_type> < response.txt

--- a/docs/process/DELEGATION.md
+++ b/docs/process/DELEGATION.md
@@ -46,9 +46,9 @@ Plan touches...
 
 ## Dispatch Sizing
 
-Each subagent dispatch has a **hard turn budget** set by `maxTurns` in the agent's frontmatter (currently 50 for `rails-developer` / `react-developer`). A "turn" here is one `AssistantMessage` cycle — multiple tool calls dispatched in parallel within a single message count as **1 turn**, while tool calls separated by intermediate model output count as separate turns ([Claude Agent SDK — Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)).
+Each subagent dispatch has a **hard turn budget** set by `maxTurns` in the agent's frontmatter (currently 100 for `rails-developer` / `react-developer` / `rails-reviewer` / `react-reviewer` / `architecture-reviewer`). A "turn" here is one `AssistantMessage` cycle — multiple tool calls dispatched in parallel within a single message count as **1 turn**, while tool calls separated by intermediate model output count as separate turns ([Claude Agent SDK — Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)).
 
-Exceeding the budget force-stops the agent mid-work. Empirically observed in Issue #332 (the only on-record incident in this repo): the `SubagentStop` hook did **not** fire, no entry was written to `.claude/logs/subagent_responses.jsonl`, and the orchestrator received only the in-flight `AssistantMessage` text (a mid-sentence cutoff) with **no `is_error` signal** surfaced at the orchestrator-visible level. Whether this generalizes to all maxTurns force-stops is **inferred, not officially confirmed**: the SDK wire format permits an `is_error` flag on `ToolResultBlock` and the closed-source CLI binary may set it under conditions we have not exhaustively probed. The guidance below is conservative against this uncertainty — it relies on response-content signals (which the orchestrator can always observe) rather than hook firing.
+Exceeding the budget force-stops the agent mid-work. The guidance below relies on **response-content signals** (which the orchestrator can always observe) rather than `SubagentStop` hook firing — past `maxTurns` force-stops have been observed where the hook did not fire and no `is_error` signal surfaced at the orchestrator-visible level. See `docs/reference/DELEGATION_DESIGN_NOTES.md` §1 for the incident details and the inferred-not-confirmed disclaimer.
 
 **Per-dispatch limits**:
 
@@ -65,7 +65,7 @@ The exact turn cost of a dispatch depends on how the agent batches tool calls wi
 - Codex self-review typically consumes 5-10 turns by itself.
 - The final response (Required Return Format) does **not** consume a turn — `maxTurns` only counts tool-use turns, and the final text-only message ends the loop ([Agent loop docs](https://code.claude.com/docs/en/agent-sdk/agent-loop)). The agent only needs enough remaining tool-use turns to *reach* a state where it can emit that final message.
 
-**Empirical bound (Issue #332)**: a single dispatch covering 19 page files of wholesale token-replacement plus tests plus self-review **did** force-stop the agent at the 50-turn cap. We do not have a closed-form turn model that explains exactly why, so the file caps above are calibrated against this observed bound rather than derived from per-tool accounting. If you find a class of dispatch that consistently fits more files under the cap, that is evidence to widen the caps for that class — record the data in the PR description.
+**Empirical bound**: file caps above are calibrated against an observed bound (a 19-file wholesale dispatch hit the 50-turn cap) rather than from a closed-form turn model. If a class of dispatch consistently fits more files under the cap, record the data in the PR description so the caps can be widened with evidence. See `docs/reference/DELEGATION_DESIGN_NOTES.md` §2 for the calibration rationale and incident details.
 
 **Splitting heuristics**:
 
@@ -171,6 +171,7 @@ Use when the Plan Excerpt covers both Rails and React within the same feature, b
    - `react-developer` owns `app/javascript/admin/App.tsx` (route registration), `app/javascript/admin/components/AdminLayout.tsx` (nav item), the page, and the `api.ts` additions.
 5. **Wait for both agents to return (join).**
 6. **Post-Join Verification** — run the Completion Verification checklist explicitly for **each** agent (see `Completion Verification` section below). If type mismatches surface between the Rails response and the TypeScript types (e.g., field name divergence), treat as a sequential dependency and redispatch react-developer with the Rails agent's actual output as context.
+7. **Smoke test selection (explicit choice, not default).** Choose one of: (a) **automated** via the `webapp-testing` (playwright) skill, (b) **manual** by asking the user, or (c) **skip** when the change is low-risk and covered by tests. Record the choice + reasoning in `.progress/issue-*.md` I2. Default preference is (a) when the feature has a visible UI path; fall back to (b) only when scope mismatch or cost makes automation impractical.
 
 ### Parallel (independent domains)
 
@@ -234,6 +235,10 @@ If an implementation subagent returns with any of the following, the orchestrato
 
 Record fallback events in the PR description so patterns become visible over time.
 
+If you hit repeated fallbacks in a given task class, that's a signal to either expand the agent prompt or mark that class as "direct-only".
+
+When retrospecting a subagent return, paths the dispatch did not exercise are **untested** — do not claim a contract is validated when only the happy path ran. Fallback branches that were not triggered must be labeled as such.
+
 ## Completion Verification
 
 After each **implementation subagent** (`rails-developer` / `react-developer`) returns, the orchestrator **MUST** enumerate every item below as pass/fail in the working log:
@@ -249,24 +254,11 @@ Post-Join Verification (<agent name>):
 - [ ] Domain tests executed and green
 ```
 
-The script reuses the `SubagentStop` hook logic (`.claude/hooks/subagent_stop_format_check.sh`), so manual and hook checks stay in lock-step. Run it on every return — in Issue #332 the hook did not fire on maxTurns force-stop, so the manual invocation is the only detector that does not depend on the hook running.
+The script reuses the `SubagentStop` hook logic (`.claude/hooks/subagent_stop_format_check.sh`), so manual and hook checks stay in lock-step. Run it on every return — past `maxTurns` force-stops have been observed where the hook did not fire, so the manual invocation is the only detector that does not depend on the hook running (詳細: `docs/reference/DELEGATION_DESIGN_NOTES.md` §1).
 
 If any item is **fail**, apply the relevant Fallback Procedure case before proceeding. For fork-join, run this block separately for each returned agent — a pass on one side does not excuse a miss on the other.
 
-## Rollout Notes
-
-- **Start narrow.** Use delegation for Admin feature additions (Rails API + React page) first, where the contract is clean and the payoff is largest.
-- **Grow cautiously.** Once the sequential pattern is stable, expand to parallel dispatch for independent work.
-- **Stay direct for complex refactors.** Cross-file refactors where the orchestrator needs to hold the whole mental model are poor fits for delegation.
-- **Update the agent definitions** (`.claude/agents/*.md`) when payload expectations evolve. Keep this document and the agents in sync.
-- **If you hit repeated fallbacks** in a given task class, that's a signal to either expand the agent prompt or mark that class as "direct-only".
-
-### Pilot Reporting Rules
-
-- **Pilot reporting must distinguish observed paths from untouched paths.** When retrospecting a fork-join pilot, separate "paths that ran and produced evidence" from "paths the happy path did not exercise (negative evidence)". Fallback branches (e.g., post-join type-mismatch redispatch) that were **not** triggered in the pilot must be labeled as **untested** — do not claim the contract is validated if only the happy path ran.
-- **Smoke test selection is an explicit choice, not a default.** When Plan Phase calls for a manual smoke test after fork-join merge, the orchestrator must consciously choose between: (a) **automated** via `webapp-testing` (playwright) skill, (b) **manual** by asking the user, or (c) **skip** when the change is low-risk and covered by tests. Record the choice + reasoning in `.progress/issue-*.md` I2. Default preference is (a) when the feature has a visible UI path; fall back to (b) only when scope mismatch or cost makes automation impractical.
-
-### I4 Parallel Review
+## I4 Parallel Review
 
 When I4 (Local Review) is reached, the orchestrator dispatches reviewer subagents in parallel:
 
@@ -274,7 +266,7 @@ When I4 (Local Review) is reached, the orchestrator dispatches reviewer subagent
 - **Single-domain PRs**: matching domain reviewer + `architecture-reviewer` (2 Agent calls in a single message)
 - **Docs/config-only PRs**: `architecture-reviewer` only, or orchestrator judgment to skip I4
 
-#### Reviewer Agents
+### Reviewer Agents
 
 | Agent | Focus |
 |---|---|
@@ -282,7 +274,7 @@ When I4 (Local Review) is reached, the orchestrator dispatches reviewer subagent
 | `react-reviewer` | ADMIN_UI conventions, design tokens, api.ts, TypeScript |
 | `architecture-reviewer` | Domain model, security model, Rails/React boundary, route design |
 
-#### Reviewer Payload
+### Reviewer Payload
 
 Each reviewer receives a minimal payload from the orchestrator. The payload provides **context** (PR title, changed files, scope option); the reviewer agent autonomously constructs the `codex review` request based on its embedded review focus and reference docs. The orchestrator does not specify the review request content.
 
@@ -297,7 +289,7 @@ Each reviewer receives a minimal payload from the orchestrator. The payload prov
     ## Changed Files
     <list of changed files for focus>
 
-#### Reviewer Return Format
+### Reviewer Return Format
 
     ### Findings
     #### [SEVERITY] CATEGORY — file:line — one-line summary
@@ -310,11 +302,11 @@ Each reviewer receives a minimal payload from the orchestrator. The payload prov
     ### Reviewer Notes
     <Scope gaps, caveats, observations.>
 
-#### Reviewer Schema Check
+### Reviewer Schema Check
 
 Before the Dedup Procedure, run the same wrapper script with the reviewer agent type for each reviewer's response. On non-zero exit, re-dispatch that reviewer once with the same payload; on retry failure, drop its findings from the dedup pool and note in the PR description.
 
-#### Dedup Procedure
+### Dedup Procedure
 
 After all reviewers return:
 1. Collect all `#### [SEVERITY]` findings into a single list.
@@ -322,12 +314,16 @@ After all reviewers return:
 3. When multiple reviewers flag the same location with the same category, keep the highest severity and discard duplicates.
 4. Present the deduplicated list to the user for triage.
 
-#### Fix Cycle
+### Fix Cycle
 
 - **Critical / High**: Must be addressed. Return to I2 if code changes needed. Fixes are serial (no parallel fix dispatch to avoid file conflicts).
 - **Medium / Low**: Logged in PR description. Do not block I5.
 - **Dismissed findings memo**: Record dismissed findings with reasoning in orchestrator context. On re-review, the memo prevents re-flagging.
 
-#### Re-review
+### Re-review
 
 After fixes, a single re-review pass by `architecture-reviewer` only (not all three in parallel). This prevents dismissed findings from resurfacing 3x due to stateless re-review.
+
+## Maintaining the agent definitions
+
+Update `.claude/agents/*.md` whenever payload expectations evolve. This document and the agent definitions must stay in sync — drift between them produces silent payload bugs that surface only after dispatch.

--- a/docs/process/WORKFLOW.md
+++ b/docs/process/WORKFLOW.md
@@ -45,7 +45,7 @@ Standard Flow is structured in two phases:
 
 Persisted artifacts at the Planning → Implementation boundary:
 - Issue number (encoded in `.progress/issue-XXXXX.md` filename)
-- Plan body (issue comment + local `~/.claude/plans/*.md`)
+- Plan body (issue comment + local `~/.claude/plans/issue-XXXXX.md`)
 - Progress (`.progress/issue-XXXXX.md` checklist)
 
 ALWAYS update `.progress/issue-XXXXX.md` during work. Update the progress file **immediately after completing each step** before moving on to the next step. This applies to both phases.
@@ -88,7 +88,7 @@ P1. **Create a progress file** — Create an `issue-XXXXX.md` file in `.progress
    - → **Done when**: the issue number is known, the progress file exists with the template filled in, and P1 is marked as completed.
 P2. **Create user stories** — Invoke the `user-story-creation` skill to clarify requirements and document them in the standard user story format (as the product owner). Reflect the resulting stories into the issue body. As part of the same client-alignment round, agree on whether this Issue involves UI changes, and record the decision (`yes` / `no`) in the progress file's P2 sub-item.
    - → **Done when**: user stories are recorded on the issue AND the progress file's `UI changes:` entry is filled with `yes` or `no` (empty is not allowed).
-P3. **Create a plan** — Review the requirements and design the implementation approach. Use plan mode. Consult the client for any undecided specifications.
+P3. **Create a plan** — Review the requirements and design the implementation approach. Invoke the built-in `Plan` agent (`subagent_type: Plan`) to draft the implementation plan, then save the returned plan body to `~/.claude/plans/issue-XXXXX.md` (5-digit zero-padded issue number) so `plan-reviewer` can read it and the file persists across sessions. Consult the client for any undecided specifications.
    - **UI Design Loop (mandatory if UI changes: yes)** — runs **before** the Plan Review Loop:
      - **Invoke `ui-designer`**: start the agent with an instruction to read `docs/design/admin/README.md` and/or `docs/design/user/README.md` that matches the feature's surface. If the feature touches both surfaces, read both and state in the invocation which surface is primary.
      - **Iterate until approval**: the agent produces an HTML mockup; present it to the client, re-invoke with any feedback, and repeat until the client approves.
@@ -99,11 +99,11 @@ P3. **Create a plan** — Review the requirements and design the implementation 
    - **Plan Review Loop (mandatory)**: Submit the plan to `plan-reviewer`. Address all actionable findings, then re-submit. Repeat until no actionable findings remain — every revision must be re-reviewed.
    - **Display element semantics**: Before designing badges, labels, icons, or status indicators, agree with the client on what they *semantically represent*. Implementation of display conditions follows from the semantic definition, not the other way around.
    - → **Done when** (all apply):
-     - the plan exists in plan mode
+     - the plan file exists at `~/.claude/plans/issue-XXXXX.md` with the body returned by the `Plan` agent
      - if `UI changes: yes` → UI Design Loop complete, mockup approved by the client, gist URL recorded in the progress file and posted on the issue
      - the most recent `plan-reviewer` run produced no actionable findings
-P4. **Document the plan** — Exit plan mode, then document the plan in the issue as a comment. Include everything exactly as it is stated in the plan file. Do NOT ask the client for approval before posting; the plan-reviewer sign-off in P3 is the gate, and the issue comment itself is the artifact the client reviews.
-   - → **Done when**: plan mode is exited and the plan is posted as a comment on the issue, verbatim from the plan file.
+P4. **Document the plan** — Document the plan in the issue as a comment. Include everything exactly as it is stated in `~/.claude/plans/issue-XXXXX.md`. Do NOT ask the client for approval before posting; the plan-reviewer sign-off in P3 is the gate, and the issue comment itself is the artifact the client reviews.
+   - → **Done when**: the plan is posted as a comment on the issue, verbatim from `~/.claude/plans/issue-XXXXX.md`.
    - **Phase complete — STOP here.** Propose `/clear` to the client and wait for instruction. Do NOT proceed to I1 on your own.
    - **Quick start**: Use the `/start-implementation-phase` skill to handle the Entry Protocol, progress file update, branch creation (I1), and I2 delegation classification automatically. In a new session, paste:
      ```
@@ -192,8 +192,8 @@ Quick rules (see `docs/process/DELEGATION.md` for the full contract):
 - **Handoff contract**: every invocation passes a payload with Issue / Goal / Plan Excerpt / Scope / Denylist / Domain Tests / Done When / Required Return Format. `Scope` is an expected-files hint (not a hard limit); `Denylist` is strict (edit forbidden, reading allowed).
 - **Shared files are orchestrator-owned**: `config/routes.rb` (stub + temporary controller at Pre-Fork), `.progress/**`, `CLAUDE.md`, `docs/**`, `.claude/**` — orchestrator edits these directly and puts them in every subagent's Denylist. `App.tsx` and `AdminLayout.tsx` are owned by `react-developer`, not the orchestrator.
 - **Dispatch patterns**: sequential (Rails → React) for typical Admin features; parallel for independent work; single-domain for one-sided tasks; direct implementation when delegation overhead outweighs the benefit.
-- **Dispatch sizing**: each agent has a hard `maxTurns` cap (currently 50). Soft cap of ~30 useful turns / ≤ 15 files per dispatch (≤ 10 when changes are non-uniform). Wholesale edits across many page files must be split into Same-type parallel batches — see DELEGATION.md → Dispatch Sizing for the rationale and the Issue #332 incident that motivated this rule.
-- **Post-receipt validation (mandatory)**: after each subagent returns, run `.claude/scripts/check-subagent-response.sh <agent_type>` (piping the verbatim response on stdin) plus the Completion Verification checklist. The script reuses the SubagentStop hook logic and is the only schema detector that runs even when the hook does not fire (e.g., maxTurns force-stop in Issue #332).
+- **Dispatch sizing**: each agent has a hard `maxTurns` cap (currently 100). Soft cap of ~30 useful turns / ≤ 15 files per dispatch (≤ 10 when changes are non-uniform). Wholesale edits across many page files must be split into Same-type parallel batches — see DELEGATION.md → Dispatch Sizing for the rule, and `docs/reference/DELEGATION_DESIGN_NOTES.md` §1–§2 for the calibration rationale and incident details.
+- **Post-receipt validation (mandatory)**: after each subagent returns, run `.claude/scripts/check-subagent-response.sh <agent_type>` (piping the verbatim response on stdin) plus the Completion Verification checklist. The script reuses the SubagentStop hook logic and is the only schema detector that runs even when the hook does not fire on `maxTurns` force-stop (詳細: `docs/reference/DELEGATION_DESIGN_NOTES.md` §1).
 - **Fallback**: on schema-check failure, domain-test failure, Denylist violation, plan deviation, or blocker stop, the orchestrator re-delegates once or falls back to direct implementation (see DELEGATION.md → Fallback Procedure).
 
 ## Reference

--- a/docs/reference/DELEGATION_DESIGN_NOTES.md
+++ b/docs/reference/DELEGATION_DESIGN_NOTES.md
@@ -1,0 +1,75 @@
+# Delegation — 設計知見
+
+`docs/process/DELEGATION.md` で I2/I4 のサブエージェント運用ルールを定めた際、根拠として残しておきたい incident 観測値・段階的ロールアウト判断・pilot 振り返り規律をここに集約する。**通常の I2/I4 実行時にはこのドキュメントを参照する必要はない**。Dispatch caps の見直し、未知の subagent 強制停止の切り分け、過去の pilot 設計判断を辿りたい時にだけ開く。
+
+ルール本体は `docs/process/DELEGATION.md` 側にあり、各ルール直下から本ドキュメントの該当章へリンクが張ってある。
+
+---
+
+## 1. Issue #332 force-stop incident — `maxTurns` 強制停止の挙動
+
+`rails-developer` / `react-developer` の `maxTurns` ハードキャップ（現在 100、incident 当時 50）を超えた dispatch は agent を mid-work で強制停止する。Issue #332 はこのリポジトリ唯一の on-record インシデントで、19 page files の wholesale token-replacement + tests + self-review を 1 dispatch に詰め込んだ結果、当時の 50-turn cap に到達した。
+
+このとき orchestrator から観測された挙動は次のとおり：
+
+- **`SubagentStop` hook が発火しなかった**。`.claude/logs/subagent_responses.jsonl` には何も書き込まれず、フックベースのスキーマ検査が動かなかった。
+- **`is_error` シグナルが orchestrator-visible なレイヤに上がってこなかった**。orchestrator が受け取ったのは in-flight `AssistantMessage` の途中（mid-sentence cutoff）テキストのみ。
+- 結果として、レスポンス本文を直接見るまで「途中で停止した」ことが判別できなかった。
+
+この観測から `docs/process/DELEGATION.md` の Dispatch Sizing と Completion Verification は **response-content signals を前提に組まれている**（フック発火に依存しない）。`.claude/scripts/check-subagent-response.sh` を毎回手動で実行する規律はこの incident が直接の動機。
+
+### Inferred, not officially confirmed
+
+ここから先は仕様確認ではなく経験則：
+
+- SDK wire format は `ToolResultBlock` に `is_error` フラグを許す。
+- 公開ドキュメント上、closed-source CLI バイナリがこのフラグをいつセットするかの完全な条件は記述されていない。
+- Issue #332 の挙動が **すべての** `maxTurns` 強制停止に一般化できるかは未検証。条件次第ではフックが発火する場合もあり得る。
+
+DELEGATION.md のルールは保守的にこの不確実性をカバーする立場 — 「フックが必ず発火する」と仮定せず、orchestrator が常に観測できるレスポンス本文に依拠する。新しい挙動を観測した場合はこの章を更新する。
+
+## 2. Empirical bound — File caps の calibration ロジック
+
+`docs/process/DELEGATION.md` の File caps（uniform 15 / non-uniform 10）は理論モデルから導出したものではなく、**Issue #332 で観測された 1 つの bound**（19-file wholesale token-replacement dispatch が 50-turn cap に到達）から逆算で calibrate した数値である。
+
+closed-form turn model — 「N files の dispatch は M turns で終わる」と決定論的に予測する式 — は持っていない。理由は次のとおり：
+
+- agent は 1 レスポンスに複数の tool call を batching できるため、turn 消費は agent の判断に依存する。
+- 同じファイル数でも、独立 read-only なら 1 turn に収まり、Read-then-Edit のシリアル化が起きると turn 数が膨らむ。
+- codex self-review は dispatch 内容にほぼ無関係に 5–10 turns を独占する。
+
+このため caps は「19 files で爆発したのだから、その手前で安全マージンを切ろう」という観測ベースの決定で、**反証可能**である。あるクラスの dispatch（例: 同型の uniform edit）が安定して cap 内に収まることが観測されたら、そのクラス限定で caps を広げる材料になる。新しいデータを得た場合は PR description にその dispatch の構成（file 数 / 編集パターン / 消費 turn 数）を明記し、本章の根拠データを蓄積する。
+
+## 3. Pilot phase rollout — Sequential → Parallel への段階的展開
+
+DELEGATION 機構を導入した初期は次の段階で慣らした：
+
+- **Start narrow**: Admin feature の追加（Rails API + React page）から開始。API 契約がクリーンで、Rails と React で工数が均しく分割でき、payoff が最大なケース。
+- **Grow cautiously**: Sequential（Rails → React）パターンが安定したのを確認してから、独立タスク向けに parallel dispatch を解禁。
+
+現在は sequential / parallel / fork-join の各パターンが定常運用に入っており、初期段階の「narrow に絞る」運用ガイダンスは役目を終えた。本ドキュメントは「なぜ今のルールセットがこの形なのか」を理解するための背景として残す。
+
+新しい dispatch パターンを追加する際は、この段階的展開の作法をテンプレートにする：まず狭いユースケースで pilot し、観測値を得てからスコープを広げる。
+
+## 4. Pilot 振り返りの規律 — observed paths と untouched paths の区別
+
+Fork-join のような複合パターンを pilot した際、振り返りの書き方には特有の落とし穴があった。Happy path だけを動かして「契約は検証済み」と書いてしまうと、fallback branch（例: post-join type-mismatch redispatch）が pilot で trigger されていないという事実が抜け落ちる。
+
+そこで pilot retrospection の規律として次を採用した：
+
+- **観測したパス**（実際に走り、artifact を生んだ経路）と
+- **未観測のパス**（happy path が触らなかった、negative evidence しかない経路）
+
+を明示的に分けて書く。fallback branch が pilot 範囲外だった場合は **untested** と明記し、その経路に関する一般化主張は避ける。
+
+この規律自体は pilot 期間が終わった現在も「観測してない経路は untested と書く」という一般則として `docs/process/DELEGATION.md` の Fallback Procedure 末尾に圧縮して残してある。pilot 期固有の言い回しと fork-join への適用例を、この章に保存する。
+
+---
+
+## Cross-references
+
+- 運用ルール本体: `docs/process/DELEGATION.md`
+- スキーマ検査スクリプト: `.claude/scripts/check-subagent-response.sh`
+- フック実装: `.claude/hooks/subagent_stop_format_check.sh`
+- Agent loop の turn 定義: [Claude Agent SDK — Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)
+- Issue #332 PR: `f8d8d13` (PR #347 — fix/issue-332-delegation-batching)


### PR DESCRIPTION
## Summary

- delegation 系ドキュメントを整理し、Issue #332 incident 観測値や pilot 期の設計判断は新設の `docs/reference/DELEGATION_DESIGN_NOTES.md` に分離。`WORKFLOW.md` / `DELEGATION.md` 本体はオペレーション規則をスキャナブルに保つ
- WORKFLOW.md の P3/P4 を更新し、Plan agent を呼び出して `~/.claude/plans/issue-XXXXX.md` に永続化する手順を明記。plan-reviewer / 後続セッションが plan 本文を読めるようにする
- 5 つの local agent (`rails-developer` / `react-developer` / `rails-reviewer` / `react-reviewer` / `architecture-reviewer`) の `maxTurns` を 50 → 100 に引き上げ、惰性で 100 まで使い切らないように **三段階セルフペーシング** (1-50: Normal / 51-75: Warning / 76-100: Convergence) を本文に明記
- 上記に伴い `WORKFLOW.md` / `DELEGATION.md` / `DELEGATION_DESIGN_NOTES.md` の "currently 50" 記述を 100 に整合 (incident 当時の history としての 50 はそのまま残す)

## Why

実装途中で `maxTurns: 50` cap に当たって 5 セクション構造の応答が壊れる事故が developer 系 agent で頻発していた。上限を 2 倍に広げて余裕を確保しつつ、後半は新規実装単位を増やさず Required Return Format 出力に直行させる収束指示を入れることで、cap 到達による応答崩壊を抑える狙い。同じ PR で WORKFLOW/DELEGATION のドキュメント整理も進め、規則本体と incident 根拠を分離した。

## Three-phase self-pacing

サブエージェントは正確な現在ターン数を取得する API を持たないため、tool 呼び出し履歴を概算で振り返って自己位置を測る前提で記述している (1 tool call ≈ 1 turn)。

- **1-50 Normal** — 通常作業
- **51-75 Warning** — 残課題を棚卸し、polish カット、新規実装単位は critical path のみ
- **76-100 Convergence** — 新規作業停止、Required Return Format 出力に直行、未完項目は Deviations / Handoff Notes / Reviewer Notes に列挙

developer 2 つはフル版 (テスト実行 + codex self-review への配慮込み)、reviewer 3 つは軽量版 (もともと codex review 1 発で完結する短いフローのため)。

## Test plan

- [x] `grep -E '^maxTurns:' .claude/agents/*.md` で全ファイル `maxTurns: 100` を確認
- [x] `grep -nE '^## Turn Budget Management' .claude/agents/*.md` で全 5 ファイルにセクション存在を確認
- [x] 各 agent ファイル末尾の改行 (0a) を確認 (CLAUDE.md "blank line at EOF" 規約)
- [x] 各 agent ファイルの frontmatter 構造 (`---` の開閉) が健全であることを確認
- [x] `WORKFLOW.md` / `DELEGATION.md` / `DELEGATION_DESIGN_NOTES.md` の "currently 50" を 100 に整合 (incident 当時の history 言及は意図的に残置)
- [x] pre-push hook (rubocop / TypeScript typecheck) が通ることを確認
- [ ] 次回 rails-developer / react-developer をオーケストレーターから呼ぶ機会で、return が 5 セクション構造を維持しているかを観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)