### PR TITLE
feat(admin): #356 dashboard の View all StatCard をクリック可能なリンク化

### DIFF
--- a/app/javascript/admin/__tests__/components/StatCard.test.tsx
+++ b/app/javascript/admin/__tests__/components/StatCard.test.tsx
@@ -48,4 +48,9 @@ describe('StatCard', () => {
     expect(wrapper.className).not.toContain('hover:border-indigo-300')
     expect(wrapper.className).not.toContain('transition-colors')
   })
+
+  it('does not render the group-hover slide span when `to` is omitted', () => {
+    const { container } = renderCard({ ...baseProps, subtitle: '3 Roles Defined' })
+    expect(container.querySelector('.group-hover\\:translate-x-0\\.5')).toBeNull()
+  })
 })

--- a/app/javascript/admin/__tests__/components/StatCard.test.tsx
+++ b/app/javascript/admin/__tests__/components/StatCard.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import StatCard from '@admin/components/StatCard'
+
+const renderCard = (props: Parameters<typeof StatCard>[0]) =>
+  render(
+    <MemoryRouter>
+      <StatCard {...props} />
+    </MemoryRouter>
+  )
+
+const baseProps = {
+  label: 'Total Users',
+  value: 10,
+  icon: <span data-testid="stat-icon">i</span>,
+}
+
+describe('StatCard', () => {
+  it('renders as a non-link <div> when `to` is not provided', () => {
+    renderCard({ ...baseProps, subtitle: '3 Roles Defined' })
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('Total Users')).toBeInTheDocument()
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByText('3 Roles Defined')).toBeInTheDocument()
+  })
+
+  it('renders as a <Link> with the correct href when `to` is provided', () => {
+    renderCard({ ...baseProps, subtitle: 'View all users →', to: '/admin/users' })
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/admin/users')
+    expect(within(link).getByText('Total Users')).toBeInTheDocument()
+    expect(within(link).getByText('10')).toBeInTheDocument()
+    expect(within(link).getByText('View all users →')).toBeInTheDocument()
+    expect(within(link).getByTestId('stat-icon')).toBeInTheDocument()
+  })
+
+  it('applies hover transition classes when `to` is provided', () => {
+    renderCard({ ...baseProps, subtitle: 'View all users →', to: '/admin/users' })
+    const link = screen.getByRole('link')
+    expect(link.className).toContain('transition-colors')
+    expect(link.className).toContain('hover:border-indigo-300')
+    expect(link.className).toContain('focus-visible:ring-accent')
+  })
+
+  it('does not apply hover transition classes when `to` is omitted', () => {
+    const { container } = renderCard({ ...baseProps, subtitle: '3 Roles Defined' })
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).not.toContain('hover:border-indigo-300')
+    expect(wrapper.className).not.toContain('transition-colors')
+  })
+})

--- a/app/javascript/admin/__tests__/pages/DashboardPage.test.tsx
+++ b/app/javascript/admin/__tests__/pages/DashboardPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { DashboardPage } from '@admin/pages/DashboardPage'
 import * as api from '@admin/lib/api'
+import * as AuthContextModule from '@admin/contexts/AuthContext'
 
 vi.mock('@admin/lib/api', async () => {
   const actual = await vi.importActual('@admin/lib/api')
@@ -15,6 +16,22 @@ vi.mock('@admin/lib/api', async () => {
     },
   }
 })
