### PR TITLE
chore(test): per-process SQLite test DB to avoid cross-launch lock

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
 
 test:
   <<: *default
-  database: storage/test.sqlite3
+  database: <%= ENV.fetch("TEST_DATABASE_PATH", "storage/test.sqlite3") %>
 
 production:
   <<: *default

--- a/docs/conventions/TESTING.md
+++ b/docs/conventions/TESTING.md
@@ -42,6 +42,20 @@
 
 症状の見分け方: テスト実行時間が異常に短い（例: 159テストが3.7秒 vs 正常時24秒）、かつ全コントローラテストが一律同一ステータス。
 
+## 並列起動と DB ファイル分離
+
+別ターミナルで `bin/rails test:auth` と `bin/rails test:task` のように複数の `bin/rails test:*` を同時起動しても **`database is locked` で落ちない**。`test/test_helper.rb` が起動ごとに `storage/test_<pid>.sqlite3` を使うので、プロセス間で DB ファイルが衝突しない（Rails の `parallelize(workers:)` は同一プロセス内のワーカー DB しか分離しないため、本仕組みでプロセス間衝突を別途解消している）。
+
+通常終了時は `at_exit` で `storage/test_<pid>.sqlite3*`（worker 用 `-1`/`-2`、SQLite の `-shm`/`-wal` 含む）が自動掃除される。**強制終了**（`kill -9`、OS crash 等）時は `at_exit` が走らず orphan が残るので、必要に応じて `rm -f storage/test_*.sqlite3*` で手動掃除する。
+
+固定 DB パスを使いたい場合は `TEST_DATABASE_PATH` を export する:
+
+```sh
+TEST_DATABASE_PATH=storage/test.sqlite3 bin/rails test:auth   # 従来挙動（並列起動時は衝突する点に注意）
+```
+
+**注意**: `db:test:prepare` / `db:seed:replant` 等 `test_helper.rb` を読まない rake タスクは `TEST_DATABASE_PATH` を尊重しない。常にデフォルトの `storage/test.sqlite3` に作用する。
+
 ## Rails 8 `bin/rails test:*` の dispatch 罠
 
 Rails 7+/8 では `bin/rails test:*` コマンドは **Rake をバイパスして `Rails::Command::TestCommand` (Thor) に直送される**。以下の地雷に注意。

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,34 @@ SimpleCov.start "rails" do
   command_name "minitest-worker-#{ENV.fetch('TEST_ENV_NUMBER', 0)}"
 end
 
+require "fileutils"
+
+# Per-process test DB so parallel `bin/rails test:*` launches in different
+# terminals don't fight over the shared `storage/test.sqlite3` lock.
+# See docs/conventions/TESTING.md "並列起動と DB ファイル分離".
+ENV["TEST_DATABASE_PATH"] ||= "storage/test_#{Process.pid}.sqlite3"
+
+# Capture the parent PID so forked parallel workers (which inherit this
+# at_exit via fork) skip cleanup — otherwise a worker exiting early would
+# unlink sibling workers' still-active DB files (`storage/test_<pid>.sqlite3_0`,
+# `_1`, ... + `-shm`/`-wal`).
+parent_pid_for_cleanup = Process.pid
+
+# Registered before Rails environment load so Rails' own AR-disconnect
+# at_exit hooks are pushed onto the LIFO stack later and run FIRST. We
+# unlink the files only after AR has cleanly closed connections.
+at_exit do
+  next unless Process.pid == parent_pid_for_cleanup
+
+  base = ENV.fetch("TEST_DATABASE_PATH", nil)
+  # Strict allowlist: must live directly under `storage/`, start with
+  # `test_`, and end in `.sqlite3`. Rejects the legacy default
+  # (`storage/test.sqlite3`) and path-traversal attempts (`storage/test_../...`).
+  next unless base&.match?(%r{\Astorage/test_[\w.-]+\.sqlite3\z})
+
+  FileUtils.rm_f(Dir.glob("#{base}*"))
+end
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"


### PR DESCRIPTION
## Summary
- Per-process SQLite test DB (`storage/test_<pid>.sqlite3`) for `bin/rails test:*`, eliminating cross-launch `database is locked` errors when multiple terminals run domain suites in parallel.
- `at_exit` cleanup is fork-safe (parent PID guard so forked workers don't unlink siblings' active DB files) and path-traversal-safe (anchored regex allowlist).
- Closes #348.

## Test plan
- [x] `bin/rails test:auth` single run — PASS, storage cleaned up
- [x] Parallel `bin/rails test:auth` × `bin/rails test:task` (rake×rake) — both PASS, 0 lock errors, cleanup OK
- [x] Parallel `bin/rails test ...` × `bin/rails test:auth` (Thor×rake) — both PASS, 0 lock errors, cleanup OK
- [x] `bin/rails test:all` full suite — passes minus pre-existing flake tracked in #301
- [x] Probe verification: regex 8 patterns ALLOW/DENY as expected, fork child skips cleanup
- [x] Re-review by architecture-reviewer after HIGH (concurrency/race) + LOW (path-safety) fixes: No actionable findings

## Trade-off
- Each `bin/rails test:*` launch incurs schema-load cost (measured: main warm 21.8s vs branch cold ~28-34s, delta ≈ +6-10s on this codebase). Opt-out: `TEST_DATABASE_PATH=storage/test.sqlite3` (returns to legacy single-DB behavior, with cross-launch lock risk).
- Orphan DB on `kill -9` / OS crash: manual `rm -f storage/test_*.sqlite3*`.
- `db:test:prepare` / `db:seed:replant` (rake tasks that don't load `test_helper.rb`) ignore `TEST_DATABASE_PATH` and use the default — documented in `docs/conventions/TESTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)