### PR TITLE
feat(admin): #351 サイドバー開閉(desktop rail / mobile drawer)対応

### DIFF
--- a/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { AdminLayout, navSections } from '../../components/AdminLayout'
+import { AdminLayout } from '../../components/AdminLayout'
+import { navSections } from '../../lib/navConfig'
 
 // Mock useAuth
 const mockCan = vi.fn()
@@ -11,6 +12,20 @@ vi.mock('../../contexts/AuthContext', () => ({
     can: mockCan,
   }),
 }))
+
+// matchMedia helper
+function makeMatchMedia(isDesktop: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(min-width: 768px)' ? isDesktop : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
 
 describe('navSections', () => {
   it('has three sections: NAVIGATION, ADMIN, AI INFRASTRUCTURE', () => {
@@ -61,8 +76,15 @@ describe('AdminLayout', () => {
       </MemoryRouter>
     )
 
+  beforeEach(() => {
+    localStorage.clear()
+    // Default to desktop
+    window.matchMedia = makeMatchMedia(true)
+  })
+
   afterEach(() => {
     mockCan.mockReset()
+    vi.restoreAllMocks()
   })
 
   it('hides section header when all items are filtered out', () => {
@@ -104,5 +126,51 @@ describe('AdminLayout', () => {
 
     expect(screen.queryByText('Users')).not.toBeInTheDocument()
     expect(screen.getByText('Admin Accounts')).toBeInTheDocument()
+  })
+
+  // New case: clicking desktop toggle flips expanded state
+  it('clicking desktop toggle button changes aria-expanded', () => {
+    mockCan.mockReturnValue(true)
+
+    renderLayout()
+
+    // Initially expanded (localStorage empty = default expanded)
+    const toggleButton = screen.getByRole('button', { name: 'Collapse sidebar' })
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(toggleButton)
+
+    // After click: collapsed
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+  })
+
+  // New case: hamburger is present on mobile viewport
+  it('hamburger button is present in DOM (md:hidden controls visual display)', () => {
+    // Even on desktop matchMedia mock, the hamburger exists in DOM — md:hidden is CSS-only
+    mockCan.mockReturnValue(true)
+
+    renderLayout()
+
+    const hamburger = screen.getByRole('button', { name: 'Open navigation menu' })
+    expect(hamburger).toBeInTheDocument()
+  })
+
+  // New case: backdrop click closes mobile drawer
+  it('backdrop click closes mobile drawer', () => {
+    // Set mobile viewport and pre-open mobile drawer
+    window.matchMedia = makeMatchMedia(false)
+    localStorage.setItem('admin.sidebar.mobile', 'open')
+    mockCan.mockReturnValue(true)
+
+    renderLayout()
+
+    // Backdrop should be present (mobile + open)
+    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement
+    expect(backdrop).toBeInTheDocument()
+
+    fireEvent.click(backdrop)
+
+    // After click, backdrop should be gone (isMobileOpen = false)
+    expect(document.querySelector('[aria-hidden="true"]')).toBeNull()
   })
 })

--- a/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AdminLayout } from '../../components/AdminLayout'
 import { navSections } from '../../lib/navConfig'
+import { makeMatchMedia } from '../helpers/matchMedia'
 
 // Mock useAuth
 const mockCan = vi.fn()
@@ -12,20 +13,6 @@ vi.mock('../../contexts/AuthContext', () => ({
     can: mockCan,
   }),
 }))
-
-// matchMedia helper
-function makeMatchMedia(isDesktop: boolean) {
-  return vi.fn().mockImplementation((query: string) => ({
-    matches: query === '(min-width: 768px)' ? isDesktop : false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }))
-}
 
 describe('navSections', () => {
   it('has three sections: NAVIGATION, ADMIN, AI INFRASTRUCTURE', () => {

--- a/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminLayout.test.tsx
@@ -165,12 +165,12 @@ describe('AdminLayout', () => {
     renderLayout()
 
     // Backdrop should be present (mobile + open)
-    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement
+    const backdrop = document.querySelector('[data-testid="admin-sidebar-backdrop"]') as HTMLElement
     expect(backdrop).toBeInTheDocument()
 
     fireEvent.click(backdrop)
 
     // After click, backdrop should be gone (isMobileOpen = false)
-    expect(document.querySelector('[aria-hidden="true"]')).toBeNull()
+    expect(document.querySelector('[data-testid="admin-sidebar-backdrop"]')).toBeNull()
   })
 })

--- a/app/javascript/admin/__tests__/components/AdminSidebar.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminSidebar.test.tsx
@@ -1,20 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AdminSidebar } from '../../components/AdminSidebar'
-
-// matchMedia mock helper
-function makeMatchMedia(isDesktop: boolean) {
-  return vi.fn().mockImplementation((query: string) => ({
-    matches: query === '(min-width: 768px)' ? isDesktop : false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }))
-}
+import { makeMatchMedia } from '../helpers/matchMedia'
 
 const defaultProps = {
   isDesktop: true,
@@ -71,23 +58,22 @@ describe('AdminSidebar', () => {
     expect(dashboardLink).toHaveAttribute('aria-label', 'Dashboard')
   })
 
-  // Case 3: Tooltip element is present on hover (DOM rendered; CSS handles opacity)
-  it('renders tooltip elements when collapsed', () => {
+  // Case 3: Visual tooltip span is rendered when collapsed (CSS handles opacity).
+  // The span is aria-hidden — AT users get the link label via aria-label on the <Link>.
+  it('renders visual tooltip spans when collapsed', () => {
     renderSidebar({ isDesktop: true, isDesktopExpanded: false })
 
-    // Tooltip DOM elements are rendered for collapsed nav items
-    const tooltips = screen.getAllByRole('tooltip')
-    expect(tooltips.length).toBeGreaterThan(0)
-    expect(tooltips[0]).toHaveTextContent('Dashboard')
+    const visualTooltips = document.querySelectorAll('span[aria-hidden="true"].pointer-events-none')
+    expect(visualTooltips.length).toBeGreaterThan(0)
+    expect(visualTooltips[0]).toHaveTextContent('Dashboard')
   })
 
-  // Case 4: Tooltip elements present for keyboard navigation when collapsed
-  it('tooltip elements are present for keyboard navigation when collapsed', () => {
+  // Case 4: Visual tooltip spans are in DOM regardless of focus (CSS group-focus-within shows them on Tab)
+  it('visual tooltip spans are in DOM for keyboard navigation when collapsed', () => {
     renderSidebar({ isDesktop: true, isDesktopExpanded: false })
 
-    // All nav link tooltips are in the DOM (CSS group-focus-within shows them)
-    const tooltips = screen.getAllByRole('tooltip')
-    expect(tooltips.length).toBeGreaterThan(0)
+    const visualTooltips = document.querySelectorAll('span[aria-hidden="true"].pointer-events-none')
+    expect(visualTooltips.length).toBeGreaterThan(0)
   })
 
   // Case 5: Clicking the desktop toggle button calls onToggleDesktop

--- a/app/javascript/admin/__tests__/components/AdminSidebar.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminSidebar.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AdminSidebar } from '../../components/AdminSidebar'
+
+// matchMedia mock helper
+function makeMatchMedia(isDesktop: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(min-width: 768px)' ? isDesktop : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+const defaultProps = {
+  isDesktop: true,
+  isDesktopExpanded: true,
+  isMobileOpen: false,
+  onToggleDesktop: vi.fn(),
+  onCloseMobile: vi.fn(),
+  user: { name: 'Test Admin', email: 'admin@example.com' },
+  logout: vi.fn(),
+  can: vi.fn().mockReturnValue(true),
+}
+
+const renderSidebar = (props: Partial<typeof defaultProps> = {}) =>
+  render(
+    <MemoryRouter initialEntries={['/admin']}>
+      <AdminSidebar {...defaultProps} {...props} />
+    </MemoryRouter>
+  )
+
+describe('AdminSidebar', () => {
+  beforeEach(() => {
+    window.matchMedia = makeMatchMedia(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Case 1: Expanded mode renders visible labels for all nav items
+  it('renders visible nav item labels when expanded', () => {
+    renderSidebar({ isDesktop: true, isDesktopExpanded: true })
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Users')).toBeInTheDocument()
+    expect(screen.getByText('Admin Accounts')).toBeInTheDocument()
+
+    // Labels should NOT have sr-only class (they should be visible)
+    const dashboardLabel = screen.getByText('Dashboard')
+    expect(dashboardLabel).not.toHaveClass('sr-only')
+  })
+
+  // Case 2: Collapsed mode applies sr-only to labels and aria-label on links
+  it('applies sr-only to labels and aria-label on links when collapsed', () => {
+    renderSidebar({ isDesktop: true, isDesktopExpanded: false })
+
+    // The <span> label (not the tooltip) should have sr-only class.
+    // getAllByText because the text appears in both the sr-only span and the tooltip span.
+    const dashboardTextNodes = screen.getAllByText('Dashboard')
+    const srOnlyNode = dashboardTextNodes.find((el) => el.classList.contains('sr-only'))
+    expect(srOnlyNode).toBeTruthy()
+
+    // Links have aria-label when collapsed
+    const dashboardLink = screen.getByRole('link', { name: 'Dashboard' })
+    expect(dashboardLink).toHaveAttribute('aria-label', 'Dashboard')
+  })
+
+  // Case 3: Tooltip element is present on hover (DOM rendered; CSS handles opacity)
+  it('renders tooltip elements when collapsed', () => {
+    renderSidebar({ isDesktop: true, isDesktopExpanded: false })
+
+    // Tooltip DOM elements are rendered for collapsed nav items
+    const tooltips = screen.getAllByRole('tooltip')
+    expect(tooltips.length).toBeGreaterThan(0)
+    expect(tooltips[0]).toHaveTextContent('Dashboard')
+  })
+
+  // Case 4: Tooltip elements present for keyboard navigation when collapsed
+  it('tooltip elements are present for keyboard navigation when collapsed', () => {
+    renderSidebar({ isDesktop: true, isDesktopExpanded: false })
+
+    // All nav link tooltips are in the DOM (CSS group-focus-within shows them)
+    const tooltips = screen.getAllByRole('tooltip')
+    expect(tooltips.length).toBeGreaterThan(0)
+  })
+
+  // Case 5: Clicking the desktop toggle button calls onToggleDesktop
+  it('calls onToggleDesktop when chevron toggle button is clicked', () => {
+    const onToggleDesktop = vi.fn()
+    renderSidebar({ isDesktop: true, isDesktopExpanded: true, onToggleDesktop })
+
+    const toggleButton = screen.getByRole('button', { name: 'Collapse sidebar' })
+    fireEvent.click(toggleButton)
+
+    expect(onToggleDesktop).toHaveBeenCalledTimes(1)
+  })
+
+  // Case 6 (B1): Mobile mode renders in-drawer close button; clicking calls onCloseMobile
+  it('renders in-drawer close button on mobile and calls onCloseMobile on click', () => {
+    const onCloseMobile = vi.fn()
+    renderSidebar({ isDesktop: false, isMobileOpen: true, onCloseMobile })
+
+    const closeButton = screen.getByRole('button', { name: 'Close navigation' })
+    expect(closeButton).toBeInTheDocument()
+
+    fireEvent.click(closeButton)
+    expect(onCloseMobile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/javascript/admin/__tests__/components/AdminSidebarBackdrop.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminSidebarBackdrop.test.tsx
@@ -20,7 +20,7 @@ describe('AdminSidebarBackdrop', () => {
     const onClose = vi.fn()
     render(<AdminSidebarBackdrop isOpen={true} isDesktop={false} onClose={onClose} />)
 
-    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement
+    const backdrop = document.querySelector('[data-testid="admin-sidebar-backdrop"]') as HTMLElement
     fireEvent.click(backdrop)
 
     expect(onClose).toHaveBeenCalledTimes(1)

--- a/app/javascript/admin/__tests__/components/AdminSidebarBackdrop.test.tsx
+++ b/app/javascript/admin/__tests__/components/AdminSidebarBackdrop.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render } from '@testing-library/react'
+import { AdminSidebarBackdrop } from '../../components/AdminSidebarBackdrop'
+
+describe('AdminSidebarBackdrop', () => {
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(
+      <AdminSidebarBackdrop isOpen={false} isDesktop={false} onClose={vi.fn()} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when isDesktop is true (desktop mode)', () => {
+    const { container } = render(
+      <AdminSidebarBackdrop isOpen={true} isDesktop={true} onClose={vi.fn()} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(<AdminSidebarBackdrop isOpen={true} isDesktop={false} onClose={onClose} />)
+
+    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement
+    fireEvent.click(backdrop)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/javascript/admin/__tests__/helpers/matchMedia.ts
+++ b/app/javascript/admin/__tests__/helpers/matchMedia.ts
@@ -1,0 +1,21 @@
+import { vi } from 'vitest'
+
+/**
+ * Build a `window.matchMedia` mock that responds to the desktop breakpoint query
+ * (`(min-width: 768px)`) with the given `isDesktop` value. Other queries report `false`.
+ *
+ * Per-test override pattern (used by tests that need to fire `change` events):
+ * `window.matchMedia = vi.fn().mockImplementation(...)` in `beforeEach`.
+ */
+export function makeMatchMedia(isDesktop: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(min-width: 768px)' ? isDesktop : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}

--- a/app/javascript/admin/__tests__/hooks/useSidebarState.test.tsx
+++ b/app/javascript/admin/__tests__/hooks/useSidebarState.test.tsx
@@ -1,0 +1,236 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSidebarState } from '../../hooks/useSidebarState'
+
+// Helper to build a matchMedia mock that responds to the desktop query
+function makeMatchMedia(isDesktop: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(min-width: 768px)' ? isDesktop : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+describe('useSidebarState', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    // Default: desktop viewport
+    window.matchMedia = makeMatchMedia(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Case 1: Default state when no localStorage entries.
+  // Desktop expanded (additive — sidebar is in normal flow).
+  // Mobile closed (off-canvas drawer should not obscure content by default).
+  it('defaults to desktop=expanded, mobile=closed when localStorage has no entries', () => {
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isDesktopExpanded).toBe(true)
+    expect(result.current.isMobileOpen).toBe(false)
+  })
+
+  // Case 2: Reads existing localStorage values
+  it('reads existing localStorage values', () => {
+    localStorage.setItem('admin.sidebar.desktop', 'collapsed')
+    localStorage.setItem('admin.sidebar.mobile', 'closed')
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isDesktopExpanded).toBe(false)
+    expect(result.current.isMobileOpen).toBe(false)
+  })
+
+  // Case 3: toggleDesktop flips state and writes the correct key
+  it('toggleDesktop flips state and persists to localStorage', () => {
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isDesktopExpanded).toBe(true)
+
+    act(() => result.current.toggleDesktop())
+
+    expect(result.current.isDesktopExpanded).toBe(false)
+    expect(localStorage.getItem('admin.sidebar.desktop')).toBe('collapsed')
+
+    act(() => result.current.toggleDesktop())
+
+    expect(result.current.isDesktopExpanded).toBe(true)
+    expect(localStorage.getItem('admin.sidebar.desktop')).toBe('expanded')
+  })
+
+  // Case 4: toggleMobile flips state and writes the correct key
+  it('toggleMobile flips state and persists to localStorage', () => {
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isMobileOpen).toBe(false)
+
+    act(() => result.current.toggleMobile())
+
+    expect(result.current.isMobileOpen).toBe(true)
+    expect(localStorage.getItem('admin.sidebar.mobile')).toBe('open')
+
+    act(() => result.current.toggleMobile())
+
+    expect(result.current.isMobileOpen).toBe(false)
+    expect(localStorage.getItem('admin.sidebar.mobile')).toBe('closed')
+  })
+
+  // Case 5: localStorage write failure is swallowed; in-memory state still flips
+  it('swallows localStorage write errors and still flips in-memory state', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+
+    const { result } = renderHook(() => useSidebarState())
+    act(() => result.current.toggleDesktop())
+
+    expect(result.current.isDesktopExpanded).toBe(false)
+  })
+
+  // Case 6: matchMedia change false→true (mobile→desktop) closes mobile in memory
+  it('closes mobile in memory when viewport crosses to desktop', () => {
+    // Pre-seed mobile=open so we can observe the in-memory close on viewport crossing.
+    localStorage.setItem('admin.sidebar.mobile', 'open')
+
+    // Capture the addEventListener calls so we can fire the change event
+    const listeners: Array<(e: MediaQueryListEvent) => void> = []
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (e: MediaQueryListEvent) => void) => {
+          listeners.push(handler)
+        }
+      ),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isMobileOpen).toBe(true)
+
+    // Simulate crossing to desktop
+    act(() => {
+      listeners.forEach((fn) =>
+        fn({ matches: true } as MediaQueryListEvent)
+      )
+    })
+
+    expect(result.current.isMobileOpen).toBe(false)
+    expect(result.current.isDesktop).toBe(true)
+  })
+
+  // Case 7 (S1): mobile→desktop transition does NOT mutate admin.sidebar.mobile in localStorage
+  it('does not write admin.sidebar.mobile when crossing mobile→desktop', () => {
+    const listeners: Array<(e: MediaQueryListEvent) => void> = []
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (e: MediaQueryListEvent) => void) => {
+          listeners.push(handler)
+        }
+      ),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    renderHook(() => useSidebarState())
+
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+    act(() => {
+      listeners.forEach((fn) =>
+        fn({ matches: true } as MediaQueryListEvent)
+      )
+    })
+
+    const mobileWrites = setItemSpy.mock.calls.filter(
+      ([key]) => key === 'admin.sidebar.mobile'
+    )
+    expect(mobileWrites).toHaveLength(0)
+  })
+
+  // Case 8: Esc keydown when isMobileOpen && !isDesktop calls closeMobile
+  it('closes mobile drawer on Esc key when mobile is open', () => {
+    window.matchMedia = makeMatchMedia(false)
+    localStorage.setItem('admin.sidebar.mobile', 'open')
+
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isMobileOpen).toBe(true)
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(result.current.isMobileOpen).toBe(false)
+  })
+
+  // Case 9 (S1): Esc keydown on desktop is a no-op (does not toggle desktop expanded state)
+  it('Esc key on desktop does not change isDesktopExpanded', () => {
+    window.matchMedia = makeMatchMedia(true)
+
+    const { result } = renderHook(() => useSidebarState())
+    const before = result.current.isDesktopExpanded
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(result.current.isDesktopExpanded).toBe(before)
+  })
+
+  // Case 11 (H2): desktop→mobile transition rehydrates isMobileOpen from localStorage
+  it('rehydrates isMobileOpen from localStorage on desktop→mobile transition', () => {
+    // Start desktop, with mobile previously saved as 'open'
+    localStorage.setItem('admin.sidebar.mobile', 'open')
+
+    const listeners: Array<(e: MediaQueryListEvent) => void> = []
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (e: MediaQueryListEvent) => void) => {
+          listeners.push(handler)
+        }
+      ),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    const { result } = renderHook(() => useSidebarState())
+    expect(result.current.isDesktop).toBe(true)
+
+    // Simulate crossing to mobile
+    act(() => {
+      listeners.forEach((fn) => fn({ matches: false } as MediaQueryListEvent))
+    })
+
+    expect(result.current.isDesktop).toBe(false)
+    expect(result.current.isMobileOpen).toBe(true)
+  })
+
+  // Case 10 (S1): Unmount removes the keydown listener
+  it('removes keydown listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+    const { unmount } = renderHook(() => useSidebarState())
+    unmount()
+
+    const keydownRemovals = removeSpy.mock.calls.filter(
+      ([event]) => event === 'keydown'
+    )
+    expect(keydownRemovals.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/app/javascript/admin/__tests__/hooks/useSidebarState.test.tsx
+++ b/app/javascript/admin/__tests__/hooks/useSidebarState.test.tsx
@@ -1,20 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSidebarState } from '../../hooks/useSidebarState'
-
-// Helper to build a matchMedia mock that responds to the desktop query
-function makeMatchMedia(isDesktop: boolean) {
-  return vi.fn().mockImplementation((query: string) => ({
-    matches: query === '(min-width: 768px)' ? isDesktop : false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }))
-}
+import { makeMatchMedia } from '../helpers/matchMedia'
 
 describe('useSidebarState', () => {
   beforeEach(() => {

--- a/app/javascript/admin/__tests__/setup.ts
+++ b/app/javascript/admin/__tests__/setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom/vitest'
+
+// window.matchMedia polyfill for jsdom (jsdom does not implement matchMedia).
+// Individual tests can override per-test with:
+//   beforeEach(() => { window.matchMedia = vi.fn().mockImplementation(query => ({ matches: false, ... })) })
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})

--- a/app/javascript/admin/components/AdminHeader.tsx
+++ b/app/javascript/admin/components/AdminHeader.tsx
@@ -1,0 +1,43 @@
+import { useLocation } from 'react-router-dom'
+import { navSections } from '../lib/navConfig'
+
+type AdminHeaderProps = {
+  isMobileOpen: boolean
+  onMobileToggle: () => void
+}
+
+export function AdminHeader({ isMobileOpen, onMobileToggle }: AdminHeaderProps) {
+  const location = useLocation()
+
+  const isActive = (to: string, exact?: boolean) => {
+    if (exact) return location.pathname === to
+    return location.pathname.startsWith(to)
+  }
+
+  const activeLabel =
+    navSections.flatMap((s) => s.items).find((i) => isActive(i.to, i.exact))?.label ?? 'Admin'
+
+  return (
+    <header className="flex h-14 shrink-0 items-center border-b border-slate-200 bg-white px-4 md:px-6">
+      {/* Hamburger button — mobile only */}
+      <button
+        type="button"
+        onClick={onMobileToggle}
+        aria-label={isMobileOpen ? 'Close navigation menu' : 'Open navigation menu'}
+        aria-controls="admin-sidebar"
+        aria-expanded={isMobileOpen}
+        className="mr-3 flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 md:hidden"
+      >
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+
+      {/* Breadcrumb-style page label */}
+      <div className="flex flex-1 items-center gap-2 text-sm text-slate-400">
+        <span className="text-slate-300">/</span>
+        <span className="font-medium text-slate-600">{activeLabel}</span>
+      </div>
+    </header>
+  )
+}

--- a/app/javascript/admin/components/AdminLayout.tsx
+++ b/app/javascript/admin/components/AdminLayout.tsx
@@ -1,138 +1,15 @@
-import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
-import { Action, ResourceType } from '../lib/api'
+import { Outlet, useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
-import Avatar from './Avatar'
-
-type NavItem = {
-  to: string
-  label: string
-  exact?: boolean
-  icon: React.ReactNode
-  requiredCapability?: { resource: ResourceType; action: Action }
-}
-
-export const navSections: { label: string; items: NavItem[] }[] = [
-  {
-    label: 'NAVIGATION',
-    items: [
-      {
-        to: '/admin',
-        label: 'Dashboard',
-        exact: true,
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/events',
-        label: 'Event Logs',
-        requiredCapability: { resource: 'EventLog', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/system-info',
-        label: 'System Info',
-        requiredCapability: { resource: 'Admin', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/users',
-        label: 'Users',
-        requiredCapability: { resource: 'User', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
-          </svg>
-        ),
-      },
-    ],
-  },
-  {
-    label: 'ADMIN',
-    items: [
-      {
-        to: '/admin/admin-accounts',
-        label: 'Admin Accounts',
-        requiredCapability: { resource: 'Admin', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/roles',
-        label: 'Roles',
-        requiredCapability: { resource: 'Admin', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/permissions',
-        label: 'Permissions',
-        requiredCapability: { resource: 'Admin', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" />
-          </svg>
-        ),
-      },
-    ],
-  },
-  {
-    label: 'AI INFRASTRUCTURE',
-    items: [
-      {
-        to: '/admin/llm-providers',
-        label: 'LLM Providers',
-        requiredCapability: { resource: 'LlmProvider', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/prompt-sets',
-        label: 'Prompt Sets',
-        requiredCapability: { resource: 'LlmProvider', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-          </svg>
-        ),
-      },
-      {
-        to: '/admin/suggestion-configs',
-        label: 'Suggestion Configs',
-        requiredCapability: { resource: 'LlmProvider', action: 'read' },
-        icon: (
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75" />
-          </svg>
-        ),
-      },
-    ],
-  },
-]
+import { useSidebarState } from '../hooks/useSidebarState'
+import { AdminSidebar } from './AdminSidebar'
+import { AdminSidebarBackdrop } from './AdminSidebarBackdrop'
+import { AdminHeader } from './AdminHeader'
 
 export const AdminLayout = () => {
   const { user, logout, can } = useAuth()
   const navigate = useNavigate()
-  const location = useLocation()
+  const { isDesktop, isDesktopExpanded, isMobileOpen, toggleDesktop, toggleMobile, closeMobile } =
+    useSidebarState()
 
   const handleLogout = async () => {
     try {
@@ -143,98 +20,21 @@ export const AdminLayout = () => {
     navigate('/admin/login')
   }
 
-  const isActive = (item: NavItem) => {
-    if (item.exact) return location.pathname === item.to
-    return location.pathname.startsWith(item.to)
-  }
-
   return (
-    <div className="flex min-h-screen bg-[#f8f9fc]">
-      {/* Sidebar */}
-      <nav className="flex w-[220px] shrink-0 flex-col border-r border-[#1e2130] bg-[#0f1117]">
-        {/* Logo */}
-        <div className="flex items-center gap-3 border-b border-[#1e2130] px-4 py-5">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#6366f1] shadow-md shadow-indigo-500/30">
-            <svg className="h-4 w-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2v-4M9 21H5a2 2 0 01-2-2v-4m0 0h18" />
-            </svg>
-          </div>
-          <div>
-            <p className="text-sm font-bold leading-none text-white" style={{ fontFamily: 'Syne, sans-serif' }}>Hobo Admin</p>
-            <p className="mt-0.5 text-[9px] tracking-[0.15em] text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>CONTROL PANEL</p>
-          </div>
-        </div>
-
-        {/* Navigation */}
-        <div className="flex-1 overflow-y-auto py-4">
-          {navSections.map((section) => {
-            const visibleItems = section.items.filter((item) =>
-              !item.requiredCapability || can(item.requiredCapability.resource, item.requiredCapability.action)
-            )
-            if (visibleItems.length === 0) return null
-            return (
-              <div key={section.label} className="mb-4 px-3">
-                <p className="mb-2 px-2 text-[9px] font-semibold tracking-[0.15em] text-slate-600" style={{ fontFamily: 'DM Mono, monospace' }}>
-                  {section.label}
-                </p>
-                <ul className="space-y-0.5">
-                  {visibleItems.map((item) => {
-                    const active = isActive(item)
-                    return (
-                      <li key={item.to}>
-                        <Link
-                          to={item.to}
-                          className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
-                            active
-                              ? 'bg-[rgba(99,102,241,0.15)] text-[#6366f1]'
-                              : 'text-slate-400 hover:bg-white/5 hover:text-slate-200'
-                          }`}
-                        >
-                          <span className={active ? 'text-[#6366f1]' : 'text-slate-600'}>{item.icon}</span>
-                          {item.label}
-                        </Link>
-                      </li>
-                    )
-                  })}
-                </ul>
-              </div>
-            )
-          })}
-        </div>
-
-        {/* User footer */}
-        <div className="border-t border-[#1e2130] px-3 py-4">
-          <div className="flex items-center gap-3 rounded-lg px-2 py-2">
-            <Avatar name={user?.name ?? user?.email ?? 'A'} size="sm" />
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-xs font-medium text-slate-200">{user?.name ?? user?.email}</p>
-              <p className="text-[10px] text-slate-500">Super Admin</p>
-            </div>
-          </div>
-          <button
-            onClick={handleLogout}
-            className="mt-2 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
-          >
-            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
-            </svg>
-            Logout
-          </button>
-        </div>
-      </nav>
-
-      {/* Main content */}
+    <div className="flex min-h-screen bg-surface">
+      <AdminSidebarBackdrop isOpen={isMobileOpen} isDesktop={isDesktop} onClose={closeMobile} />
+      <AdminSidebar
+        isDesktop={isDesktop}
+        isDesktopExpanded={isDesktopExpanded}
+        isMobileOpen={isMobileOpen}
+        onToggleDesktop={toggleDesktop}
+        onCloseMobile={closeMobile}
+        user={user}
+        logout={handleLogout}
+        can={can}
+      />
       <div className="flex min-w-0 flex-1 flex-col">
-        {/* Top header */}
-        <header className="flex h-14 shrink-0 items-center border-b border-slate-200 bg-white px-6">
-          <div className="flex flex-1 items-center gap-2 text-sm text-slate-400">
-            <span className="text-slate-300">/</span>
-            <span className="font-medium text-slate-600">
-              {navSections.flatMap(s => s.items).find(i => isActive(i))?.label ?? 'Admin'}
-            </span>
-          </div>
-        </header>
-
+        <AdminHeader isMobileOpen={isMobileOpen} onMobileToggle={toggleMobile} />
         <main className="flex-1 overflow-y-auto p-6">
           <Outlet />
         </main>

--- a/app/javascript/admin/components/AdminSidebar.tsx
+++ b/app/javascript/admin/components/AdminSidebar.tsx
@@ -192,6 +192,7 @@ export function AdminSidebar({
           <div className="flex flex-col items-center gap-2">
             <Avatar name={user?.name ?? user?.email ?? 'A'} size="sm" />
             <button
+              type="button"
               onClick={logout}
               aria-label="Logout"
               className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
@@ -211,6 +212,7 @@ export function AdminSidebar({
               </div>
             </div>
             <button
+              type="button"
               onClick={logout}
               className="mt-2 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
             >

--- a/app/javascript/admin/components/AdminSidebar.tsx
+++ b/app/javascript/admin/components/AdminSidebar.tsx
@@ -1,0 +1,227 @@
+import { Link, useLocation } from 'react-router-dom'
+import { Action, ResourceType } from '../lib/api'
+import { navSections, type NavItem } from '../lib/navConfig'
+import Avatar from './Avatar'
+
+type NavItemProps = {
+  item: NavItem
+  collapsed: boolean
+  active: boolean
+}
+
+function NavItem({ item, collapsed, active }: NavItemProps) {
+  return (
+    <li>
+      <Link
+        to={item.to}
+        aria-label={collapsed ? item.label : undefined}
+        className={`group relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+          active
+            ? 'bg-accent/15 text-accent'
+            : 'text-slate-400 hover:bg-white/5 hover:text-slate-200'
+        }`}
+      >
+        <span className={`shrink-0 ${active ? 'text-accent' : 'text-slate-600'}`}>
+          {item.icon}
+        </span>
+        <span className={collapsed ? 'sr-only' : ''}>{item.label}</span>
+        {collapsed && (
+          <span
+            role="tooltip"
+            className="pointer-events-none absolute left-full ml-2 z-50 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+          >
+            {item.label}
+          </span>
+        )}
+      </Link>
+    </li>
+  )
+}
+
+type AdminSidebarProps = {
+  isDesktop: boolean
+  isDesktopExpanded: boolean
+  isMobileOpen: boolean
+  onToggleDesktop: () => void
+  onCloseMobile: () => void
+  user: { name?: string; email?: string } | null
+  logout: () => Promise<void>
+  can: (resource: ResourceType, action: Action) => boolean
+}
+
+export function AdminSidebar({
+  isDesktop,
+  isDesktopExpanded,
+  isMobileOpen,
+  onToggleDesktop,
+  onCloseMobile,
+  user,
+  logout,
+  can,
+}: AdminSidebarProps) {
+  const location = useLocation()
+
+  const collapsed = isDesktop && !isDesktopExpanded
+
+  const isActive = (item: NavItem) => {
+    if (item.exact) return location.pathname === item.to
+    return location.pathname.startsWith(item.to)
+  }
+
+  // On desktop: sidebar is always rendered with width transition
+  // On mobile: sidebar is a fixed drawer that slides in/out
+  const sidebarWidth = isDesktop
+    ? isDesktopExpanded
+      ? 'w-[220px]'
+      : 'w-16'
+    : 'w-64'
+
+  const mobileTransform = !isDesktop
+    ? isMobileOpen
+      ? 'translate-x-0'
+      : '-translate-x-full'
+    : ''
+
+  const positionClasses = isDesktop
+    ? 'relative shrink-0'
+    : 'fixed inset-y-0 left-0 z-40'
+
+  // Per-axis transitions: desktop animates width (220 ⇄ 64), mobile animates transform (slide).
+  // motion-reduce honored by reduced-motion modifier.
+  const transitionClasses = isDesktop
+    ? 'transition-[width] duration-200 ease-out motion-reduce:transition-none'
+    : 'transition-transform duration-300 ease-out motion-reduce:transition-none motion-reduce:transform-none'
+
+  // Off-canvas drawer is still in DOM; mark inert so its focusable descendants are not tab-reachable.
+  const offCanvas = !isDesktop && !isMobileOpen
+
+  return (
+    <nav
+      id="admin-sidebar"
+      aria-label="Admin navigation"
+      inert={offCanvas}
+      className={`flex flex-col border-r border-sidebar-border bg-sidebar ${sidebarWidth} ${positionClasses} ${mobileTransform} ${transitionClasses}`}
+    >
+      {/* Sidebar header: branding + desktop chevron toggle + mobile close button */}
+      <div className="relative flex items-center gap-3 border-b border-sidebar-border px-4 py-5">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent shadow-md shadow-indigo-500/30">
+          <svg className="h-4 w-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2v-4M9 21H5a2 2 0 01-2-2v-4m0 0h18" />
+          </svg>
+        </div>
+
+        {!collapsed && (
+          <div className="min-w-0 overflow-hidden transition-opacity duration-200">
+            <p className="text-sm font-bold leading-none text-white" style={{ fontFamily: 'Syne, sans-serif' }}>Hobo Admin</p>
+            <p className="mt-0.5 text-[9px] tracking-[0.15em] text-slate-500" style={{ fontFamily: 'DM Mono, monospace' }}>CONTROL PANEL</p>
+          </div>
+        )}
+
+        {/* Desktop chevron toggle (hidden on mobile) */}
+        {isDesktop && (
+          <button
+            type="button"
+            onClick={onToggleDesktop}
+            aria-label={isDesktopExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+            aria-controls="admin-sidebar"
+            aria-expanded={isDesktopExpanded}
+            className="absolute -right-3 top-6 hidden h-6 w-6 items-center justify-center rounded-full border border-sidebar-border bg-sidebar text-slate-400 shadow-md shadow-black/40 hover:text-white hover:border-accent/60 transition-colors md:flex"
+          >
+            <svg
+              className={`h-3.5 w-3.5 transition-transform duration-200 ${isDesktopExpanded ? '' : 'rotate-180'}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+        )}
+
+        {/* Mobile in-drawer close button */}
+        {!isDesktop && (
+          <button
+            type="button"
+            onClick={onCloseMobile}
+            aria-label="Close navigation"
+            className="ml-auto flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 hover:bg-white/5 hover:text-slate-200 transition-colors md:hidden"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Navigation sections */}
+      <div className="flex-1 overflow-y-auto py-4">
+        {navSections.map((section) => {
+          const visibleItems = section.items.filter(
+            (item) => !item.requiredCapability || can(item.requiredCapability.resource, item.requiredCapability.action)
+          )
+          if (visibleItems.length === 0) return null
+          return (
+            <div key={section.label} className="mb-4 px-3">
+              {!collapsed && (
+                <p
+                  className="mb-2 px-2 text-[9px] font-semibold tracking-[0.15em] text-slate-600"
+                  style={{ fontFamily: 'DM Mono, monospace' }}
+                >
+                  {section.label}
+                </p>
+              )}
+              <ul className="space-y-0.5">
+                {visibleItems.map((item) => (
+                  <NavItem
+                    key={item.to}
+                    item={item}
+                    collapsed={collapsed}
+                    active={isActive(item)}
+                  />
+                ))}
+              </ul>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* User footer */}
+      <div className="border-t border-sidebar-border px-3 py-4">
+        {collapsed ? (
+          <div className="flex flex-col items-center gap-2">
+            <Avatar name={user?.name ?? user?.email ?? 'A'} size="sm" />
+            <button
+              onClick={logout}
+              aria-label="Logout"
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
+              </svg>
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-3 rounded-lg px-2 py-2">
+              <Avatar name={user?.name ?? user?.email ?? 'A'} size="sm" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs font-medium text-slate-200">{user?.name ?? user?.email}</p>
+                <p className="text-[10px] text-slate-500">Super Admin</p>
+              </div>
+            </div>
+            <button
+              onClick={logout}
+              className="mt-2 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
+              </svg>
+              Logout
+            </button>
+          </>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/app/javascript/admin/components/AdminSidebar.tsx
+++ b/app/javascript/admin/components/AdminSidebar.tsx
@@ -27,7 +27,7 @@ function NavItem({ item, collapsed, active }: NavItemProps) {
         <span className={collapsed ? 'sr-only' : ''}>{item.label}</span>
         {collapsed && (
           <span
-            role="tooltip"
+            aria-hidden="true"
             className="pointer-events-none absolute left-full ml-2 z-50 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
           >
             {item.label}

--- a/app/javascript/admin/components/AdminSidebarBackdrop.tsx
+++ b/app/javascript/admin/components/AdminSidebarBackdrop.tsx
@@ -1,0 +1,17 @@
+type AdminSidebarBackdropProps = {
+  isOpen: boolean
+  isDesktop: boolean
+  onClose: () => void
+}
+
+export function AdminSidebarBackdrop({ isOpen, isDesktop, onClose }: AdminSidebarBackdropProps) {
+  if (!isOpen || isDesktop) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-30 bg-black/40 transition-opacity duration-200 motion-reduce:transition-none"
+      aria-hidden="true"
+      onClick={onClose}
+    />
+  )
+}

--- a/app/javascript/admin/components/AdminSidebarBackdrop.tsx
+++ b/app/javascript/admin/components/AdminSidebarBackdrop.tsx
@@ -9,6 +9,7 @@ export function AdminSidebarBackdrop({ isOpen, isDesktop, onClose }: AdminSideba
 
   return (
     <div
+      data-testid="admin-sidebar-backdrop"
       className="fixed inset-0 z-30 bg-black/40 transition-opacity duration-200 motion-reduce:transition-none"
       aria-hidden="true"
       onClick={onClose}

--- a/app/javascript/admin/hooks/useSidebarState.ts
+++ b/app/javascript/admin/hooks/useSidebarState.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const KEY_DESKTOP = 'admin.sidebar.desktop' // 'expanded' | 'collapsed'
+const KEY_MOBILE = 'admin.sidebar.mobile' // 'open' | 'closed'
+
+function readStorage(key: string, defaultValue: boolean): boolean {
+  if (typeof window === 'undefined') return defaultValue
+  try {
+    const raw = localStorage.getItem(key)
+    if (raw === null) return defaultValue
+    if (key === KEY_DESKTOP) return raw === 'expanded'
+    return raw === 'open'
+  } catch {
+    return defaultValue
+  }
+}
+
+function writeStorage(key: string, value: boolean): void {
+  if (typeof window === 'undefined') return
+  try {
+    if (key === KEY_DESKTOP) {
+      localStorage.setItem(key, value ? 'expanded' : 'collapsed')
+    } else {
+      localStorage.setItem(key, value ? 'open' : 'closed')
+    }
+  } catch {
+    // Safari Private Mode or storage quota: degrade silently
+  }
+}
+
+export interface UseSidebarStateResult {
+  isDesktop: boolean
+  isDesktopExpanded: boolean
+  isMobileOpen: boolean
+  toggleDesktop: () => void
+  toggleMobile: () => void
+  closeMobile: () => void
+}
+
+export function useSidebarState(): UseSidebarStateResult {
+  const getIsDesktop = useCallback(
+    () =>
+      typeof window !== 'undefined'
+        ? window.matchMedia('(min-width: 768px)').matches
+        : false,
+    []
+  )
+
+  const [isDesktop, setIsDesktop] = useState<boolean>(getIsDesktop)
+  const [isDesktopExpanded, setIsDesktopExpanded] = useState<boolean>(() =>
+    readStorage(KEY_DESKTOP, true)
+  )
+  // Mobile defaults to closed: the drawer is off-canvas and would obscure content if open by default.
+  const [isMobileOpen, setIsMobileOpen] = useState<boolean>(() =>
+    readStorage(KEY_MOBILE, false)
+  )
+
+  // Subscribe to viewport changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const mql = window.matchMedia('(min-width: 768px)')
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      const nowDesktop = e.matches
+      setIsDesktop(nowDesktop)
+      if (nowDesktop) {
+        // Mobile→desktop: force-close mobile drawer in memory only.
+        // Do NOT write to localStorage — preserves the user's last explicit mobile choice.
+        setIsMobileOpen(false)
+      } else {
+        // Desktop→mobile: rehydrate mobile state from localStorage so a live resize
+        // restores the user's previously chosen state instead of always landing closed.
+        setIsMobileOpen(readStorage(KEY_MOBILE, false))
+      }
+    }
+
+    mql.addEventListener('change', handleChange)
+    return () => {
+      mql.removeEventListener('change', handleChange)
+    }
+  }, [])
+
+  // Esc key closes mobile drawer (no-op on desktop)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isMobileOpen && !isDesktop) {
+        setIsMobileOpen(false)
+        writeStorage(KEY_MOBILE, false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isMobileOpen, isDesktop])
+
+  const toggleDesktop = useCallback(() => {
+    setIsDesktopExpanded((prev) => {
+      const next = !prev
+      writeStorage(KEY_DESKTOP, next)
+      return next
+    })
+  }, [])
+
+  const toggleMobile = useCallback(() => {
+    setIsMobileOpen((prev) => {
+      const next = !prev
+      writeStorage(KEY_MOBILE, next)
+      return next
+    })
+  }, [])
+
+  const closeMobile = useCallback(() => {
+    setIsMobileOpen(false)
+    writeStorage(KEY_MOBILE, false)
+  }, [])
+
+  return { isDesktop, isDesktopExpanded, isMobileOpen, toggleDesktop, toggleMobile, closeMobile }
+}

--- a/app/javascript/admin/hooks/useSidebarState.ts
+++ b/app/javascript/admin/hooks/useSidebarState.ts
@@ -81,21 +81,6 @@ export function useSidebarState(): UseSidebarStateResult {
     }
   }, [])
 
-  // Esc key closes mobile drawer (no-op on desktop)
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isMobileOpen && !isDesktop) {
-        setIsMobileOpen(false)
-        writeStorage(KEY_MOBILE, false)
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [isMobileOpen, isDesktop])
-
   const toggleDesktop = useCallback(() => {
     setIsDesktopExpanded((prev) => {
       const next = !prev
@@ -116,6 +101,20 @@ export function useSidebarState(): UseSidebarStateResult {
     setIsMobileOpen(false)
     writeStorage(KEY_MOBILE, false)
   }, [])
+
+  // Esc key closes mobile drawer (no-op on desktop)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isMobileOpen && !isDesktop) {
+        closeMobile()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isMobileOpen, isDesktop, closeMobile])
 
   return { isDesktop, isDesktopExpanded, isMobileOpen, toggleDesktop, toggleMobile, closeMobile }
 }

--- a/app/javascript/admin/hooks/useSidebarState.ts
+++ b/app/javascript/admin/hooks/useSidebarState.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
 
+function detectIsDesktop(): boolean {
+  return typeof window !== 'undefined'
+    ? window.matchMedia('(min-width: 768px)').matches
+    : false
+}
+
 const KEY_DESKTOP = 'admin.sidebar.desktop' // 'expanded' | 'collapsed'
 const KEY_MOBILE = 'admin.sidebar.mobile' // 'open' | 'closed'
 
@@ -38,15 +44,7 @@ export interface UseSidebarStateResult {
 }
 
 export function useSidebarState(): UseSidebarStateResult {
-  const getIsDesktop = useCallback(
-    () =>
-      typeof window !== 'undefined'
-        ? window.matchMedia('(min-width: 768px)').matches
-        : false,
-    []
-  )
-
-  const [isDesktop, setIsDesktop] = useState<boolean>(getIsDesktop)
+  const [isDesktop, setIsDesktop] = useState<boolean>(detectIsDesktop)
   const [isDesktopExpanded, setIsDesktopExpanded] = useState<boolean>(() =>
     readStorage(KEY_DESKTOP, true)
   )

--- a/app/javascript/admin/lib/navConfig.ts
+++ b/app/javascript/admin/lib/navConfig.ts
@@ -1,0 +1,124 @@
+import { createElement, type ReactNode } from 'react'
+import type { Action, ResourceType } from './api'
+
+export type NavItem = {
+  to: string
+  label: string
+  exact?: boolean
+  icon: ReactNode
+  requiredCapability?: { resource: ResourceType; action: Action }
+}
+
+export type NavSection = {
+  label: string
+  items: NavItem[]
+}
+
+const Icon = (path: string) =>
+  createElement(
+    'svg',
+    {
+      className: 'h-4 w-4',
+      fill: 'none',
+      viewBox: '0 0 24 24',
+      stroke: 'currentColor',
+      strokeWidth: 1.5,
+    },
+    createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: path })
+  )
+
+export const navSections: NavSection[] = [
+  {
+    label: 'NAVIGATION',
+    items: [
+      {
+        to: '/admin',
+        label: 'Dashboard',
+        exact: true,
+        icon: Icon(
+          'M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z'
+        ),
+      },
+      {
+        to: '/admin/events',
+        label: 'Event Logs',
+        requiredCapability: { resource: 'EventLog', action: 'read' },
+        icon: Icon('M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z'),
+      },
+      {
+        to: '/admin/system-info',
+        label: 'System Info',
+        requiredCapability: { resource: 'Admin', action: 'read' },
+        icon: Icon(
+          'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z'
+        ),
+      },
+      {
+        to: '/admin/users',
+        label: 'Users',
+        requiredCapability: { resource: 'User', action: 'read' },
+        icon: Icon(
+          'M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z'
+        ),
+      },
+    ],
+  },
+  {
+    label: 'ADMIN',
+    items: [
+      {
+        to: '/admin/admin-accounts',
+        label: 'Admin Accounts',
+        requiredCapability: { resource: 'Admin', action: 'read' },
+        icon: Icon(
+          'M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z'
+        ),
+      },
+      {
+        to: '/admin/roles',
+        label: 'Roles',
+        requiredCapability: { resource: 'Admin', action: 'read' },
+        icon: Icon(
+          'M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z'
+        ),
+      },
+      {
+        to: '/admin/permissions',
+        label: 'Permissions',
+        requiredCapability: { resource: 'Admin', action: 'read' },
+        icon: Icon(
+          'M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z'
+        ),
+      },
+    ],
+  },
+  {
+    label: 'AI INFRASTRUCTURE',
+    items: [
+      {
+        to: '/admin/llm-providers',
+        label: 'LLM Providers',
+        requiredCapability: { resource: 'LlmProvider', action: 'read' },
+        icon: Icon(
+          'M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z'
+        ),
+      },
+      {
+        to: '/admin/prompt-sets',
+        label: 'Prompt Sets',
+        requiredCapability: { resource: 'LlmProvider', action: 'read' },
+        icon: Icon(
+          'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z'
+        ),
+      },
+      {
+        to: '/admin/suggestion-configs',
+        label: 'Suggestion Configs',
+        requiredCapability: { resource: 'LlmProvider', action: 'read' },
+        icon: Icon(
+          'M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75'
+        ),
+      },
+    ],
+  },
+]

--- a/docs/conventions/ADMIN_UI.md
+++ b/docs/conventions/ADMIN_UI.md
@@ -284,9 +284,12 @@ options list 側 (`rolesApi.list` 等) の fetch 失敗は引き続き Save **en
 
 ### 全体構造
 
-- サイドバー: `w-[220px]` 固定、`bg-[#0f1117]`
-- メインコンテンツ: `flex-1`、`p-6`、`bg-[#f8f9fc]`
-- トップヘッダー: `h-14`、`bg-white`、`border-b border-slate-200`
+- サイドバー: dual-mode (`bg-sidebar`)
+  - **Desktop (≥ md / 768px)**: rail collapse 64px ⇄ expand 220px、`transition-[width] duration-200`
+  - **Mobile (< md)**: off-canvas drawer (`fixed inset-y-0 left-0 z-40 w-64`)、`translate-x-0` ⇄ `-translate-x-full`、`transition-transform duration-300 ease-out`
+  - Toggle/state 詳細・三 dismiss path・localStorage キー等は [`docs/design/admin/layouts/navigation.md`](../design/admin/layouts/navigation.md) 参照
+- メインコンテンツ: `flex-1`、`p-6`、`bg-surface`
+- トップヘッダー: `h-14`、`bg-white`、`border-b border-slate-200`、モバイル時は左にハンバーガー (`md:hidden`)
 
 ### グリッド
 
@@ -319,7 +322,7 @@ options list 側 (`rolesApi.list` 等) の fetch 失敗は引き続き Save **en
 | カード外枠 | `border border-slate-200` |
 | パネル区切り | `border-b border-slate-100` |
 | 行区切り | `divide-y divide-slate-50` |
-| サイドバー | `border-r border-[#1e2130]` |
+| サイドバー | `border-r border-sidebar-border` |
 
 ### ラディウス
 

--- a/docs/design/admin/layouts/navigation.md
+++ b/docs/design/admin/layouts/navigation.md
@@ -83,10 +83,11 @@ admin.sidebar.mobile   → 'open' | 'closed'
 
 ## Tooltip Behavior (Collapsed Rail Only)
 
-In the desktop collapsed state, nav item labels are `sr-only`, so a tooltip appears on hover or focus:
+In the desktop collapsed state, nav item labels are `sr-only`, so a visual-only tooltip appears on hover or focus:
 
 - Display is controlled via Tailwind `group-hover` + `group-focus-within` (focus-within ensures the tooltip also appears on Tab navigation).
 - Each `<Link>` carries `aria-label={item.label}` so screen readers announce the destination.
+- The tooltip `<span>` is marked `aria-hidden="true"` (purely visual; the `<Link>`'s `aria-label` is the AT-facing label). It does **not** use `role="tooltip"` because the WAI-ARIA tooltip pattern requires `aria-describedby` wiring from the trigger, which would duplicate the already-present `aria-label`.
 - The tooltip uses `pointer-events-none` to avoid intercepting clicks.
 - Style: `bg-slate-900 text-white text-xs px-2 py-1 rounded-md`; a flat pill with no arrow.
 

--- a/docs/design/admin/layouts/navigation.md
+++ b/docs/design/admin/layouts/navigation.md
@@ -1,6 +1,21 @@
 # Navigation
 
-## Sidebar Navigation States
+## Sidebar States
+
+The sidebar's behavior switches based on viewport width (`md` = 768px). State is persisted per-viewport in independent `localStorage` keys.
+
+| Mode | Viewport | Width | Position | Transform / Width Animation |
+|---|---|---|---|---|
+| Desktop expanded | ≥ md | `w-[220px]` | relative flow | `transition-[width] duration-200` |
+| Desktop collapsed (rail) | ≥ md | `w-16` (64px) | relative flow | `transition-[width] duration-200`; labels and section headings cross-fade between `opacity-0` and `opacity-100` |
+| Mobile drawer (open) | < md | `w-64` (256px) | `fixed inset-y-0 left-0 z-40` | `translate-x-0`, `transition-transform duration-300 ease-out` |
+| Mobile drawer (closed) | < md | `w-64` (256px) | `fixed inset-y-0 left-0 z-40` | `-translate-x-full` |
+
+**Reduced motion**: `motion-reduce:transition-none motion-reduce:transform-none` is applied to the sidebar and drawer. When the OS "reduce motion" setting is enabled, transitions are disabled.
+
+**Width animation trade-off**: The desktop rail collapse animates the `width` property, which is not GPU-composited. However, the 156px delta over 200ms (220px → 64px) is imperceptible in practice and is considered acceptable. If issues are reported, switch to a fixed-width container with `transform` instead.
+
+## Sidebar Navigation Item States
 
 **Active item**:
 ```
@@ -13,20 +28,83 @@ Icon: text-[#6366f1]
 ```
 flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors
 text-slate-400 hover:bg-white/5 hover:text-slate-200
-Icon: text-slate-600
 ```
 
 ## Active State Logic
 
 - Items with `exact: true` match only on exact pathname equality.
-- Other items match when pathname starts with the item's `to` path.
+- Other items match when the pathname starts with the item's `to` path.
 
 ## Navigation Sections
 
-Sections are visually separated by labeled groups:
+Sections are visually separated into labeled groups:
 
-| Section Label         | Items                              |
-|-----------------------|------------------------------------|
-| NAVIGATION            | Dashboard, Users, Roles, Permissions |
-| AI INFRASTRUCTURE     | LLM Providers                      |
+| Section Label         | Items                                                  |
+|-----------------------|--------------------------------------------------------|
+| NAVIGATION            | Dashboard, Event Logs, System Info, Users              |
+| ADMIN                 | Admin Accounts, Roles, Permissions                     |
+| AI INFRASTRUCTURE     | LLM Providers, Prompt Sets, Suggestion Configs         |
 
+## Toggle Locations
+
+| Toggle | Location | Visibility | aria |
+|---|---|---|---|
+| **Desktop chevron** | Pinned absolute to the top-right edge of the sidebar header (`absolute -right-3 top-6`); circular (`rounded-full`, `h-6 w-6`); `shadow-md shadow-black/40` | `hidden md:flex` (desktop only) | `aria-label="Collapse sidebar" \| "Expand sidebar"`, `aria-controls="admin-sidebar"`, `aria-expanded={isDesktopExpanded}` |
+| **Mobile hamburger** | Leftmost element of `AdminHeader` | `md:hidden` (mobile only) | `aria-label` toggles between `"Open navigation menu"` and `"Close navigation menu"` based on `isMobileOpen`; `aria-controls="admin-sidebar"`; `aria-expanded={isMobileOpen}` |
+| **In-drawer ✕** | Top-right corner of the mobile drawer header | Mobile drawer only | `aria-label="Close navigation"` (distinct wording from the hamburger to avoid ambiguous role-name targeting in tests and screen readers) |
+
+The chevron points **left** when expanded ("collapse" intent) and **right** when collapsed ("expand" intent — `rotate-180`).
+
+## Three Dismiss Paths (Mobile Drawer)
+
+The mobile drawer can be dismissed via any of the following paths. Multiple paths are intentional, accommodating accidental taps, user preference, and keyboard navigation:
+
+1. **Backdrop tap**: Tap the translucent overlay (`fixed inset-0 z-30 bg-black/40`).
+2. **In-drawer ✕**: Tap the close button in the drawer header.
+3. **Esc key**: A `keydown` listener inside `useSidebarState` triggers only when `isMobileOpen && !isDesktop`.
+
+## State Persistence
+
+```
+admin.sidebar.desktop  → 'expanded' | 'collapsed'
+admin.sidebar.mobile   → 'open' | 'closed'
+```
+
+- **Storage format**: String literals are stored for human-readability when inspecting DevTools. The hook converts them to booleans in memory.
+- **Default (missing key)**:
+  - `admin.sidebar.desktop` → `expanded` (the desktop rail sits in normal flow; expanded by default is purely additive).
+  - `admin.sidebar.mobile` → `closed` (the mobile drawer is off-canvas with a backdrop; defaulting to open would obscure the main content immediately on first visit).
+  - There is no special "first-visit-only" tracking — the user's first toggle persists.
+- **Robustness**: If `localStorage` throws (e.g., Safari Private Mode), the hook continues to operate using in-memory state only (failures are caught and swallowed).
+- **Viewport transition behavior**:
+  - **Mobile → desktop**: `isMobileOpen` is reset to `false` in memory but **not** written to `admin.sidebar.mobile` — preserving the user's last explicit mobile choice for when they return to a mobile viewport.
+  - **Desktop → mobile**: `isMobileOpen` is rehydrated from `admin.sidebar.mobile` so a live resize restores the user's previously chosen state instead of always landing closed.
+- **Shared-machine note**: `localStorage` is per-browser-profile. State carrying over across account switches is within spec.
+
+## Tooltip Behavior (Collapsed Rail Only)
+
+In the desktop collapsed state, nav item labels are `sr-only`, so a tooltip appears on hover or focus:
+
+- Display is controlled via Tailwind `group-hover` + `group-focus-within` (focus-within ensures the tooltip also appears on Tab navigation).
+- Each `<Link>` carries `aria-label={item.label}` so screen readers announce the destination.
+- The tooltip uses `pointer-events-none` to avoid intercepting clicks.
+- Style: `bg-slate-900 text-white text-xs px-2 py-1 rounded-md`; a flat pill with no arrow.
+
+## z-index Discipline
+
+| Layer | z-index |
+|---|---|
+| Backdrop | `z-30` |
+| Drawer (mobile sidebar) | `z-40` |
+| Tooltip (collapsed rail) | `z-50` |
+
+## Out of Scope
+
+The following are out of scope for this issue (#351). They will be addressed in separate issues if a need emerges:
+
+- Focus trap (constraining focus inside the drawer)
+- Body scroll lock (skipped due to iOS layout-shift bugs)
+- Keyboard shortcuts such as Cmd/Ctrl + B
+- Server-side persistence (currently `localStorage`-only)
+- Resize handle (variable width)
+- Drag-to-reorder for nav items

--- a/tests/admin/admin-sidebar.spec.ts
+++ b/tests/admin/admin-sidebar.spec.ts
@@ -69,7 +69,10 @@ test.describe('Admin Sidebar — Desktop rail collapse/expand', () => {
     const dashboardLink = page.getByRole('link', { name: 'Dashboard' })
     await expect(dashboardLink).toHaveAttribute('aria-label', 'Dashboard')
     await dashboardLink.focus()
-    await expect(page.locator('[role="tooltip"]', { hasText: 'Dashboard' }).first()).toBeVisible()
+    // Visual-only tooltip span (aria-hidden); rendered always, opacity controlled by CSS group-focus-within.
+    await expect(
+      page.locator('span[aria-hidden="true"].pointer-events-none', { hasText: 'Dashboard' }).first()
+    ).toBeVisible()
   })
 })
 

--- a/tests/admin/admin-sidebar.spec.ts
+++ b/tests/admin/admin-sidebar.spec.ts
@@ -129,8 +129,11 @@ test.describe('Admin Sidebar — Viewport transition', () => {
     expect(before).toBe('open')
 
     await page.setViewportSize(DESKTOP_VIEWPORT)
-    // give matchMedia change a tick
-    await page.waitForTimeout(200)
+
+    // Wait for the matchMedia transition to take effect (sidebar leftEdge changes when isDesktop flips),
+    // then assert the localStorage key was not mutated. Polling on a real DOM signal is more resilient
+    // than a fixed sleep under CI load.
+    await expect.poll(() => sidebarLeftEdge(page)).toBeGreaterThanOrEqual(0)
 
     const after = await page.evaluate((k) => localStorage.getItem(k), KEY_MOBILE)
     expect(after).toBe(before)

--- a/tests/admin/admin-sidebar.spec.ts
+++ b/tests/admin/admin-sidebar.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from '../fixtures/coverage'
+import { TEST_PASSWORD } from '../fixtures/auth'
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 }
+const MOBILE_VIEWPORT = { width: 500, height: 800 }
+
+const SIDEBAR_SELECTOR = '#admin-sidebar'
+const KEY_DESKTOP = 'admin.sidebar.desktop'
+const KEY_MOBILE = 'admin.sidebar.mobile'
+
+async function loginAsAdmin(page: Page): Promise<void> {
+  await page.goto('/admin/login')
+  await page.locator('input[type="email"]').fill('admin@example.com')
+  await page.locator('input[type="password"]').fill(TEST_PASSWORD)
+  await page.getByRole('button', { name: 'Login' }).click()
+  await expect(page).toHaveURL('/admin', { timeout: 10000 })
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({ timeout: 10000 })
+}
+
+async function clearSidebarStorage(page: Page): Promise<void> {
+  await page.evaluate(({ d, m }) => {
+    localStorage.removeItem(d)
+    localStorage.removeItem(m)
+  }, { d: KEY_DESKTOP, m: KEY_MOBILE })
+}
+
+async function sidebarWidth(page: Page): Promise<number> {
+  const box = await page.locator(SIDEBAR_SELECTOR).boundingBox()
+  return box?.width ?? 0
+}
+
+async function sidebarLeftEdge(page: Page): Promise<number> {
+  const box = await page.locator(SIDEBAR_SELECTOR).boundingBox()
+  return box?.x ?? Number.NEGATIVE_INFINITY
+}
+
+test.describe('Admin Sidebar — Desktop rail collapse/expand', () => {
+  test.use({ viewport: DESKTOP_VIEWPORT })
+
+  test('既定で expanded (220px)、chevron で rail (64px) に折り畳めて localStorage に永続化される', async ({ page }) => {
+    await loginAsAdmin(page)
+    await clearSidebarStorage(page)
+    await page.reload()
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeVisible()
+
+    expect(await sidebarWidth(page)).toBeCloseTo(220, -1)
+
+    await page.getByRole('button', { name: 'Collapse sidebar' }).click()
+    await expect.poll(() => sidebarWidth(page)).toBeCloseTo(64, -1)
+
+    const stored = await page.evaluate((k) => localStorage.getItem(k), KEY_DESKTOP)
+    expect(stored).toBe('collapsed')
+
+    await page.reload()
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeVisible()
+    expect(await sidebarWidth(page)).toBeCloseTo(64, -1)
+
+    await page.getByRole('button', { name: 'Expand sidebar' }).click()
+    await expect.poll(() => sidebarWidth(page)).toBeCloseTo(220, -1)
+    expect(await page.evaluate((k) => localStorage.getItem(k), KEY_DESKTOP)).toBe('expanded')
+  })
+
+  test('rail 状態でナビアイテムにフォーカスを当てるとツールチップが表示される', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.evaluate(({ k }) => localStorage.setItem(k, 'collapsed'), { k: KEY_DESKTOP })
+    await page.reload()
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeVisible()
+
+    const dashboardLink = page.getByRole('link', { name: 'Dashboard' })
+    await expect(dashboardLink).toHaveAttribute('aria-label', 'Dashboard')
+    await dashboardLink.focus()
+    await expect(page.locator('[role="tooltip"]', { hasText: 'Dashboard' }).first()).toBeVisible()
+  })
+})
+
+test.describe('Admin Sidebar — Mobile drawer', () => {
+  test.use({ viewport: MOBILE_VIEWPORT })
+
+  test('既定で closed、ハンバーガーで開き、in-drawer ✕ で閉じる', async ({ page }) => {
+    await loginAsAdmin(page)
+    await clearSidebarStorage(page)
+    await page.reload()
+
+    // Default closed: no localStorage entry → 'closed' on mobile (off-canvas should not obscure content).
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeAttached()
+    expect(await sidebarLeftEdge(page)).toBeLessThan(-100)
+
+    await page.getByRole('button', { name: 'Open navigation menu' }).click()
+    await expect.poll(() => sidebarLeftEdge(page)).toBeGreaterThanOrEqual(-10)
+
+    await page.getByRole('button', { name: 'Close navigation', exact: true }).click()
+    await expect.poll(() => sidebarLeftEdge(page)).toBeLessThan(-100)
+  })
+
+  test('Backdrop タップで drawer が閉じる', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.evaluate(({ k }) => localStorage.setItem(k, 'open'), { k: KEY_MOBILE })
+    await page.reload()
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeVisible()
+    expect(await sidebarLeftEdge(page)).toBeGreaterThanOrEqual(-10)
+
+    // Backdrop covers viewport at z-30; drawer is at z-40 with width 256.
+    // Click well to the right of the drawer.
+    await page.mouse.click(450, 400)
+    await expect.poll(() => sidebarLeftEdge(page)).toBeLessThan(-100)
+  })
+
+  test('Esc キーで drawer が閉じる', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.evaluate(({ k }) => localStorage.setItem(k, 'open'), { k: KEY_MOBILE })
+    await page.reload()
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeVisible()
+    expect(await sidebarLeftEdge(page)).toBeGreaterThanOrEqual(-10)
+
+    await page.keyboard.press('Escape')
+    await expect.poll(() => sidebarLeftEdge(page)).toBeLessThan(-100)
+  })
+})
+
+test.describe('Admin Sidebar — Viewport transition', () => {
+  test('mobile→desktop 遷移時に admin.sidebar.mobile の localStorage は変化しない', async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT)
+    await loginAsAdmin(page)
+    await page.evaluate(({ k }) => localStorage.setItem(k, 'open'), { k: KEY_MOBILE })
+    await page.reload()
+    await expect(page.locator(SIDEBAR_SELECTOR)).toBeVisible()
+
+    const before = await page.evaluate((k) => localStorage.getItem(k), KEY_MOBILE)
+    expect(before).toBe('open')
+
+    await page.setViewportSize(DESKTOP_VIEWPORT)
+    // give matchMedia change a tick
+    await page.waitForTimeout(200)
+
+    const after = await page.evaluate((k) => localStorage.getItem(k), KEY_MOBILE)
+    expect(after).toBe(before)
+  })
+
+  test('desktop→mobile live resize で localStorage の mobile state を復元する', async ({ page }) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT)
+    await loginAsAdmin(page)
+    await page.evaluate(({ k }) => localStorage.setItem(k, 'open'), { k: KEY_MOBILE })
+
+    // No reload — simulate a live resize.
+    await page.setViewportSize(MOBILE_VIEWPORT)
+    await expect.poll(() => sidebarLeftEdge(page)).toBeGreaterThanOrEqual(-10)
+  })
+})


### PR DESCRIPTION
Closes #351

## Summary

- Admin サイドバーを viewport-aware にトグル可能化: **desktop = rail collapse (220 ⇄ 64px)**、**mobile = off-canvas drawer (256px)**
- Per-viewport `localStorage` 永続化: `admin.sidebar.desktop` / `admin.sidebar.mobile`
- Mobile drawer は **3 つの dismiss path** (backdrop tap / in-drawer ✕ / Esc)
- 既存の capability filtering / nav 構造はそのまま維持。Frontend-only 変更、Rails 変更なし
- 4 components + 1 hook + 1 nav config に分解 (旧 `AdminLayout.tsx` 244行 → 41行)

## Default Behavior

| Viewport | Default (missing localStorage key) | 理由 |
|---|---|---|
| Desktop | `expanded` (220px) | rail は通常 flow、expanded default は purely additive |
| Mobile | `closed` (`-translate-x-full`) | off-canvas drawer + backdrop が初回訪問でコンテンツを覆ってしまうため |

Viewport 遷移時:
- mobile→desktop: `isMobileOpen` を memory のみで false (localStorage は保持)
- desktop→mobile: `localStorage` から rehydrate (live resize でユーザーの選択を復元)

## Files Changed (14)

**New**
- `app/javascript/admin/lib/navConfig.ts` — shared NavItem/NavSection types + navSections constant
- `app/javascript/admin/hooks/useSidebarState.ts`
- `app/javascript/admin/components/AdminSidebar.tsx`
- `app/javascript/admin/components/AdminSidebarBackdrop.tsx`
- `app/javascript/admin/components/AdminHeader.tsx`
- `app/javascript/admin/__tests__/hooks/useSidebarState.test.tsx` (11 cases)
- `app/javascript/admin/__tests__/components/AdminSidebar.test.tsx` (6 cases)
- `app/javascript/admin/__tests__/components/AdminSidebarBackdrop.test.tsx` (3 cases)
- `tests/admin/admin-sidebar.spec.ts` (7 Playwright cases)

**Edited**
- `app/javascript/admin/components/AdminLayout.tsx` (244 → 41行)
- `app/javascript/admin/__tests__/components/AdminLayout.test.tsx`
- `app/javascript/admin/__tests__/setup.ts` (matchMedia polyfill for jsdom)
- `docs/conventions/ADMIN_UI.md` (§5 dual-mode + §7 token migration)
- `docs/design/admin/layouts/navigation.md` (major expansion)

## Local Review (I4)

Round 1 (react-reviewer + architecture-reviewer 並列) → HIGH 4 / MEDIUM 4 / LOW 3 受領、対応:

**Fixed**
- H1 (a11y): off-canvas drawer に `inert={offCanvas}` 付与 — 不可視リンクへの tab 到達を防止
- H2 (behavior): desktop→mobile live resize で localStorage の mobile state を rehydrate
- H3 (component coupling): `navSections` + `NavItem` 型を `lib/navConfig.ts` に抽出 (child→parent back-import を解消)
- H4 (state design): mobile default を `open` → `closed` に変更 (P2 決定時にモバイル UX を考慮できていなかった)
- M1: `border-[#1e2130]` (hardcode) → `border-sidebar-border` (token)
- M2: `transition-all duration-300` → per-axis (`transition-[width] duration-200` / `transition-transform duration-300`)
- M3: ハンバーガー `aria-label` を動的に "Open/Close navigation menu" (in-drawer ✕ "Close navigation" と意図的に差別化して role-name 衝突回避)
- L2: `navigation.md` Navigation Sections 表に `ADMIN` 行追加

**Deferred (本 PR 範囲外)**
- M4: `AdminSidebarBackdrop.test.tsx` の `[aria-hidden="true"]` selector (fragile) — `data-testid` 化は別 PR で
- L1: `makeMatchMedia` helper が 3 test file に重複 — `__tests__/helpers/` 抽出は別 PR で
- L3: `setup.ts` global polyfill と per-test `vi.fn()` reassign の interaction (`restoreAllMocks` で吸収しており実害なし)
- M5 (re-review新規): desktop chevron `aria-controls="admin-sidebar"` が自身を含む `<nav>` を指す pattern — ARIA 1.1 違反でなく、reviewer 自身も "not outright wrong" と注釈。chevron は visual に sidebar header にピン留めなので DOM 外移動は構造変更を伴うため defer

Round 2 (architecture-reviewer 単独 re-review): HIGH 4 件全て confirmed resolved、新 MEDIUM 1 件 (上記 M5)

## Test plan

- [x] `npx vitest run` — 145 / 145 passed (新規 27 cases 含む)
- [x] `bin/rails test:all` — 1008 runs / 2466 assertions / 0 failures / 0 errors / 2 skips (pre-existing)
- [x] `npx playwright test tests/admin/admin-sidebar.spec.ts` — 7 / 7 passed (default closed / hamburger open / in-drawer ✕ close / backdrop tap close / Esc close / mobile→desktop preserves localStorage / desktop→mobile rehydrate)
- [x] `npm run typecheck` — clean
- [x] `npx eslint` (changed files) — clean (95 pre-existing errors in unchanged `controllers/*.js` left per project policy)
- [x] Manual smoke (dev server, headless Playwright): expanded(220px) / rail(64px) / mobile drawer / backdrop close — visual match to approved mockup ([gist](https://gist.github.com/tetran/a36974dcfa08ac86a6001996a120e98f))

🤖 Generated with [Claude Code](https://claude.com/claude-code)