+
+vi.mock('@admin/contexts/AuthContext')
+const mockUseAuth = vi.mocked(AuthContextModule.useAuth)
+
+const mockAuth = (canReturn: boolean | ((resource: api.ResourceType, action: api.Action) => boolean) = true) => {
+  const canFn = typeof canReturn === 'function' ? canReturn : () => canReturn
+  mockUseAuth.mockReturnValue({
+    user: { id: 1, email: 'admin@test.com', name: 'Admin', is_admin: true, capabilities: {} },
+    loading: false,
+    refreshing: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    can: vi.fn(canFn),
+    isAdmin: true,
+  } as unknown as ReturnType<typeof AuthContextModule.useAuth>)
+}
 
 vi.mock('@admin/lib/sentry', () => ({
   reportTruncation: vi.fn(),
@@ -74,6 +91,7 @@ const renderPage = () =>
 describe('DashboardPage — partial failure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAuth(true)
   })
 
   it('shows SectionError with layout=stacked when providers fetch fails', async () => {
@@ -125,9 +143,14 @@ describe('DashboardPage — partial failure', () => {
 describe('DashboardPage — stat card link wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAuth(true)
   })
 
-  it('passes `to` only to Total Users and LLM Models cards', async () => {
+  const cardByLabel = (label: string) =>
+    screen.getAllByTestId('stat-card').find((el) => el.getAttribute('data-label') === label)!
+
+  it('passes `to` to Total Users and LLM Models cards when capabilities allow', async () => {
+    mockAuth(true)
     mockDashboardGet.mockResolvedValue(mockDashboardData)
     mockProvidersList.mockResolvedValue(mockProvidersResponse)
     renderPage()
@@ -136,12 +159,37 @@ describe('DashboardPage — stat card link wiring', () => {
       expect(screen.getAllByTestId('stat-card')).toHaveLength(4)
     })
 
-    const cardByLabel = (label: string) =>
-      screen.getAllByTestId('stat-card').find((el) => el.getAttribute('data-label') === label)!
-
     expect(cardByLabel('Total Users')).toHaveAttribute('data-to', '/admin/users')
     expect(cardByLabel('LLM Models')).toHaveAttribute('data-to', '/admin/llm-providers')
     expect(cardByLabel('Active Roles')).not.toHaveAttribute('data-to')
     expect(cardByLabel('LLM Providers')).not.toHaveAttribute('data-to')
+  })
+
+  it('omits `to` when the admin lacks the required capability', async () => {
+    mockAuth((resource, action) => !(action === 'read' && (resource === 'User' || resource === 'LlmProvider')))
+    mockDashboardGet.mockResolvedValue(mockDashboardData)
+    mockProvidersList.mockResolvedValue(mockProvidersResponse)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('stat-card')).toHaveLength(4)
+    })
+
+    expect(cardByLabel('Total Users')).not.toHaveAttribute('data-to')
+    expect(cardByLabel('LLM Models')).not.toHaveAttribute('data-to')
+  })
+
+  it('gates Total Users and LLM Models independently', async () => {
+    mockAuth((resource, action) => action === 'read' && resource === 'User')
+    mockDashboardGet.mockResolvedValue(mockDashboardData)
+    mockProvidersList.mockResolvedValue(mockProvidersResponse)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('stat-card')).toHaveLength(4)
+    })
+
+    expect(cardByLabel('Total Users')).toHaveAttribute('data-to', '/admin/users')
+    expect(cardByLabel('LLM Models')).not.toHaveAttribute('data-to')
   })
 })

--- a/app/javascript/admin/__tests__/pages/DashboardPage.test.tsx
+++ b/app/javascript/admin/__tests__/pages/DashboardPage.test.tsx
@@ -21,8 +21,10 @@ vi.mock('@admin/lib/sentry', () => ({
 }))
 
 vi.mock('@admin/components/StatCard', () => ({
-  default: ({ label, value }: { label: string; value: number }) => (
-    <div data-testid="stat-card">{label}: {value}</div>
+  default: ({ label, value, to }: { label: string; value: number; to?: string }) => (
+    <div data-testid="stat-card" data-label={label} {...(to ? { 'data-to': to } : {})}>
+      {label}: {value}
+    </div>
   ),
 }))
 
@@ -117,5 +119,29 @@ describe('DashboardPage — partial failure', () => {
     })
     expect(screen.queryByTestId('stat-card')).not.toBeInTheDocument()
     expect(screen.queryByText('OpenAI')).not.toBeInTheDocument()
+  })
+})
+
+describe('DashboardPage — stat card link wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes `to` only to Total Users and LLM Models cards', async () => {
+    mockDashboardGet.mockResolvedValue(mockDashboardData)
+    mockProvidersList.mockResolvedValue(mockProvidersResponse)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('stat-card')).toHaveLength(4)
+    })
+
+    const cardByLabel = (label: string) =>
+      screen.getAllByTestId('stat-card').find((el) => el.getAttribute('data-label') === label)!
+
+    expect(cardByLabel('Total Users')).toHaveAttribute('data-to', '/admin/users')
+    expect(cardByLabel('LLM Models')).toHaveAttribute('data-to', '/admin/llm-providers')
+    expect(cardByLabel('Active Roles')).not.toHaveAttribute('data-to')
+    expect(cardByLabel('LLM Providers')).not.toHaveAttribute('data-to')
   })
 })

--- a/app/javascript/admin/components/StatCard.tsx
+++ b/app/javascript/admin/components/StatCard.tsx
@@ -1,14 +1,17 @@
+import { Link } from 'react-router-dom'
+
 type StatCardProps = {
   label: string
   value: number | string
   icon: React.ReactNode
   accent?: string
   subtitle?: string
+  to?: string
 }
 
-export default function StatCard({ label, value, icon, accent = 'text-indigo-400', subtitle }: StatCardProps) {
-  return (
-    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+export default function StatCard({ label, value, icon, accent = 'text-indigo-400', subtitle, to }: StatCardProps) {
+  const inner = (
+    <>
       <div className="flex items-center justify-between">
         <p className="text-xs font-medium uppercase tracking-widest text-slate-400">{label}</p>
         <span className={`text-lg ${accent}`}>{icon}</span>
@@ -17,8 +20,27 @@ export default function StatCard({ label, value, icon, accent = 'text-indigo-400
         {value}
       </p>
       {subtitle && (
-        <p className="mt-1.5 text-xs text-slate-400">{subtitle}</p>
+        <p className="mt-1.5 text-xs text-slate-400">
+          <span className="inline-block transition-transform group-hover:translate-x-0.5">{subtitle}</span>
+        </p>
       )}
+    </>
+  )
+
+  if (to) {
+    return (
+      <Link
+        to={to}
+        className="group block rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition-colors hover:border-indigo-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        {inner}
+      </Link>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      {inner}
     </div>
   )
 }

--- a/app/javascript/admin/components/StatCard.tsx
+++ b/app/javascript/admin/components/StatCard.tsx
@@ -10,7 +10,7 @@ type StatCardProps = {
 }
 
 export default function StatCard({ label, value, icon, accent = 'text-indigo-400', subtitle, to }: StatCardProps) {
-  const inner = (
+  const header = (
     <>
       <div className="flex items-center justify-between">
         <p className="text-xs font-medium uppercase tracking-widest text-slate-400">{label}</p>
@@ -19,28 +19,33 @@ export default function StatCard({ label, value, icon, accent = 'text-indigo-400
       <p className="mt-3 text-3xl font-bold text-slate-800" style={{ fontFamily: 'Syne, sans-serif' }}>
         {value}
       </p>
-      {subtitle && (
-        <p className="mt-1.5 text-xs text-slate-400">
-          <span className="inline-block transition-transform group-hover:translate-x-0.5">{subtitle}</span>
-        </p>
-      )}
     </>
   )
 
   if (to) {
+    // hover:border-indigo-300 は ADMIN_UI §2 のトークン優先ルールに反する palette literal だが意図的に許容:
+    // --color-accent (= #6366f1, ≒ indigo-500) は border として濃く selected 状態と誤認しやすく、
+    // light shade トークン (--color-accent-soft 等) は admin で未定義のため。
+    // 将来 light shade トークンが定義された時点で置き換える。
     return (
       <Link
         to={to}
         className="group block rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition-colors hover:border-indigo-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
       >
-        {inner}
+        {header}
+        {subtitle && (
+          <p className="mt-1.5 text-xs text-slate-400">
+            <span className="inline-block transition-transform group-hover:translate-x-0.5">{subtitle}</span>
+          </p>
+        )}
       </Link>
     )
   }
 
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-      {inner}
+      {header}
+      {subtitle && <p className="mt-1.5 text-xs text-slate-400">{subtitle}</p>}
     </div>
   )
 }

--- a/app/javascript/admin/pages/DashboardPage.tsx
+++ b/app/javascript/admin/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { dashboardApi, llmProvidersApi, DashboardData, LlmProvider, DROPDOWN_PER_PAGE } from '../lib/api'
 import { reportTruncation } from '../lib/sentry'
+import { useAuth } from '../contexts/AuthContext'
 import StatCard from '../components/StatCard'
 import Avatar from '../components/Avatar'
 import Badge from '../components/Badge'
@@ -11,6 +12,7 @@ function buildSectionErrorMessage(reason: unknown): string {
 }
 
 export const DashboardPage = () => {
+  const { can } = useAuth()
   const [data, setData] = useState<DashboardData | null>(null)
   const [providers, setProviders] = useState<LlmProvider[]>([])
   const [dashboardError, setDashboardError] = useState('')
@@ -79,7 +81,7 @@ export const DashboardPage = () => {
             value={data?.stats?.users_count ?? 0}
             subtitle="View all users →"
             accent="text-indigo-400"
-            to="/admin/users"
+            to={can('User', 'read') ? '/admin/users' : undefined}
             icon={
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
@@ -113,7 +115,7 @@ export const DashboardPage = () => {
             value={data?.stats?.llm_models_count ?? 0}
             subtitle="View all models →"
             accent="text-emerald-400"
-            to="/admin/llm-providers"
+            to={can('LlmProvider', 'read') ? '/admin/llm-providers' : undefined}
             icon={
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />

--- a/app/javascript/admin/pages/DashboardPage.tsx
+++ b/app/javascript/admin/pages/DashboardPage.tsx
@@ -79,6 +79,7 @@ export const DashboardPage = () => {
             value={data?.stats?.users_count ?? 0}
             subtitle="View all users →"
             accent="text-indigo-400"
+            to="/admin/users"
             icon={
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
@@ -112,6 +113,7 @@ export const DashboardPage = () => {
             value={data?.stats?.llm_models_count ?? 0}
             subtitle="View all models →"
             accent="text-emerald-400"
+            to="/admin/llm-providers"
             icon={
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />

--- a/tests/admin/auth.spec.ts
+++ b/tests/admin/auth.spec.ts
@@ -57,7 +57,7 @@ test.describe('ナビゲーション capabilities フィルタリング', () => 
     await page.getByRole('button', { name: 'Login' }).click()
     await expect(page).toHaveURL('/admin', { timeout: 10000 })
 
-    await expect(page.getByRole('link', { name: 'Users' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Users', exact: true })).toBeVisible()
     await expect(page.getByRole('link', { name: 'LLM Providers' })).not.toBeVisible()
   })
 

--- a/tests/admin/dashboard.spec.ts
+++ b/tests/admin/dashboard.spec.ts
@@ -16,7 +16,7 @@ test.describe('Admin ダッシュボード', () => {
 
   test('ナビゲーションリンクが表示されること', async ({ page }) => {
     await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Users' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Users', exact: true })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Roles' })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Permissions' })).toBeVisible()
     await expect(page.getByRole('link', { name: 'LLM Providers' })).toBeVisible()


### PR DESCRIPTION
## Summary
- Admin Dashboard の `Total Users` / `LLM Models` StatCard で `View all users →` / `View all models →` と表示しながら、card 自体はクリックしても何も起きない「リンクのように見えるけどリンクではない」状態を解消 (#356)
- `StatCard` に optional `to?: string` prop を追加し、指定時は card 全体を react-router の `<Link>` でラップしてキーボード/マウス両対応のクリック可能領域に
- `useAuth().can(...)` で `to` を capability gate (`User:read` / `LlmProvider:read`)。capability 不足時は `to` を渡さず non-link `<div>` 分岐にフォールバックして click→bounce-back loop を防ぐ (`AdminSidebar.tsx:161` と同じ確立済パターン)

## Closes
Closes #356

## Changes
- `app/javascript/admin/components/StatCard.tsx` — `to?: string` prop + `<Link>` 分岐 + hover (`hover:border-indigo-300` / `transition-colors`) + focus ring (`focus-visible:ring-accent`) + `→` 矢印スライド (`group-hover:translate-x-0.5`)
- `app/javascript/admin/pages/DashboardPage.tsx` — `useAuth().can('User','read')` / `can('LlmProvider','read')` で `to` を条件付け
- 新規 `__tests__/components/StatCard.test.tsx` (5 ケース: link/non-link/hover class/subtitle 包含/non-link 時 group-hover span 不在)
- `__tests__/pages/DashboardPage.test.tsx` — useAuth mock + capability gate 3 ケース (両方 true / 両方 false / 片側のみ)

## Out of Scope (フォローアップ別 issue 推奨)
- Dashboard 下部の `Recent Users → View all` (line 134) と `System Status → Manage` (line 169) は素の `<a>` のまま。これらの `<Link>` 化と capability gating は Cmd-Click / SPA 遷移整合の観点で別 issue 案件 (両 reviewer 同意)
- LLM Models 専用 index ページの新設 (今回は Provider workspace `/admin/llm-providers` に揃えた)

## Local Review (I4)
- 並列 dispatch: `react-reviewer` + `architecture-reviewer`
- dedup 後: HIGH (AUTHZ capability gating) 1 件 / LOW (dead-style, consistency) 2 件
  - HIGH: 修正 (commit `fce2afd`)
  - LOW dead-style: 修正 (group-hover span を Link 分岐内に閉じ込め)
  - LOW consistency (palette literal `indigo-300`): 採用理由をコードコメントとして明示し dismiss (light shade トークン未定義のため)
- `architecture-reviewer` 単体 re-review: findings ゼロ ✅

## Test plan
- [x] `npx vitest run app/javascript/admin/__tests__/` → 21 files / 153 tests pass
- [x] `npx tsc --noEmit` exit 0
- [x] `bin/rails test:all` (full suite) → 1008 runs / 2466 assertions / 0 failures / 0 errors
- [ ] `/admin` を実機で開き、`Total Users` / `LLM Models` card の hover で border 変化と矢印スライド、Tab で focus ring、Enter / クリックで遷移、Cmd-Click で別タブを目視確認
- [ ] `Active Roles` / `LLM Providers` card は hover 効果なし・クリック非反応を目視確認
- [ ] capability `User:read` / `LlmProvider:read` を持たない admin で該当 card がリンク化されないことを確認 (権限制御済 admin アカウント)

🤖 Generated with [Claude Code](https://claude.com/claude-code)